### PR TITLE
Breitere Buchungsseite + Package-Auto-Logik in [faltin_anfrage]

### DIFF
--- a/WORDPRESS-INTEGRATION.md
+++ b/WORDPRESS-INTEGRATION.md
@@ -389,3 +389,11 @@ Ausgebucht-Status, Product-JSON-LD, Buchungslinks auf die Faltin-Buchungsseite).
   zurück zur WordPress-Seite — kein iframe, keine Doppel-Pflege.
 - Design-Änderungen am Karten-Layout passieren zentral im Faltin-System;
   WordPress muss dafür nie angefasst werden (10-Minuten-Cache via Transient).
+
+### Auto-Logik in `[faltin_anfrage]` (ab Plugin 1.5.0)
+
+Bestehende Einbettungen wie `[faltin_anfrage event="americas-cup-2024"
+name="America's Cup 2024"]` bleiben unverändert gültig — und **upgraden
+automatisch**: Sobald das Event buchbare Packages hat, liefert der Shortcode
+die Package-Karten aus; sonst wie bisher das Anfrageformular. Kein Umbau
+bestehender WordPress-Seiten nötig. `packages="0"` erzwingt das reine Formular.

--- a/src/app/admin/shortcodes/page.tsx
+++ b/src/app/admin/shortcodes/page.tsx
@@ -58,10 +58,11 @@ const PLUGINS: Plugin[] = [
       {
         code: '[faltin_anfrage]',
         example: '[faltin_anfrage event="super-bowl-2027" title="Jetzt unverbindlich anfragen"]',
-        title: 'Anfrage-/Kontaktformular',
-        desc: 'Eingebettetes Anfrageformular (serverseitig). Sendet an /api/bookings.',
+        title: 'Anfrage-/Kontaktformular (mit Package-Auto-Logik)',
+        desc: 'Eingebettetes Anfrageformular (serverseitig), sendet an /api/bookings. Ab Plugin 1.5.0: Hat das Event buchbare Packages, werden automatisch die Package-Karten ausgeliefert — bestehende Einbettungen bleiben gültig und upgraden von selbst. packages="0" erzwingt das reine Formular.',
         recommended: true,
         params: [
+          { name: 'packages', def: 'auto', desc: 'auto = Package-Karten zeigen, wenn vorhanden; 0 = immer Formular.' },
           { name: 'event', def: 'allgemeine-anfrage', desc: 'Event-Slug, dem die Anfrage zugeordnet wird.' },
           { name: 'name', def: '(leer)', desc: 'Anzeigename des Events im Formular (sonst = event).' },
           { name: 'title', def: 'Jetzt unverbindlich anfragen', desc: 'Überschrift des Formulars.' },

--- a/src/components/BookingForm.tsx
+++ b/src/components/BookingForm.tsx
@@ -446,7 +446,7 @@ export default function BookingForm() {
         </div>
       </div>
 
-      <div className='container mx-auto px-4 py-8 max-w-6xl'>
+      <div className='container mx-auto px-4 py-8 max-w-[88rem]'>
         <div className='grid lg:grid-cols-3 gap-8'>
           <div className='lg:col-span-2'>
             <div className='bg-white rounded-xl shadow-lg overflow-hidden'>

--- a/wordpress-plugin/faltin-events.php
+++ b/wordpress-plugin/faltin-events.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Faltin Travel – Event Shortcodes
  * Description: SEO-freundliche, serverseitig gerenderte Event-Karten, Package-Karten + natives Anfrageformular. Shortcodes: [faltin_events serie="..."], [faltin_event event="..."], [faltin_packages event="..."], [faltin_anfrage event="..."].
- * Version: 1.4.0
+ * Version: 1.5.0
  * Author: Faltin Travel AG
  *
  * Die Inhalte werden serverseitig per REST-API geladen (wp_remote_get) und als
@@ -13,6 +13,12 @@
  *   [faltin_events serie="darts-wm" limit="6" columns="3"]
  *   [faltin_event event="super-bowl-lxi-2027"]
  *   [faltin_packages event="super-bowl-2027"]  – Package-Karten; ohne Packages → Anfrageformular
+ *
+ * Ab 1.5.0 gilt dieselbe Logik auch für [faltin_anfrage]: hat das Event
+ * buchbare Packages, werden automatisch die Package-Karten ausgeliefert —
+ * bestehende Einbettungen wie [faltin_anfrage event="americas-cup-2024"
+ * name="America's Cup 2024"] bleiben unverändert gültig. Mit packages="0"
+ * lässt sich das reine Formular erzwingen.
  *
  * Optionale Parameter:
  *   api_url   – Basis-URL des Systems (Default: https://next.faltintravel.com)
@@ -282,7 +288,21 @@ function faltin_anfrage_shortcode($atts) {
         'title' => 'Jetzt unverbindlich anfragen',
         'intro' => '',
         'api_url' => FALTIN_EVENTS_DEFAULT_API,
+        'packages' => 'auto', // auto = Package-Karten ausliefern, wenn das Event welche hat; 0/off = immer Formular
+        'cache' => 600,
     ), $atts, 'faltin_anfrage');
+
+    // Wie auf der Faltin-Event-Seite: hat das Event buchbare Packages, zeigen
+    // wir die Karten statt des Formulars — bestehende [faltin_anfrage]-
+    // Einbettungen bleiben so unverändert gültig und "upgraden" automatisch.
+    $want_packages = !in_array(strtolower((string)$atts['packages']), array('0', 'off', 'no', 'false'), true);
+    if ($want_packages && $atts['event'] && $atts['event'] !== 'allgemeine-anfrage') {
+        $pk_url = rtrim($atts['api_url'], '/') . '/api/packages-html?event=' . rawurlencode($atts['event']);
+        $pk = faltin_events_fetch($pk_url, (int)$atts['cache']);
+        if ($pk && !empty($pk['has_packages']) && !empty($pk['html'])) {
+            return $pk['html'];
+        }
+    }
 
     static $instance = 0;
     $instance++;
@@ -451,6 +471,7 @@ function faltin_packages_shortcode($atts) {
         'event' => $atts['event'],
         'name' => $atts['name'] ?: (is_array($data) && !empty($data['event_name']) ? $data['event_name'] : ''),
         'api_url' => $atts['api_url'],
+        'packages' => '0', // Packages wurden hier bereits geprüft — direkt das Formular rendern
     ));
 }
 add_shortcode('faltin_packages', 'faltin_packages_shortcode');


### PR DESCRIPTION
## Was
1. **Buchungsseite breiter**: Container von `max-w-6xl` (1152px) auf `max-w-[88rem]` (1408px) — Formular und Sidebar bekommen spürbar mehr Luft, die Sidebar wirkt nicht mehr gestaucht (Preiszeilen brechen seltener um).
2. **`[faltin_anfrage]` upgraded automatisch** (Plugin 1.5.0): Der bestehende CF-Shortcode prüft jetzt selbst, ob das Event buchbare Packages hat — wenn ja, liefert er die Package-Karten aus, sonst wie bisher das Formular.
   - **Bestehende Einbettungen bleiben 1:1 gültig**: `[faltin_anfrage event="americas-cup-2024" name="America's Cup 2024"]` muss nicht angefasst werden — sobald ihr dem Event Packages gebt, erscheinen dort automatisch die Karten.
   - Opt-out: `packages="0"` erzwingt das reine Formular.
   - `[faltin_packages]` bleibt als expliziter Shortcode bestehen; sein Formular-Fallback übergibt `packages="0"` (kein Doppel-Fetch).

## Verifiziert
`tsc` grün; PHP folgt exakt den bestehenden Plugin-Mustern (Transient-Cache via `faltin_events_fetch`, kein Fetch beim Default-Event `allgemeine-anfrage`).

## Nach dem Merge
`wordpress-plugin/faltin-events.php` (v1.5.0) einmal in der WP-Instanz aktualisieren — danach sind keine WP-Änderungen mehr nötig, auch nicht beim Anlegen neuer Packages.

✅ **PR ist komplett — kann gemerged werden.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)