### PR TITLE
Doku: Auto-Merge-Flow (CI-Pflicht-Check + gh pr merge --auto)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ Laufzeit-Lesen Content: `src/lib/contentStore.ts` (`findPackagesByEvent` etc.).
 
 ## Branch-Flow / Zusammenarbeit
 - `feature/*` oder `fix/*` → Pull Request → **CI muss grün sein** → Merge nach `main` → Prod-Deploy.
+- **Auto-Merge (seit 2026-07-03):** Repo hat `allow_auto_merge` + Branch-Protection auf `main` (Pflicht-Check: CI-Job `verify`, keine Review-Pflicht, Admins ausgenommen). Bei fertigen PRs `gh pr merge --auto --merge` setzen → merged automatisch, sobald CI grün ist.
 - Nicht direkt auf `main` pushen (außer triviale Hotfixes mit Absprache).
 - Offene Stränge im GitHub-Projects-Board pflegen.
 


### PR DESCRIPTION
Dokumentiert den neuen Merge-Prozess in CLAUDE.md. Dieser PR ist zugleich der End-to-End-Test für Auto-Merge: er wurde mit `--auto` markiert und sollte selbstständig mergen, sobald die CI grün ist. 🤖 Generated with [Claude Code](https://claude.com/claude-code)