### PR TITLE
WordPress: [faltin_packages]-Shortcode mit Anfrageformular-Fallback

### DIFF
--- a/WORDPRESS-INTEGRATION.md
+++ b/WORDPRESS-INTEGRATION.md
@@ -370,3 +370,22 @@ https://faltintravel.com/super-bowl-2027-tickets/
 ---
 
 Möchten Sie Hilfe beim Deployment oder haben Sie Fragen zur Integration? 🚀
+
+## Package-Karten: `[faltin_packages]` (ab Plugin 1.4.0)
+
+Zeigt die buchbaren Packages eines Events als Karten-Grid — serverseitig
+gerendertes HTML aus `/api/packages-html` (Fotos, Leistungen, Preise,
+Ausgebucht-Status, Product-JSON-LD, Buchungslinks auf die Faltin-Buchungsseite).
+
+```
+[faltin_packages event="super-bowl-2027"]
+```
+
+- **Fallback-Logik wie auf der Event-Seite:** Hat das Event keine aktiven
+  Packages (oder ist die API nicht erreichbar), rendert der Shortcode
+  automatisch das native Anfrageformular (`[faltin_anfrage]`).
+- **Buchungsseite:** Die Karten-Buttons verlinken auf die menülose
+  Buchungsseite (`…/booking`). Deren „Zurück"-Button führt per Browser-History
+  zurück zur WordPress-Seite — kein iframe, keine Doppel-Pflege.
+- Design-Änderungen am Karten-Layout passieren zentral im Faltin-System;
+  WordPress muss dafür nie angefasst werden (10-Minuten-Cache via Transient).

