### PR TITLE
feat(aufgaben): Datei-Uploads an Aufgaben

### DIFF
--- a/src/app/api/admin/tasks/[id]/attachments/route.ts
+++ b/src/app/api/admin/tasks/[id]/attachments/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import { listTaskAttachments, addTaskAttachment, getTaskAttachment, deleteTaskAttachment } from '@/lib/staffStore';
+
+/** GET → Liste (Metadaten). GET ?attId=… → Datei-Download. */
+export async function GET(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const attId = new URL(req.url).searchParams.get('attId');
+  if (attId) {
+    const a = await getTaskAttachment(attId);
+    if (!a) return NextResponse.json({ success: false, error: 'nicht gefunden' }, { status: 404 });
+    const buf = Buffer.from(a.data_b64, 'base64');
+    return new NextResponse(buf, {
+      headers: {
+        'Content-Type': a.mime || 'application/octet-stream',
+        'Content-Disposition': `inline; filename="${encodeURIComponent(a.filename)}"`,
+      },
+    });
+  }
+  const data = await listTaskAttachments(id);
+  return NextResponse.json({ success: true, data });
+}
+
+/** POST (multipart, Feld "file") → Datei anhängen. */
+export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const form = await req.formData();
+  const file = form.get('file');
+  if (!(file instanceof File)) return NextResponse.json({ success: false, error: 'Datei fehlt' }, { status: 400 });
+  const buf = Buffer.from(await file.arrayBuffer());
+  const data = await addTaskAttachment(id, {
+    filename: file.name || 'datei',
+    mime: file.type || 'application/octet-stream',
+    size: buf.length,
+    data_b64: buf.toString('base64'),
+  });
+  return NextResponse.json({ success: true, data });
+}
+
+/** DELETE ?attId=… → Datei löschen. */
+export async function DELETE(req: Request) {
+  const attId = new URL(req.url).searchParams.get('attId');
+  if (!attId) return NextResponse.json({ success: false, error: 'attId erforderlich' }, { status: 400 });
+  const ok = await deleteTaskAttachment(attId);
+  return NextResponse.json({ success: ok });
+}

