### PR TITLE
WP: SportsEvent-JSON-LD im [faltin_anfrage]-Formular-Fall (Plugin 1.7.0)

### DIFF
--- a/WORDPRESS-INTEGRATION.md
+++ b/WORDPRESS-INTEGRATION.md
@@ -410,3 +410,11 @@ Die Shortcode-Buchungslinks führen auf `…/booking?…&embed=1&ref=<host>`:
   `Quelle: <host>` in den CRM-Notizen der Buchung und in der
   Team-Benachrichtigungsmail („Eingegangen über: …"). Das native
   Anfrageformular sendet die Quelle ebenfalls mit (`source`-Feld).
+
+### SportsEvent-JSON-LD im Formular-Fall (ab Plugin 1.7.0)
+
+`[faltin_anfrage event="…"]` liefert auch OHNE Packages strukturierte Daten:
+ein `SportsEvent`-JSON-LD (Name, Datum, Venue, Stadt, Bild, Beschreibung) aus
+`/api/events` — gecacht wie die übrigen Shortcodes. Damit spielt jede
+Einbettung SEO/GEO-Signale aus: mit Packages `Product`/`Offer`, ohne Packages
+`SportsEvent`. (`event="allgemeine-anfrage"` bleibt ohne JSON-LD.)

--- a/src/app/admin/shortcodes/page.tsx
+++ b/src/app/admin/shortcodes/page.tsx
@@ -59,7 +59,7 @@ const PLUGINS: Plugin[] = [
         code: '[faltin_anfrage]',
         example: '[faltin_anfrage event="super-bowl-2027" title="Jetzt unverbindlich anfragen"]',
         title: 'Anfrage-/Kontaktformular (mit Package-Auto-Logik)',
-        desc: 'Eingebettetes Anfrageformular (serverseitig), sendet an /api/bookings. Ab Plugin 1.5.0: Hat das Event buchbare Packages, werden automatisch die Package-Karten ausgeliefert — bestehende Einbettungen bleiben gültig und upgraden von selbst. packages="0" erzwingt das reine Formular.',
+        desc: 'Eingebettetes Anfrageformular (serverseitig), sendet an /api/bookings. Ab Plugin 1.5.0: Hat das Event buchbare Packages, werden automatisch die Package-Karten ausgeliefert — bestehende Einbettungen bleiben gültig und upgraden von selbst. packages="0" erzwingt das reine Formular. Ab 1.7.0 liefert auch der Formular-Fall SportsEvent-JSON-LD (SEO/GEO) mit.',
         recommended: true,
         params: [
           { name: 'packages', def: 'auto', desc: 'auto = Package-Karten zeigen, wenn vorhanden; 0 = immer Formular.' },

--- a/wordpress-plugin/faltin-events.php
+++ b/wordpress-plugin/faltin-events.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Faltin Travel – Event Shortcodes
  * Description: SEO-freundliche, serverseitig gerenderte Event-Karten, Package-Karten + natives Anfrageformular. Shortcodes: [faltin_events serie="..."], [faltin_event event="..."], [faltin_packages event="..."], [faltin_anfrage event="..."].
- * Version: 1.6.0
+ * Version: 1.7.0
  * Author: Faltin Travel AG
  *
  * Die Inhalte werden serverseitig per REST-API geladen (wp_remote_get) und als
@@ -428,7 +428,18 @@ function faltin_anfrage_shortcode($atts) {
     })();
     </script>
     <?php
-    return faltin_anfrage_styles() . ob_get_clean();
+    // SEO/GEO: Auch ohne Packages strukturierte Event-Daten ausliefern —
+    // SportsEvent-JSON-LD aus /api/events (gecacht), gleiche LD-Funktion
+    // wie [faltin_events]/[faltin_event]. Formular bleibt unverändert.
+    $jsonld = '';
+    if ($atts['event'] && $atts['event'] !== 'allgemeine-anfrage') {
+        $ev_url = rtrim($atts['api_url'], '/') . '/api/events?event=' . rawurlencode($atts['event']);
+        $ev = faltin_events_fetch($ev_url, (int)$atts['cache']);
+        if (is_array($ev) && !empty($ev['url']) && (!empty($ev['name']) || !empty($ev['title']))) {
+            $jsonld = faltin_events_jsonld(array($ev));
+        }
+    }
+    return $jsonld . faltin_anfrage_styles() . ob_get_clean();
 }
 add_shortcode('faltin_anfrage', 'faltin_anfrage_shortcode');
 


### PR DESCRIPTION
## Was
**SEO/GEO-Lücke geschlossen:** `[faltin_anfrage event="…"]` liefert im reinen Formular-Fall (Event ohne Packages, z. B. America's Cup) jetzt ein **`SportsEvent`-JSON-LD** mit — Name, Start-/Enddatum, Venue, Stadt, Hero-Bild, Beschreibung. Datenquelle ist `/api/events` (gecacht via Transient), gerendert mit der vorhandenen LD-Funktion der Event-Shortcodes.

Damit spielt **jede** WP-Einbettung strukturierte Daten aus:

| Zustand | Content | JSON-LD |
|---|---|---|
| Packages vorhanden | Karten | `Product`/`Offer` |
| Keine Packages | Formular | `SportsEvent` (neu) |

`event="allgemeine-anfrage"` (Default) bleibt bewusst ohne LD. Plugin → **1.7.0**.

## Verifiziert
`tsc` grün; Struktur-Checks der PHP-Funktion 4/4 (Packages-Check zuerst, LD vor Return, kein LD beim Default-Event, Klammern balanciert); `/api/events?event=…` liefert live alle benötigten Felder.

## Nach dem Merge
`wordpress-plugin/faltin-events.php` (v1.7.0) einmal in WP aktualisieren — der LD-Teil ist reiner Plugin-Code.

✅ PR ist komplett — Auto-Merge ist gesetzt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
