### PR TITLE
feat(aufgaben): Subtasks (Backend + API)

### DIFF
--- a/src/app/api/admin/tasks/[id]/subtasks/route.ts
+++ b/src/app/api/admin/tasks/[id]/subtasks/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import { listSubtasks, addSubtask, setSubtaskDone, deleteSubtask } from '@/lib/staffStore';
+
+/** GET → Subtasks einer Aufgabe. */
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const data = await listSubtasks(id);
+  return NextResponse.json({ success: true, data });
+}
+
+/** POST { title } → neuen Subtask anlegen. */
+export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const body = await req.json().catch(() => ({}));
+  const title = (body?.title || '').trim();
+  if (!title) return NextResponse.json({ success: false, error: 'title erforderlich' }, { status: 400 });
+  const data = await addSubtask(id, title);
+  return NextResponse.json({ success: true, data });
+}
+
+/** PATCH { subtaskId, done } → Subtask abhaken / zurücknehmen. */
+export async function PATCH(req: Request) {
+  const body = await req.json().catch(() => ({}));
+  if (!body?.subtaskId) return NextResponse.json({ success: false, error: 'subtaskId erforderlich' }, { status: 400 });
+  const ok = await setSubtaskDone(body.subtaskId, !!body.done);
+  return NextResponse.json({ success: ok });
+}
+
+/** DELETE ?subtaskId=… → Subtask löschen. */
+export async function DELETE(req: Request) {
+  const subtaskId = new URL(req.url).searchParams.get('subtaskId');
+  if (!subtaskId) return NextResponse.json({ success: false, error: 'subtaskId erforderlich' }, { status: 400 });
+  const ok = await deleteSubtask(subtaskId);
+  return NextResponse.json({ success: ok });
+}

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -276,6 +276,16 @@ export function initDatabase() {
     CREATE INDEX IF NOT EXISTS idx_vacation_requests_employee ON vacation_requests(employee_id, start_date);
     CREATE INDEX IF NOT EXISTS idx_staff_tasks_assignee ON staff_tasks(assignee_id, status);
 
+    CREATE TABLE IF NOT EXISTS staff_task_subtasks (
+      id TEXT PRIMARY KEY,
+      task_id TEXT NOT NULL,
+      title TEXT NOT NULL,
+      done INTEGER NOT NULL DEFAULT 0,
+      sort_order INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_subtasks_task ON staff_task_subtasks(task_id);
+
     CREATE TABLE IF NOT EXISTS tippspiel_users (
       id TEXT PRIMARY KEY,
       email TEXT NOT NULL UNIQUE,

--- a/src/lib/dbq.ts
+++ b/src/lib/dbq.ts
@@ -243,6 +243,15 @@ export async function applyPgSchemaEnhancements(): Promise<void> {
       )`);
       await pool.query(`ALTER TABLE incentive_plans ADD COLUMN IF NOT EXISTS error text NOT NULL DEFAULT ''`);
       await pool.query(`ALTER TABLE incentive_plans ADD COLUMN IF NOT EXISTS progress text NOT NULL DEFAULT ''`);
+      await pool.query(`CREATE TABLE IF NOT EXISTS staff_task_subtasks (
+        id text PRIMARY KEY,
+        task_id text NOT NULL,
+        title text NOT NULL,
+        done integer NOT NULL DEFAULT 0,
+        sort_order integer NOT NULL DEFAULT 0,
+        created_at timestamptz NOT NULL DEFAULT now()
+      )`);
+      await pool.query(`CREATE INDEX IF NOT EXISTS idx_subtasks_task ON staff_task_subtasks(task_id)`);
     } catch (e) { console.warn('[pg] Portal-Schema:', (e as Error).message); }
 
     // Defaults auf Timestamp-Spalten (damit Inserts ohne created_at/updated_at funktionieren)

--- a/src/lib/staffStore.ts
+++ b/src/lib/staffStore.ts
@@ -428,3 +428,30 @@ export async function listStaffTasks(filter?: { assignee_id?: string; status?: s
     ORDER BY CASE status WHEN 'erledigt' THEN 1 ELSE 0 END, due_date IS NULL, due_date, created_at DESC`;
   return dbAll<StaffTask>(sql, params);
 }
+
+export interface Subtask {
+  id: string;
+  task_id: string;
+  title: string;
+  done: number;
+  sort_order: number;
+  created_at: string;
+}
+
+export async function listSubtasks(taskId: string): Promise<Subtask[]> {
+  return dbAll<Subtask>('SELECT * FROM staff_task_subtasks WHERE task_id = ? ORDER BY sort_order, created_at', [taskId]);
+}
+
+export async function addSubtask(taskId: string, title: string): Promise<Subtask> {
+  const id = crypto.randomUUID();
+  await dbRun('INSERT INTO staff_task_subtasks (id, task_id, title) VALUES (?, ?, ?)', [id, taskId, title]);
+  return (await dbGet<Subtask>('SELECT * FROM staff_task_subtasks WHERE id = ?', [id]))!;
+}
+
+export async function setSubtaskDone(id: string, done: boolean): Promise<boolean> {
+  return (await dbRun('UPDATE staff_task_subtasks SET done = ? WHERE id = ?', [done ? 1 : 0, id])).changes > 0;
+}
+
+export async function deleteSubtask(id: string): Promise<boolean> {
+  return (await dbRun('DELETE FROM staff_task_subtasks WHERE id = ?', [id])).changes > 0;
+}


### PR DESCRIPTION
Phase 5, Teil 1: Fundament fuer Subtasks an Aufgaben.

- Neue Tabelle **staff_task_subtasks** (SQLite-Init + **PG CREATE TABLE IF NOT EXISTS** -> non-destruktiv auf Live-DB, gleiches Muster wie die bestehenden Portal-/Attachment-Tabellen)
- Store-CRUD: listSubtasks / addSubtask / setSubtaskDone / deleteSubtask
- REST: /api/admin/tasks/[id]/subtasks (GET/POST/PATCH/DELETE), via Middleware admin-geschuetzt

Naechste Teile: **UI-Drawer** (Beschreibung editieren + Subtasks abhaken), dann **Datei-Uploads** und **Zeit-Buchung** auf Aufgaben.

🤖 via Claude Code