### PR TITLE
fix(dnd): reactStrictMode aus (Dev-Drag&Drop)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,9 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   // Docker Production Build
   output: 'standalone',
+
+  // @hello-pangea/dnd (Drag&Drop) bricht unter React-StrictMode im Dev-Modus -> aus.
+  reactStrictMode: false,
   
   // SEO & Performance Optimierungen
   images: {


### PR DESCRIPTION
Drag&Drop liess sich lokal nicht greifen — Ursache: React-StrictMode mountet @hello-pangea/dnd im Dev-Modus doppelt. reactStrictMode:false behebt das. Falls Drag&Drop danach auch auf PROD nicht geht, steige ich auf dnd-kit um.

🤖 via Claude Code