### PR TITLE
feat(aufgaben): Zeit-Buchung auf Aufgaben

### DIFF
--- a/src/app/api/admin/tasks/[id]/time/route.ts
+++ b/src/app/api/admin/tasks/[id]/time/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import { listTaskTime, addTaskTime, sumTaskMinutes, deleteTaskTime } from '@/lib/staffStore';
+
+/** GET → { entries, totalMinutes }. */
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const [entries, totalMinutes] = await Promise.all([listTaskTime(id), sumTaskMinutes(id)]);
+  return NextResponse.json({ success: true, data: { entries, totalMinutes } });
+}
+
+/** POST { minutes, note? } → Zeit buchen. */
+export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const body = await req.json().catch(() => ({}));
+  const minutes = Math.round(Number(body?.minutes));
+  if (!minutes || minutes <= 0) return NextResponse.json({ success: false, error: 'minutes > 0 erforderlich' }, { status: 400 });
+  const data = await addTaskTime(id, minutes, (body?.note || '').trim() || undefined);
+  return NextResponse.json({ success: true, data });
+}
+
+/** DELETE ?entryId=… → Buchung löschen. */
+export async function DELETE(req: Request) {
+  const entryId = new URL(req.url).searchParams.get('entryId');
+  if (!entryId) return NextResponse.json({ success: false, error: 'entryId erforderlich' }, { status: 400 });
+  const ok = await deleteTaskTime(entryId);
+  return NextResponse.json({ success: ok });
+}