--- a/src/components/admin/TaskDrawer.tsx
+++ b/src/components/admin/TaskDrawer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { X, Plus, Trash2, Check } from 'lucide-react';
+import { useEffect, useState, useRef } from 'react';
+import { X, Plus, Trash2, Check, Paperclip, Download } from 'lucide-react';
 import { Button, TextArea, Spinner, Badge, COLORS } from './ui';
 
 interface Task {
@@ -13,6 +13,7 @@ interface Task {
   due_date: string | null;
 }
 interface Subtask { id: string; title: string; done: number }
+interface Att { id: string; filename: string; mime: string; size: number }
 
 const PRIO_TONE = { niedrig: 'muted', normal: 'info', hoch: 'danger' } as const;
 const STATUS_LABEL = { offen: 'Offen', in_arbeit: 'In Arbeit', erledigt: 'Erledigt' } as const;
@@ -23,6 +24,9 @@ export default function TaskDrawer({ task, onClose, onChanged }: { task: Task; o
   const [subs, setSubs] = useState<Subtask[]>([]);
   const [newSub, setNewSub] = useState('');
   const [loading, setLoading] = useState(true);
+  const [atts, setAtts] = useState<Att[]>([]);
+  const [uploading, setUploading] = useState(false);
+  const fileRef = useRef<HTMLInputElement>(null);
 
   const loadSubs = () => {
     setLoading(true);
@@ -32,7 +36,10 @@ export default function TaskDrawer({ task, onClose, onChanged }: { task: Task; o
       .catch(() => {})
       .finally(() => setLoading(false));
   };
-  useEffect(() => { loadSubs(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [task.id]);
+  const loadAtts = () => {
+    fetch(`/api/admin/tasks/${task.id}/attachments`).then((r) => r.json()).then((r) => { if (r.success) setAtts(r.data); }).catch(() => {});
+  };
+  useEffect(() => { loadSubs(); loadAtts(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [task.id]);
 
   const saveDesc = async () => {
     setSavingDesc(true);
@@ -62,6 +69,18 @@ export default function TaskDrawer({ task, onClose, onChanged }: { task: Task; o
   const delSub = async (s: Subtask) => {
     setSubs((prev) => prev.filter((x) => x.id !== s.id));
     await fetch(`/api/admin/tasks/${task.id}/subtasks?subtaskId=${encodeURIComponent(s.id)}`, { method: 'DELETE' });
+  };
+  const onUpload = async (f: File) => {
+    setUploading(true);
+    try {
+      const fd = new FormData(); fd.append('file', f);
+      await fetch(`/api/admin/tasks/${task.id}/attachments`, { method: 'POST', body: fd });
+      loadAtts();
+    } finally { setUploading(false); }
+  };
+  const delAtt = async (a: Att) => {
+    setAtts((prev) => prev.filter((x) => x.id !== a.id));
+    await fetch(`/api/admin/tasks/${task.id}/attachments?attId=${encodeURIComponent(a.id)}`, { method: 'DELETE' });
   };
 
   const doneCount = subs.filter((s) => s.done).length;
@@ -137,6 +156,28 @@ export default function TaskDrawer({ task, onClose, onChanged }: { task: Task; o
             />
             <Button size="sm" variant="ghost" onClick={addSub} disabled={!newSub.trim()}><Plus className="h-4 w-4" /></Button>
           </div>
+        </div>
+
+        {/* Datei-Anhänge */}
+        <div className="mt-6">
+          <label className="mb-2 block text-xs font-semibold" style={{ color: COLORS.textMuted }}>Dateien</label>
+          <input ref={fileRef} type="file" className="hidden" onChange={(e) => { const f = e.target.files?.[0]; e.target.value = ''; if (f) onUpload(f); }} />
+          <Button size="sm" variant="secondary" onClick={() => fileRef.current?.click()} disabled={uploading}>
+            {uploading ? <Spinner className="h-4 w-4" /> : <Paperclip className="h-4 w-4" />} Datei anhängen
+          </Button>
+          {atts.length > 0 && (
+            <div className="mt-2 space-y-1.5">
+              {atts.map((a) => (
+                <div key={a.id} className="group flex items-center gap-2 text-sm">
+                  <a href={`/api/admin/tasks/${task.id}/attachments?attId=${encodeURIComponent(a.id)}`} target="_blank" rel="noreferrer" className="flex flex-1 items-center gap-1.5 truncate hover:underline" style={{ color: COLORS.navy }}>
+                    <Download className="h-3.5 w-3.5 shrink-0" style={{ color: COLORS.textMuted }} />
+                    <span className="truncate">{a.filename}</span>
+                  </a>
+                  <button onClick={() => delAtt(a)} className="opacity-0 transition group-hover:opacity-100" title="Löschen"><Trash2 className="h-3.5 w-3.5" style={{ color: COLORS.textMuted }} /></button>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -288,6 +288,18 @@ export function initDatabase() {
     );
     CREATE INDEX IF NOT EXISTS idx_subtasks_task ON staff_task_subtasks(task_id);
 
+    CREATE TABLE IF NOT EXISTS task_attachments (
+      id TEXT PRIMARY KEY,
+      task_id TEXT NOT NULL,
+      filename TEXT NOT NULL DEFAULT 'datei',
+      mime TEXT NOT NULL DEFAULT 'application/octet-stream',
+      size INTEGER NOT NULL DEFAULT 0,
+      data_b64 TEXT NOT NULL DEFAULT '',
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      created_by TEXT NOT NULL DEFAULT ''
+    );
+    CREATE INDEX IF NOT EXISTS idx_task_attach_task ON task_attachments(task_id);
+
     CREATE TABLE IF NOT EXISTS tippspiel_users (
       id TEXT PRIMARY KEY,
       email TEXT NOT NULL UNIQUE,

--- a/src/lib/dbq.ts
+++ b/src/lib/dbq.ts
@@ -254,6 +254,17 @@ export async function applyPgSchemaEnhancements(): Promise<void> {
         created_at timestamptz NOT NULL DEFAULT now()
       )`);
       await pool.query(`CREATE INDEX IF NOT EXISTS idx_subtasks_task ON staff_task_subtasks(task_id)`);
+      await pool.query(`CREATE TABLE IF NOT EXISTS task_attachments (
+        id text PRIMARY KEY,
+        task_id text NOT NULL,
+        filename text NOT NULL DEFAULT 'datei',
+        mime text NOT NULL DEFAULT 'application/octet-stream',
+        size integer NOT NULL DEFAULT 0,
+        data_b64 text NOT NULL DEFAULT '',
+        created_at timestamptz NOT NULL DEFAULT now(),
+        created_by text NOT NULL DEFAULT ''
+      )`);
+      await pool.query(`CREATE INDEX IF NOT EXISTS idx_task_attach_task ON task_attachments(task_id)`);
     } catch (e) { console.warn('[pg] Portal-Schema:', (e as Error).message); }
 
     // Defaults auf Timestamp-Spalten (damit Inserts ohne created_at/updated_at funktionieren)

--- a/src/lib/staffStore.ts
+++ b/src/lib/staffStore.ts
@@ -455,3 +455,31 @@ export async function setSubtaskDone(id: string, done: boolean): Promise<boolean
 export async function deleteSubtask(id: string): Promise<boolean> {
   return (await dbRun('DELETE FROM staff_task_subtasks WHERE id = ?', [id])).changes > 0;
 }
+
+export interface TaskAttachment {
+  id: string;
+  task_id: string;
+  filename: string;
+  mime: string;
+  size: number;
+  created_at: string;
+  created_by: string;
+}
+
+export async function listTaskAttachments(taskId: string): Promise<TaskAttachment[]> {
+  return dbAll<TaskAttachment>('SELECT id, task_id, filename, mime, size, created_at, created_by FROM task_attachments WHERE task_id = ? ORDER BY created_at DESC', [taskId]);
+}
+
+export async function addTaskAttachment(taskId: string, a: { filename: string; mime: string; size: number; data_b64: string; created_by?: string }): Promise<TaskAttachment> {
+  const id = crypto.randomUUID();
+  await dbRun('INSERT INTO task_attachments (id, task_id, filename, mime, size, data_b64, created_by) VALUES (?, ?, ?, ?, ?, ?, ?)', [id, taskId, a.filename, a.mime, a.size, a.data_b64, a.created_by || '']);
+  return (await dbGet<TaskAttachment>('SELECT id, task_id, filename, mime, size, created_at, created_by FROM task_attachments WHERE id = ?', [id]))!;
+}
+
+export async function getTaskAttachment(id: string): Promise<{ filename: string; mime: string; data_b64: string } | null> {
+  return (await dbGet<{ filename: string; mime: string; data_b64: string }>('SELECT filename, mime, data_b64 FROM task_attachments WHERE id = ?', [id])) ?? null;
+}
+
+export async function deleteTaskAttachment(id: string): Promise<boolean> {
+  return (await dbRun('DELETE FROM task_attachments WHERE id = ?', [id])).changes > 0;
+}


### PR DESCRIPTION
Phase 5 Teil 3: Dateien an Aufgaben anhaengen. Neue Tabelle task_attachments (SQLite + PG, non-destruktiv), REST-API (Liste/Upload/Download/Loeschen) und Upload-Bereich im Task-Drawer.

via Claude Code