--- a/src/app/admin/shortcodes/page.tsx
+++ b/src/app/admin/shortcodes/page.tsx
@@ -43,6 +43,19 @@ const PLUGINS: Plugin[] = [
         ],
       },
       {
+        code: '[faltin_packages]',
+        example: '[faltin_packages event="super-bowl-2027"]',
+        title: 'Package-Karten (mit Formular-Fallback)',
+        desc: 'Zeigt die buchbaren Packages des Events als Karten-Grid (Fotos, Leistungen, Preise, Ausgebucht-Status, Buchungslink). Ohne aktive Packages wird automatisch das Anfrageformular gerendert — gleiche Logik wie die Event-Seite.',
+        recommended: true,
+        params: [
+          { name: 'event', required: true, desc: 'Event-Slug, z.B. super-bowl-2027.' },
+          { name: 'name', def: '(leer)', desc: 'Anzeigename fürs Fallback-Formular.' },
+          { name: 'cache', def: '600', desc: 'Cache-Dauer in Sekunden (0 = aus).' },
+          { name: 'api_url', def: 'Standard', desc: 'API-Server überschreiben (selten nötig).' },
+        ],
+      },
+      {
         code: '[faltin_anfrage]',
         example: '[faltin_anfrage event="super-bowl-2027" title="Jetzt unverbindlich anfragen"]',
         title: 'Anfrage-/Kontaktformular',

--- a/src/app/api/packages-html/route.ts
+++ b/src/app/api/packages-html/route.ts
@@ -1,0 +1,190 @@
+import { NextResponse } from 'next/server';
+import { getEventBySlug, getPackagesByEventSlug, type PackageRecord } from '@/lib/eventData';
+
+/**
+ * Liefert die Package-Karten eines Events als selbstenthaltenes HTML
+ * (Inline-CSS, kein JS, absolute URLs) für die WordPress-Einbettung via
+ * [faltin_packages]-Shortcode. Antwortformat kompatibel zu faltin_events_fetch:
+ * { success, data: { has_packages, count, event_name, html } }.
+ * Keine aktiven Packages → has_packages:false, das Plugin rendert dann das
+ * native Anfrageformular (gleiche Logik wie die eigene Event-Seite).
+ */
+
+const NAVY = '#143047';
+const ORANGE = '#d9531e';
+
+function esc(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function absUrl(base: string, src: string): string {
+  if (!src) return src;
+  if (src.startsWith('http://') || src.startsWith('https://')) return src;
+  return base.replace(/\/$/, '') + (src.startsWith('/') ? src : `/${src}`);
+}
+
+function fmtPrice(amount: number, currency?: string | null): string {
+  const cur = (currency || 'EUR').toUpperCase();
+  if (cur === 'EUR') return `${amount.toLocaleString('de-DE')} €`;
+  return `${cur} ${amount.toLocaleString('de-CH')}`;
+}
+
+const CHECK_SVG = `<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="${ORANGE}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink:0;margin-top:2px"><path d="M20 6 9 17l-5-5"/></svg>`;
+
+const STYLE = `
+<style>
+.ftpk-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:24px;margin:0;padding:0}
+.ftpk-card{position:relative;display:flex;flex-direction:column;background:#fff;border:1px solid #d8e0ea;border-radius:16px;overflow:hidden;box-shadow:0 2px 10px rgba(20,48,71,.06);transition:transform .2s ease,box-shadow .2s ease}
+.ftpk-card:hover{transform:translateY(-4px);box-shadow:0 10px 26px rgba(20,48,71,.14)}
+.ftpk-card--pop{border:2px solid ${NAVY};box-shadow:0 10px 26px rgba(20,48,71,.16)}
+.ftpk-media{position:relative;height:185px;overflow:hidden;background:#eef2f7}
+.ftpk-media img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;margin:0;display:block}
+.ftpk-media--so img{filter:grayscale(.55) brightness(.9)}
+.ftpk-shade{position:absolute;inset:0;background:linear-gradient(180deg,rgba(20,48,71,.05) 40%,rgba(20,48,71,.68) 100%)}
+.ftpk-badges{position:absolute;left:12px;top:12px;display:flex;flex-wrap:wrap;gap:6px}
+.ftpk-chip{display:inline-block;padding:4px 10px;border-radius:999px;font-size:11px;font-weight:700;line-height:1.3}
+.ftpk-chip--badge{background:rgba(255,255,255,.92);color:${NAVY}}
+.ftpk-chip--hl{background:${ORANGE};color:#fff}
+.ftpk-chip--so{position:absolute;right:12px;top:12px;background:rgba(20,48,71,.92);color:#fff;text-transform:uppercase;letter-spacing:.04em}
+.ftpk-hotel{position:absolute;left:12px;right:12px;bottom:10px;display:flex;justify-content:space-between;align-items:flex-end;gap:8px}
+.ftpk-hotel b{color:#fff;font-size:13px;text-shadow:0 1px 3px rgba(0,0,0,.5);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.ftpk-stars{color:#f5b301;font-size:11px;line-height:1.2}
+.ftpk-fotos{flex-shrink:0;background:rgba(20,48,71,.55);color:#fff;font-size:10.5px;font-weight:600;padding:2px 8px;border-radius:999px}
+.ftpk-body{display:flex;flex-direction:column;flex:1;padding:18px 20px 20px}
+.ftpk-title{margin:0 0 4px;font-size:17px;font-weight:800;line-height:1.35;color:${NAVY}}
+.ftpk-desc{margin:0;font-size:13px;line-height:1.55;color:#5b6b7d}
+.ftpk-list{list-style:none;margin:14px 0 0;padding:14px 0 0;border-top:1px solid #eef2f7;display:flex;flex-direction:column;gap:8px}
+.ftpk-list li{display:flex;gap:8px;align-items:flex-start;font-size:13px;line-height:1.4;color:#33404d;margin:0}
+.ftpk-foot{margin-top:auto;padding-top:14px;border-top:1px solid #eef2f7}
+.ftpk-meta{font-size:11.5px;color:#8190a0;margin:14px 0 8px}
+.ftpk-few{font-size:11.5px;font-weight:700;color:${ORANGE};margin:0 0 6px}
+.ftpk-ab{font-size:12px;color:#8190a0}
+.ftpk-price{font-size:24px;font-weight:800;line-height:1.1;color:${NAVY}}
+.ftpk-price--so{color:#8190a0}
+.ftpk-per{font-size:11.5px;color:#8190a0}
+.ftpk-cta{display:block;margin-top:12px;padding:11px 16px;border-radius:10px;text-align:center;font-size:13px;font-weight:700;text-decoration:none;border:1.5px solid ${NAVY};color:${NAVY};transition:opacity .15s}
+.ftpk-cta:hover{opacity:.85;text-decoration:none;color:${NAVY}}
+.ftpk-cta--pop{background:${ORANGE};border-color:${ORANGE};color:#fff}
+.ftpk-cta--pop:hover{color:#fff}
+.ftpk-cta--so{background:#eef2f7;border:1.5px solid #d8e0ea;color:#8190a0;cursor:not-allowed}
+</style>`;
+
+function renderCard(pkg: PackageRecord, base: string, eventSlug: string): string {
+  const soldOut = pkg.available_spots === 0;
+  const spots = typeof pkg.available_spots === 'number' ? pkg.available_spots : null;
+  const fewSpots = !soldOut && spots !== null && spots > 0 && spots <= 10;
+  const popular = Boolean(pkg.popular) && !soldOut;
+  const images = (pkg.hotel_images || []).filter(Boolean).map((i) => absUrl(base, i));
+  const includes = (pkg.package_includes || (pkg as PackageRecord & { includes?: Array<{ name: string }> }).includes || [])
+    .filter((i) => i && i.name)
+    .slice(0, 6);
+  const stars = Math.max(0, Math.min(5, Number(pkg.stars || 0)));
+  const nights = Number(pkg.nights || 0);
+  const price = Number(pkg.price || 0);
+  const bookingUrl = `${base}/booking?event=${encodeURIComponent(eventSlug)}&package=${encodeURIComponent(pkg.slug || pkg.id)}&persons=2`;
+
+  const media = images.length
+    ? `<div class="ftpk-media${soldOut ? ' ftpk-media--so' : ''}">
+        <img src="${esc(images[0])}" alt="${esc(pkg.hotel || pkg.title || '')}" loading="lazy" />
+        <div class="ftpk-shade"></div>
+        <div class="ftpk-badges">
+          ${pkg.badge_text ? `<span class="ftpk-chip ftpk-chip--badge">${esc(pkg.badge_text)}</span>` : ''}
+          ${popular ? `<span class="ftpk-chip ftpk-chip--hl">★ Highlight</span>` : ''}
+        </div>
+        ${soldOut ? `<span class="ftpk-chip ftpk-chip--so">Ausgebucht</span>` : ''}
+        <div class="ftpk-hotel">
+          <span style="min-width:0">
+            ${pkg.hotel ? `<b>${esc(pkg.hotel)}</b>` : ''}
+            ${stars ? `<span class="ftpk-stars" style="display:block">${'★'.repeat(stars)}</span>` : ''}
+          </span>
+          ${images.length > 1 ? `<span class="ftpk-fotos">📷 ${images.length} Fotos</span>` : ''}
+        </div>
+      </div>`
+    : '';
+
+  const metaBits = [
+    pkg.travel_period ? esc(pkg.travel_period) : '',
+    nights ? `${nights} ${nights === 1 ? 'Nacht' : 'Nächte'}` : '',
+  ].filter(Boolean).join(' · ');
+
+  const cta = soldOut
+    ? `<span class="ftpk-cta ftpk-cta--so">Ausgebucht</span>`
+    : `<a class="ftpk-cta${popular ? ' ftpk-cta--pop' : ''}" href="${esc(bookingUrl)}">Unverbindlich anfragen →</a>`;
+
+  return `<div class="ftpk-card${popular ? ' ftpk-card--pop' : ''}">
+    ${media}
+    <div class="ftpk-body">
+      <h3 class="ftpk-title">${esc(pkg.title || '')}</h3>
+      ${pkg.short_description ? `<p class="ftpk-desc">${esc(pkg.short_description)}</p>` : ''}
+      ${includes.length ? `<ul class="ftpk-list">${includes.map((i) => `<li>${CHECK_SVG}<span>${esc(i.name)}</span></li>`).join('')}</ul>` : ''}
+      <div class="ftpk-foot">
+        ${metaBits ? `<div class="ftpk-meta">${metaBits}</div>` : ''}
+        ${fewSpots ? `<div class="ftpk-few">Nur noch wenige Plätze verfügbar</div>` : ''}
+        <div class="ftpk-ab">ab</div>
+        <div class="ftpk-price${soldOut ? ' ftpk-price--so' : ''}">${fmtPrice(price, pkg.currency)}</div>
+        <div class="ftpk-per">pro Person im Doppelzimmer</div>
+        ${cta}
+      </div>
+    </div>
+  </div>`;
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const eventSlug = searchParams.get('event') || '';
+  if (!eventSlug) {
+    return NextResponse.json({ success: false, error: 'event fehlt' }, { status: 400 });
+  }
+
+  const event = await getEventBySlug(eventSlug);
+  if (!event) {
+    return NextResponse.json({ success: false, error: 'Event nicht gefunden' }, { status: 404 });
+  }
+
+  const base = (event.base_url || process.env.NEXT_PUBLIC_SITE_URL || 'https://next.faltintravel.com').replace(/\/$/, '');
+  const packages = (await getPackagesByEventSlug(eventSlug)).filter((p) => p.active !== false);
+
+  if (packages.length === 0) {
+    return NextResponse.json({
+      success: true,
+      data: { has_packages: false, count: 0, event_name: event.name || event.title, html: '' },
+    });
+  }
+
+  // Product/Offer-JSON-LD (GEO/SEO): Preise & Verfügbarkeit maschinenlesbar
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    itemListElement: packages.map((p, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      item: {
+        '@type': 'Product',
+        name: `${event.name || event.title} – ${p.title}`,
+        description: p.short_description || undefined,
+        image: (p.hotel_images || []).filter(Boolean).slice(0, 1).map((img) => absUrl(base, img)),
+        offers: {
+          '@type': 'Offer',
+          price: Number(p.price || 0),
+          priceCurrency: (p.currency || 'EUR').toUpperCase(),
+          availability: p.available_spots === 0 ? 'https://schema.org/SoldOut' : 'https://schema.org/InStock',
+          url: `${base}/booking?event=${encodeURIComponent(eventSlug)}&package=${encodeURIComponent(p.slug || p.id)}`,
+        },
+      },
+    })),
+  };
+
+  const html =
+    STYLE +
+    `<div class="ftpk-grid" data-ftv="1.4.0">${packages.map((p) => renderCard(p, base, eventSlug)).join('')}</div>` +
+    `<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>`;
+
+  return NextResponse.json({
+    success: true,
+    data: { has_packages: true, count: packages.length, event_name: event.name || event.title, html },
+  });
+}