--- a/src/components/admin/TaskDrawer.tsx
+++ b/src/components/admin/TaskDrawer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState, useRef } from 'react';
-import { X, Plus, Trash2, Check, Paperclip, Download } from 'lucide-react';
+import { X, Plus, Trash2, Check, Paperclip, Download, Clock } from 'lucide-react';
 import { Button, TextArea, Spinner, Badge, COLORS } from './ui';
 
 interface Task {
@@ -14,9 +14,16 @@ interface Task {
 }
 interface Subtask { id: string; title: string; done: number }
 interface Att { id: string; filename: string; mime: string; size: number }
+interface TimeEntry { id: string; minutes: number; note: string }
 
 const PRIO_TONE = { niedrig: 'muted', normal: 'info', hoch: 'danger' } as const;
 const STATUS_LABEL = { offen: 'Offen', in_arbeit: 'In Arbeit', erledigt: 'Erledigt' } as const;
+
+function fmtMin(m: number): string {
+  if (!m) return '0 min';
+  const h = Math.floor(m / 60), mm = m % 60;
+  return h ? `${h}h ${mm}min` : `${mm} min`;
+}
 
 export default function TaskDrawer({ task, onClose, onChanged }: { task: Task; onClose: () => void; onChanged?: () => void }) {
   const [desc, setDesc] = useState(task.description || '');
@@ -27,6 +34,10 @@ export default function TaskDrawer({ task, onClose, onChanged }: { task: Task; o
   const [atts, setAtts] = useState<Att[]>([]);
   const [uploading, setUploading] = useState(false);
   const fileRef = useRef<HTMLInputElement>(null);
+  const [mins, setMins] = useState('');
+  const [timeNote, setTimeNote] = useState('');
+  const [times, setTimes] = useState<TimeEntry[]>([]);
+  const [totalMin, setTotalMin] = useState(0);
 
   const loadSubs = () => {
     setLoading(true);
@@ -39,7 +50,10 @@ export default function TaskDrawer({ task, onClose, onChanged }: { task: Task; o
   const loadAtts = () => {
     fetch(`/api/admin/tasks/${task.id}/attachments`).then((r) => r.json()).then((r) => { if (r.success) setAtts(r.data); }).catch(() => {});
   };
-  useEffect(() => { loadSubs(); loadAtts(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [task.id]);
+  const loadTimes = () => {
+    fetch(`/api/admin/tasks/${task.id}/time`).then((r) => r.json()).then((r) => { if (r.success) { setTimes(r.data.entries); setTotalMin(r.data.totalMinutes); } }).catch(() => {});
+  };
+  useEffect(() => { loadSubs(); loadAtts(); loadTimes(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [task.id]);
 
   const saveDesc = async () => {
     setSavingDesc(true);
@@ -81,6 +95,18 @@ export default function TaskDrawer({ task, onClose, onChanged }: { task: Task; o
   const delAtt = async (a: Att) => {
     setAtts((prev) => prev.filter((x) => x.id !== a.id));
     await fetch(`/api/admin/tasks/${task.id}/attachments?attId=${encodeURIComponent(a.id)}`, { method: 'DELETE' });
+  };
+  const bookTime = async () => {
+    const m = Math.round(Number(mins));
+    if (!m || m <= 0) return;
+    setMins(''); setTimeNote('');
+    await fetch(`/api/admin/tasks/${task.id}/time`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ minutes: m, note: timeNote }) });
+    loadTimes();
+  };
+  const delTime = async (t: TimeEntry) => {
+    setTimes((prev) => prev.filter((x) => x.id !== t.id));
+    await fetch(`/api/admin/tasks/${task.id}/time?entryId=${encodeURIComponent(t.id)}`, { method: 'DELETE' });
+    loadTimes();
   };
 
   const doneCount = subs.filter((s) => s.done).length;
@@ -174,6 +200,30 @@ export default function TaskDrawer({ task, onClose, onChanged }: { task: Task; o
                     <span className="truncate">{a.filename}</span>
                   </a>
                   <button onClick={() => delAtt(a)} className="opacity-0 transition group-hover:opacity-100" title="Löschen"><Trash2 className="h-3.5 w-3.5" style={{ color: COLORS.textMuted }} /></button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Zeit */}
+        <div className="mt-6">
+          <div className="mb-2 flex items-center justify-between">
+            <label className="text-xs font-semibold" style={{ color: COLORS.textMuted }}>Zeit</label>
+            <span className="text-xs font-bold tabular-nums" style={{ color: COLORS.navy }}>{fmtMin(totalMin)} gebucht</span>
+          </div>
+          <div className="flex gap-2">
+            <input type="number" min={1} value={mins} onChange={(e) => setMins(e.target.value)} placeholder="Min" className="w-20 rounded-lg border px-3 py-1.5 text-sm focus:outline-none" style={{ borderColor: COLORS.stroke }} />
+            <input value={timeNote} onChange={(e) => setTimeNote(e.target.value)} placeholder="Notiz (optional)" className="flex-1 rounded-lg border px-3 py-1.5 text-sm focus:outline-none" style={{ borderColor: COLORS.stroke }} />
+            <Button size="sm" variant="secondary" onClick={bookTime} disabled={!mins || Number(mins) <= 0}><Clock className="h-4 w-4" /></Button>
+          </div>
+          {times.length > 0 && (
+            <div className="mt-2 space-y-1 text-xs">
+              {times.map((t) => (
+                <div key={t.id} className="group flex items-center gap-2">
+                  <span className="tabular-nums font-semibold" style={{ color: COLORS.navy }}>{fmtMin(t.minutes)}</span>
+                  <span className="flex-1 truncate" style={{ color: COLORS.textMuted }}>{t.note}</span>
+                  <button onClick={() => delTime(t)} className="opacity-0 transition group-hover:opacity-100" title="Löschen"><Trash2 className="h-3 w-3" style={{ color: COLORS.textMuted }} /></button>
                 </div>
               ))}
             </div>

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -300,6 +300,16 @@ export function initDatabase() {
     );
     CREATE INDEX IF NOT EXISTS idx_task_attach_task ON task_attachments(task_id);
 
+    CREATE TABLE IF NOT EXISTS task_time (
+      id TEXT PRIMARY KEY,
+      task_id TEXT NOT NULL,
+      employee_id TEXT,
+      minutes INTEGER NOT NULL DEFAULT 0,
+      note TEXT NOT NULL DEFAULT '',
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_task_time_task ON task_time(task_id);
+
     CREATE TABLE IF NOT EXISTS tippspiel_users (
       id TEXT PRIMARY KEY,
       email TEXT NOT NULL UNIQUE,

--- a/src/lib/dbq.ts
+++ b/src/lib/dbq.ts
@@ -265,6 +265,15 @@ export async function applyPgSchemaEnhancements(): Promise<void> {
         created_by text NOT NULL DEFAULT ''
       )`);
       await pool.query(`CREATE INDEX IF NOT EXISTS idx_task_attach_task ON task_attachments(task_id)`);
+      await pool.query(`CREATE TABLE IF NOT EXISTS task_time (
+        id text PRIMARY KEY,
+        task_id text NOT NULL,
+        employee_id text,
+        minutes integer NOT NULL DEFAULT 0,
+        note text NOT NULL DEFAULT '',
+        created_at timestamptz NOT NULL DEFAULT now()
+      )`);
+      await pool.query(`CREATE INDEX IF NOT EXISTS idx_task_time_task ON task_time(task_id)`);
     } catch (e) { console.warn('[pg] Portal-Schema:', (e as Error).message); }
 
     // Defaults auf Timestamp-Spalten (damit Inserts ohne created_at/updated_at funktionieren)

--- a/src/lib/staffStore.ts
+++ b/src/lib/staffStore.ts
@@ -483,3 +483,31 @@ export async function getTaskAttachment(id: string): Promise<{ filename: string;
 export async function deleteTaskAttachment(id: string): Promise<boolean> {
   return (await dbRun('DELETE FROM task_attachments WHERE id = ?', [id])).changes > 0;
 }
+
+export interface TaskTime {
+  id: string;
+  task_id: string;
+  employee_id: string | null;
+  minutes: number;
+  note: string;
+  created_at: string;
+}
+
+export async function listTaskTime(taskId: string): Promise<TaskTime[]> {
+  return dbAll<TaskTime>('SELECT * FROM task_time WHERE task_id = ? ORDER BY created_at DESC', [taskId]);
+}
+
+export async function sumTaskMinutes(taskId: string): Promise<number> {
+  const r = await dbGet<{ total: number }>('SELECT COALESCE(SUM(minutes), 0) AS total FROM task_time WHERE task_id = ?', [taskId]);
+  return r?.total ?? 0;
+}
+
+export async function addTaskTime(taskId: string, minutes: number, note?: string, employeeId?: string | null): Promise<TaskTime> {
+  const id = crypto.randomUUID();
+  await dbRun('INSERT INTO task_time (id, task_id, employee_id, minutes, note) VALUES (?, ?, ?, ?, ?)', [id, taskId, employeeId || null, minutes, note || '']);
+  return (await dbGet<TaskTime>('SELECT * FROM task_time WHERE id = ?', [id]))!;
+}
+
+export async function deleteTaskTime(id: string): Promise<boolean> {
+  return (await dbRun('DELETE FROM task_time WHERE id = ?', [id])).changes > 0;
+}


### PR DESCRIPTION
Phase 5 Teil 4 (Abschluss): Zeit auf Aufgaben buchen. Neue Tabelle task_time (getrennt von der Schicht-Zeiterfassung, SQLite + PG non-destruktiv), REST-API + Zeit-Bereich im Task-Drawer (Gesamtzeit + Minuten buchen + Liste).

via Claude Code