### PR TITLE
fix(admin): native Datei-Inputs durch echte Buttons ersetzen

### DIFF
--- a/src/app/admin/crm/page.tsx
+++ b/src/app/admin/crm/page.tsx
@@ -8,7 +8,7 @@ import {
   ChevronRight, X, FileText, RefreshCw, Receipt,
   Plus, Trash2, Download, CheckCircle, Clock, AlertCircle,
   TrendingUp, Banknote, BarChart3, Target,
-  MessageSquare, Send, Hash, CornerDownRight
+  MessageSquare, Send, Hash, CornerDownRight, Paperclip
 } from 'lucide-react';
 
 /* ─── Types ──────────────────────────────────────────────────────────── */
@@ -349,6 +349,7 @@ function ConversationTab({ lead }: { lead: Lead }) {
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const fileRef = useRef<HTMLInputElement>(null);
+  const [replyFiles, setReplyFiles] = useState<string[]>([]);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -383,6 +384,7 @@ function ConversationTab({ lead }: { lead: Lead }) {
       if (data.success) {
         setReply('');
         if (fileRef.current) fileRef.current.value = '';
+        setReplyFiles([]);
         await load();
       } else {
         setError(data.error || 'Versand fehlgeschlagen.');
@@ -457,7 +459,18 @@ function ConversationTab({ lead }: { lead: Lead }) {
           className="w-full border rounded-lg px-3 py-2.5 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none resize-none"
           style={{ borderColor: '#e5e8ed' }}
         />
-        <input ref={fileRef} type="file" multiple className="block w-full text-xs text-gray-500 file:mr-3 file:cursor-pointer file:rounded-lg file:border-0 file:bg-[#143047] file:px-3 file:py-2 file:text-xs file:font-bold file:text-white hover:file:opacity-90" />
+        <input ref={fileRef} type="file" multiple className="hidden" onChange={e => setReplyFiles(Array.from(e.target.files ?? []).map(f => f.name))} />
+        <div className="flex items-center gap-2 flex-wrap">
+          <button
+            type="button"
+            onClick={() => fileRef.current?.click()}
+            className="inline-flex items-center gap-1.5 rounded-lg px-3 py-2 text-xs font-bold text-white transition hover:opacity-90"
+            style={{ background: '#143047' }}
+          >
+            <Paperclip className="w-3.5 h-3.5" /> Dateien anhängen
+          </button>
+          <span className="text-xs text-gray-500 truncate">{replyFiles.length ? replyFiles.join(', ') : 'Keine Dateien gewählt'}</span>
+        </div>
         {error && <p className="text-red-600 text-xs">{error}</p>}
         <button
           onClick={handleSend}

--- a/src/app/admin/kunden/[id]/page.tsx
+++ b/src/app/admin/kunden/[id]/page.tsx
@@ -48,6 +48,7 @@ export default function KundenakteePage() {
   const [docBooking, setDocBooking] = useState('');
   const [uploading, setUploading] = useState(false);
   const fileRef = useRef<HTMLInputElement>(null);
+  const [docFileName, setDocFileName] = useState<string | null>(null);
 
   const flash = (ok: boolean, msg: string) => { setToast({ ok, msg }); setTimeout(() => setToast(null), 4000); };
 
@@ -84,7 +85,7 @@ export default function KundenakteePage() {
       fd.append('title', docTitle);
       fd.append('booking_id', docBooking);
       const res = await fetch(`/api/admin/customers/${id}/documents`, { method: 'POST', body: fd }).then((r) => r.json());
-      if (res.success) { setDocTitle(''); if (fileRef.current) fileRef.current.value = ''; flash(true, 'Dokument hochgeladen – im Portal sichtbar.'); await loadDocs(); }
+      if (res.success) { setDocTitle(''); if (fileRef.current) fileRef.current.value = ''; setDocFileName(null); flash(true, 'Dokument hochgeladen – im Portal sichtbar.'); await loadDocs(); }
       else flash(false, res.error || 'Upload fehlgeschlagen.');
     } catch { flash(false, 'Verbindungsfehler.'); } finally { setUploading(false); }
   };
@@ -304,8 +305,12 @@ export default function KundenakteePage() {
                     {c.bookings.map((b) => <option key={b.id} value={b.id}>{b.request_number || b.id.slice(0, 8)} · {b.package_title}</option>)}
                   </select>
                 </Field>
-                <input ref={fileRef} type="file" className="block w-full text-xs text-gray-500 file:mr-3 file:cursor-pointer file:rounded-lg file:border-0 file:bg-[#143047] file:px-3 file:py-2 file:text-xs file:font-bold file:text-white hover:file:opacity-90" />
-                <Button type="button" variant="accent" onClick={uploadDoc} disabled={uploading}>{uploading ? <Spinner className="h-4 w-4 border-white" /> : <Upload className="h-4 w-4" />} Hochladen</Button>
+                <input ref={fileRef} type="file" className="hidden" onChange={(e) => setDocFileName(e.target.files?.[0]?.name ?? null)} />
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button type="button" variant="secondary" onClick={() => fileRef.current?.click()}><Upload className="h-4 w-4" /> Datei wählen</Button>
+                  <span className="truncate text-xs" style={{ color: docFileName ? '#143047' : '#9ca3af' }} title={docFileName ?? undefined}>{docFileName ?? 'Keine Datei gewählt'}</span>
+                </div>
+                <Button type="button" variant="accent" onClick={uploadDoc} disabled={uploading || !docFileName}>{uploading ? <Spinner className="h-4 w-4 border-white" /> : <Upload className="h-4 w-4" />} Hochladen</Button>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Ersetzt die zwei verbliebenen nativen <input type="file"> (CRM-Antwortkomposer + Kunden-Dokumente) durch echte, gestylte Buttons mit Anzeige der gewählten Datei(en) — konsistent zum restlichen Admin-UI.

- CRM: verstecktes Input + "Dateien anhängen"-Button (Paperclip) + Dateinamen-Anzeige
- Kunden: "Datei wählen"-Button + Dateiname; "Hochladen" ohne Auswahl deaktiviert

Typecheck gruen. 🤖 via Claude Code