### PR TITLE
fix(prod): http->https Redirect + neutrale Auto-Antwort-Begruessung

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -110,12 +110,14 @@ const nextConfig: NextConfig = {
   // Redirects (falls WordPress-URLs umgeleitet werden sollen)
   async redirects() {
     return [
-      // Beispiel: WordPress URL zu Next.js
-      // {
-      //   source: '/old-wordpress-page',
-      //   destination: '/new-page',
-      //   permanent: true,
-      // },
+      // Harte http -> https Weiterleitung (hinter Reverse-Proxy via x-forwarded-proto).
+      // Behebt u.a. den Microsoft-SSO Redirect-URI-Mismatch (AADSTS50011) bei http-Aufruf.
+      {
+        source: '/:path*',
+        has: [{ type: 'header', key: 'x-forwarded-proto', value: 'http' }],
+        destination: 'https://next.faltintravel.com/:path*',
+        permanent: true,
+      },
     ]
   },
 };

--- a/src/lib/emailTemplates.ts
+++ b/src/lib/emailTemplates.ts
@@ -90,6 +90,15 @@ export function formalGreeting(r: RecipientInfo): string {
  *   {{nachname}} → Nachname
  * Räumt überflüssige Leerzeichen vor Satzzeichen auf (Fallback ohne Nachname).
  */
+/** Wie formalGreeting, aber OHNE tageszeit-abhaengige Grussformel (immer "Guten Tag"). */
+export function neutralGreeting(r: RecipientInfo): string {
+  const s = (r.salutation || '').trim().toLowerCase();
+  const last = (r.lastName || '').trim();
+  if (s === 'herr') return last ? `Guten Tag Herr ${escapeHtml(last)},` : `Guten Tag Herr,`;
+  if (s === 'frau') return last ? `Guten Tag Frau ${escapeHtml(last)},` : `Guten Tag Frau,`;
+  return 'Sehr geehrte Damen und Herren,';
+}
+
 export function renderRecipientTokens(escapedText: string, r: RecipientInfo): string {
   const s = (r.salutation || '').trim().toLowerCase();
   const hasSalutation = s === 'herr' || s === 'frau';
@@ -282,7 +291,7 @@ export function autoReplyHtml(input: AutoReplyInput): string {
   const hasOwnGreeting = /^(sehr geehrt|hallo|guten (tag|morgen|mittag|abend)|liebe|moin|servus|hi[\s,]|hey[\s,])/.test(firstLine);
   const greetingHtml = hasOwnGreeting
     ? ''
-    : `<p style="margin:0 0 16px;font-size:15px;line-height:1.7;color:#374151;">${formalGreeting(r)}</p>`;
+    : `<p style="margin:0 0 16px;font-size:15px;line-height:1.7;color:#374151;">${neutralGreeting(r)}</p>`;
 
   const bodyHtml = rendered.replace(/\n/g, '<br>');
 


### PR DESCRIPTION
Zwei kleine Prod-Fixes:

1. **http->https Hard-Redirect** (next.config.ts): Hinter dem Reverse-Proxy wird bei x-forwarded-proto=http per 308 auf https umgeleitet. Behebt den Microsoft-SSO Redirect-URI-Mismatch (AADSTS50011), der auftrat, wenn die Seite ueber http aufgerufen wurde.
2. **Neutrale Begruessung in der Auto-Antwort** (emailTemplates.ts): statt tageszeit-abhaengiger Grussformel ("Guten Abend" trotz Morgen) jetzt immer "Guten Tag" via neutralGreeting(). Confirmation/Reply unveraendert.

🤖 via Claude Code