--- a/wordpress-plugin/faltin-events.php
+++ b/wordpress-plugin/faltin-events.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * Plugin Name: Faltin Travel – Event Shortcodes
- * Description: SEO-freundliche, serverseitig gerenderte Event-Karten + natives Anfrageformular. Shortcodes: [faltin_events serie="..."], [faltin_event event="..."], [faltin_anfrage event="..."].
- * Version: 1.3.0
+ * Description: SEO-freundliche, serverseitig gerenderte Event-Karten, Package-Karten + natives Anfrageformular. Shortcodes: [faltin_events serie="..."], [faltin_event event="..."], [faltin_packages event="..."], [faltin_anfrage event="..."].
+ * Version: 1.4.0
  * Author: Faltin Travel AG
  *
  * Die Inhalte werden serverseitig per REST-API geladen (wp_remote_get) und als
@@ -12,6 +12,7 @@
  * Shortcodes:
  *   [faltin_events serie="darts-wm" limit="6" columns="3"]
  *   [faltin_event event="super-bowl-lxi-2027"]
+ *   [faltin_packages event="super-bowl-2027"]  – Package-Karten; ohne Packages → Anfrageformular
  *
  * Optionale Parameter:
  *   api_url   – Basis-URL des Systems (Default: https://next.faltintravel.com)
@@ -408,3 +409,48 @@ function faltin_anfrage_shortcode($atts) {
     return faltin_anfrage_styles() . ob_get_clean();
 }
 add_shortcode('faltin_anfrage', 'faltin_anfrage_shortcode');
+
+/* ─── Shortcode: Package-Karten (mit Anfrageformular-Fallback) ───────────── */
+/**
+ * [faltin_packages event="super-bowl-2027"]
+ *
+ * Rendert die buchbaren Packages des Events als Karten-Grid — fertiges HTML
+ * aus dem Faltin-System (/api/packages-html): Fotos, Leistungen, Preise,
+ * Ausgebucht-Status, Buchungslinks. Design-Änderungen im System sind damit
+ * automatisch live, ohne dieses Plugin anzufassen.
+ *
+ * Hat das Event keine aktiven Packages, wird stattdessen das native
+ * Anfrageformular gerendert (gleiche Logik wie die Faltin-Event-Seite).
+ *
+ * Parameter:
+ *   event   – Event-Slug (Pflicht), z.B. super-bowl-2027
+ *   name    – Anzeigename fürs Fallback-Formular (optional)
+ *   cache   – Cache-Dauer in Sekunden (Default 600, 0 = aus)
+ *   api_url – API-Server überschreiben (selten nötig)
+ */
+function faltin_packages_shortcode($atts) {
+    $atts = shortcode_atts(array(
+        'event' => '',
+        'name' => '',
+        'cache' => 600,
+        'api_url' => FALTIN_EVENTS_DEFAULT_API,
+    ), $atts, 'faltin_packages');
+
+    if (!$atts['event']) return '<!-- faltin_packages: Parameter "event" fehlt -->';
+
+    $url = rtrim($atts['api_url'], '/') . '/api/packages-html?event=' . rawurlencode($atts['event']);
+    $data = faltin_events_fetch($url, (int)$atts['cache']);
+
+    if ($data && !empty($data['has_packages']) && !empty($data['html'])) {
+        // Fertiges, selbstenthaltenes HTML aus dem System (inkl. Styles & JSON-LD)
+        return $data['html'];
+    }
+
+    // Fallback: keine aktiven Packages (oder API nicht erreichbar) → Anfrageformular
+    return faltin_anfrage_shortcode(array(
+        'event' => $atts['event'],
+        'name' => $atts['name'] ?: (is_array($data) && !empty($data['event_name']) ? $data['event_name'] : ''),
+        'api_url' => $atts['api_url'],
+    ));
+}
+add_shortcode('faltin_packages', 'faltin_packages_shortcode');


### PR DESCRIPTION
## Was
WordPress-Integration der Package-Karten — serverseitig gerendert, kein iframe:

- **Neuer Endpoint `/api/packages-html?event=<slug>`**: liefert die Karten als selbstenthaltenes HTML (Inline-CSS, kein JS, absolute Bild-/Buchungslinks, Ausgebucht-Status, „wenige Plätze" ohne Zahlen) + **Product/Offer-JSON-LD** (zahlt aufs GEO/SEO-Backlog ein). Antwortformat kompatibel zum bestehenden `faltin_events_fetch`-Helper.
- **Plugin `faltin-events.php` → 1.4.0**: neuer Shortcode
  ```
  [faltin_packages event="super-bowl-2027"]
  ```
  Gibt das System-HTML aus. **Ohne aktive Packages (oder bei API-Fehler): automatischer Fallback aufs native Anfrageformular** (`faltin_anfrage`) — exakt die Logik der eigenen Event-Seite. Karten-Design lebt zentral im System; WP muss bei Änderungen nie angefasst werden (10-min-Transient-Cache).
- **Buchungsseite**: bewusst NICHT eingebettet — Karten verlinken auf die menülose `/booking`-Seite; deren Zurück-Button führt per `history.back()` zur WordPress-Herkunftsseite zurück.
- Doku: Eintrag in `/admin/shortcodes` (mit Copy-Beispielen) + `WORDPRESS-INTEGRATION.md`.

## Verifiziert
- `tsc` grün; Karten-Renderer offline getestet (12/12: absolute URLs, HTML-Escaping, soldOut ohne CTA, keine Platzzahlen, Highlight-Variante, Foto-Zähler).
- PHP-Änderung folgt 1:1 den bestehenden Shortcode-Mustern des Plugins (kein `php -l` in dieser Umgebung verfügbar).

## Nach dem Merge
1. Deploy läuft automatisch → Endpoint live.
2. **`wordpress-plugin/faltin-events.php` einmal in WP aktualisieren** (Plugin-Datei ersetzen, Version 1.4.0).
3. Auf der WP-Event-Seite `[faltin_packages event="super-bowl-2027"]` einsetzen — dort, wo heute das CF steht.

✅ **PR ist komplett — kann gemerged werden.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)