### PR TITLE
CRM-Fixes: Buchungs-Slugs gespeichert (Reisezeitraum!), Anrede, breite Sidebar

### DIFF
--- a/src/app/admin/crm/page.tsx
+++ b/src/app/admin/crm/page.tsx
@@ -545,7 +545,7 @@ function DetailDrawer({
   return (
     <div className="fixed inset-0 z-50 flex justify-end" style={{ background: 'rgba(20,48,71,0.4)' }} onClick={onClose}>
       <div
-        className="h-full w-full max-w-lg bg-white shadow-2xl overflow-y-auto flex flex-col"
+        className="h-full w-full max-w-3xl bg-white shadow-2xl overflow-y-auto flex flex-col"
         onClick={e => e.stopPropagation()}
       >
         {/* Header */}

--- a/src/app/api/bookings/route.ts
+++ b/src/app/api/bookings/route.ts
@@ -8,7 +8,7 @@ import {
   internalNotificationHtml, internalNotificationSubject,
   autoReplyHtml, autoReplySubjectDefault, subjectTag,
 } from '@/lib/emailTemplates';
-import { linkBookingToCustomer } from '@/lib/customerStore';
+import { linkBookingToCustomer, normalizeSalutation } from '@/lib/customerStore';
 import { readAutoReplyPdfBase64 } from '@/lib/autoReplyStore';
 
 /**
@@ -59,7 +59,7 @@ export async function POST(request: Request) {
     // Hauptbucher/Kontakt hat Vorrang vor erstem Reisenden.
     const firstName = body.firstName || firstTraveler?.firstName || firstTraveler?.first_name || body.email.split('@')[0];
     const lastName = body.lastName || firstTraveler?.lastName || firstTraveler?.last_name || '';
-    const salutation = body.salutation || firstTraveler?.salutation || '';
+    const salutation = normalizeSalutation(body.salutation || firstTraveler?.salutation || '');
 
     // Kunde herleiten/verknüpfen (E-Mail = eindeutige ID)
     try {

--- a/src/app/api/invoices/[id]/pdf/route.ts
+++ b/src/app/api/invoices/[id]/pdf/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getInvoiceById, getInvoiceItems, getBookingById } from '@/lib/database';
-import { findEventBySlug, findPackagesByEvent } from '@/lib/contentStore';
-import { getCustomer } from '@/lib/customerStore';
+import { findEventBySlug, findPackagesByEvent, getPackages, getEvents } from '@/lib/contentStore';
+import { getCustomer, normalizeSalutation } from '@/lib/customerStore';
 import { getSettings } from '@/lib/settingsStore';
 import { jsPDF } from 'jspdf';
 import fs from 'fs';
@@ -56,9 +56,18 @@ export async function GET(
     } catch { /* ignore parse errors */ }
 
     // Try to find the real event from booking's event_slug
-    const eventRecord = booking.event_slug ? findEventBySlug(booking.event_slug) : null;
+    let eventRecord = booking.event_slug ? findEventBySlug(booking.event_slug) : null;
     const eventPackages = eventRecord ? findPackagesByEvent(eventRecord.id) : [];
-    const bookedPackage = eventPackages.find((p: any) => p.slug === booking.package_slug || p.title === booking.package_title);
+    let bookedPackage = eventPackages.find((p: any) => p.slug === booking.package_slug || p.title === booking.package_title);
+    // Fallback für Bestandsbuchungen ohne gespeicherte Slugs: Package über
+    // Slug/Titel global suchen, Event über dessen event_id herleiten.
+    if (!bookedPackage) {
+      bookedPackage = (getPackages() as any[]).find((p: any) =>
+        (booking.package_slug && p.slug === booking.package_slug) || p.title === booking.package_title);
+      if (bookedPackage && !eventRecord) {
+        eventRecord = (getEvents() as any[]).find((e: any) => e.id === (bookedPackage as any).event_id) || null;
+      }
+    }
 
     // Build event display strings — noteMeta (admin edits) wins over auto-lookup
     const eventName = noteMeta.event_name ||
@@ -184,7 +193,7 @@ export async function GET(
     const traveler = booking.travelers[0];
     const recipientName = (customer?.name || [customer?.first_name, customer?.last_name].filter(Boolean).join(' ').trim())
       || `${traveler.firstName} ${traveler.lastName}`.trim();
-    const recipientLine1 = [customer?.salutation, recipientName].filter(Boolean).join(' ');
+    const recipientLine1 = [normalizeSalutation(customer?.salutation), recipientName].filter(Boolean).join(' ');
     doc.text(recipientLine1, leftMargin, currentY);
     currentY += 4;
     if (customer?.street) { doc.text(customer.street, leftMargin, currentY); currentY += 4; }

--- a/src/app/api/invoices/prefill/route.ts
+++ b/src/app/api/invoices/prefill/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getBooking } from '@/lib/bookingStore';
 import { getCustomer } from '@/lib/customerStore';
-import { findEventBySlug, findPackagesByEvent, type ContentPackageRecord } from '@/lib/contentStore';
+import { findEventBySlug, findPackagesByEvent, getPackages, getEvents, type ContentPackageRecord } from '@/lib/contentStore';
 
 /**
  * Rechnungs-Vorbefüllung aus einer Buchungsanfrage: lädt Buchung + Package +
@@ -30,9 +30,19 @@ export async function GET(request: Request) {
     return NextResponse.json({ success: false, error: 'Buchung nicht gefunden' }, { status: 404 });
   }
 
-  const event = booking.event_slug ? findEventBySlug(booking.event_slug) : null;
+  let event = booking.event_slug ? findEventBySlug(booking.event_slug) : null;
   const eventPackages = (event ? findPackagesByEvent(event.id) : []) as ContentPackageRecord[];
-  const pkg = eventPackages.find((p) => p.slug === booking.package_slug || p.title === booking.package_title) || null;
+  let pkg = eventPackages.find((p) => p.slug === booking.package_slug || p.title === booking.package_title) || null;
+  // Fallback für Bestandsbuchungen ohne gespeicherte Slugs (Titel-Match global)
+  if (!pkg) {
+    pkg = (getPackages() as ContentPackageRecord[]).find((p) =>
+      (booking.package_slug && p.slug === booking.package_slug) || p.title === booking.package_title) || null;
+    if (pkg && !event) {
+      const found = (getEvents() as Array<NonNullable<ReturnType<typeof findEventBySlug>>>)
+        .find((e) => e.id === (pkg as ContentPackageRecord & { event_id?: string }).event_id);
+      if (found) event = found;
+    }
+  }
 
   const persons = Number(booking.number_of_persons || 0) || Math.max(1, Number(booking.double_rooms || 0) * 2 + Number(booking.single_rooms || 0));
   const singles = Number(booking.single_rooms || 0);

--- a/src/lib/bookingStore.ts
+++ b/src/lib/bookingStore.ts
@@ -52,6 +52,8 @@ export interface BookingInput {
 export async function createBooking(input: BookingInput) {
   if (!isSupabaseConfigured() || !supabase) {
     return insertBooking({
+      event_slug: input.eventSlug || '',
+      package_slug: input.packageSlug || '',
       package_id: input.packageId,
       package_title: input.packageTitle,
       start_date: input.startDate,

--- a/src/lib/customerStore.ts
+++ b/src/lib/customerStore.ts
@@ -60,6 +60,16 @@ export async function findCustomerIdByEmail(email: string): Promise<string | nul
 }
 
 /** Legt einen Kunden zur E-Mail an oder liefert den bestehenden. */
+/** Anrede vereinheitlichen: "herr"/"mr." → "Herr", "frau"/"mrs" → "Frau", sonst kapitalisiert. */
+export function normalizeSalutation(raw?: string | null): string {
+  const s = String(raw || '').trim();
+  if (!s) return '';
+  const l = s.toLowerCase();
+  if (l.startsWith('herr') || l === 'mr' || l === 'mr.') return 'Herr';
+  if (l.startsWith('frau') || l === 'mrs' || l === 'mrs.' || l === 'ms' || l === 'ms.') return 'Frau';
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
 export async function upsertCustomerByEmail(
   email: string,
   data?: { name?: string; firstName?: string; lastName?: string; phone?: string; salutation?: string;
@@ -82,7 +92,7 @@ export async function upsertCustomerByEmail(
         `SELECT salutation, first_name, last_name, name, phone, street, zip, city, country FROM customers WHERE id = ?`, [existingId]
       );
       if (cur) {
-        const salutation = cur.salutation?.trim() ? cur.salutation : data?.salutation || '';
+        const salutation = cur.salutation?.trim() ? normalizeSalutation(cur.salutation) : normalizeSalutation(data?.salutation);
         const first_name = cur.first_name?.trim() ? cur.first_name : inFirst;
         const last_name = cur.last_name?.trim() ? cur.last_name : inLast;
         const name = cur.name?.trim() ? cur.name : (joinName(first_name, last_name) || inName);
@@ -104,7 +114,7 @@ export async function upsertCustomerByEmail(
   const id = crypto.randomUUID();
   await dbRun(
     `INSERT INTO customers (id, salutation, first_name, last_name, name, phone, street, zip, city, country) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    [id, data?.salutation || '', inFirst, inLast, inName, data?.phone || '', data?.street || '', data?.zip || '', data?.city || '', data?.country || '']
+    [id, normalizeSalutation(data?.salutation), inFirst, inLast, inName, data?.phone || '', data?.street || '', data?.zip || '', data?.city || '', data?.country || '']
   );
   await dbRun(`INSERT INTO customer_emails (email, customer_id, is_primary) VALUES (?, ?, 1)`, [e, id]);
   return id;

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -44,6 +44,8 @@ export function initDatabase() {
       updated_at TEXT NOT NULL DEFAULT (datetime('now')),
       request_number TEXT,
       booking_number TEXT,
+      event_slug TEXT DEFAULT '',
+      package_slug TEXT DEFAULT '',
       package_id TEXT NOT NULL,
       package_title TEXT NOT NULL,
       start_date TEXT NOT NULL,
@@ -412,6 +414,8 @@ export function initDatabase() {
   if (!cols.some((c) => c.name === 'offer_sent')) addColumn('booking_requests', 'offer_sent INTEGER NOT NULL DEFAULT 0');
   if (!cols.some((c) => c.name === 'docs_ready')) addColumn('booking_requests', 'docs_ready INTEGER NOT NULL DEFAULT 0');
   if (!cols.some((c) => c.name === 'source')) addColumn('booking_requests', "source TEXT DEFAULT ''");
+  if (!cols.some((c) => c.name === 'event_slug')) addColumn('booking_requests', "event_slug TEXT DEFAULT ''");
+  if (!cols.some((c) => c.name === 'package_slug')) addColumn('booking_requests', "package_slug TEXT DEFAULT ''");
   const icols = sqlite.prepare(`PRAGMA table_info(incentive_plans)`).all() as Array<{ name: string }>;
   if (icols.length && !icols.some((c) => c.name === 'error')) addColumn('incentive_plans', "error TEXT NOT NULL DEFAULT ''");
   if (icols.length && !icols.some((c) => c.name === 'progress')) addColumn('incentive_plans', "progress TEXT NOT NULL DEFAULT ''");
@@ -488,12 +492,14 @@ export async function insertBooking(booking: Omit<BookingRequest, 'id' | 'create
 
   await dbRun(
     `INSERT INTO booking_requests (
-      id, created_at, updated_at, request_number, package_id, package_title, start_date,
+      id, created_at, updated_at, request_number, event_slug, package_slug, package_id, package_title, start_date,
       number_of_persons, double_rooms, single_rooms, travelers,
       email, phone, message, status, total_price, notes, source
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     [
       id, now, now, requestNumber,
+      (booking as { event_slug?: string }).event_slug || '',
+      (booking as { package_slug?: string }).package_slug || '',
       booking.package_id, booking.package_title, booking.start_date,
       booking.number_of_persons, booking.double_rooms, booking.single_rooms,
       booking.travelers, booking.email, booking.phone, booking.message,

--- a/src/lib/dbq.ts
+++ b/src/lib/dbq.ts
@@ -197,6 +197,8 @@ export async function applyPgSchemaEnhancements(): Promise<void> {
     try { await pool.query(`ALTER TABLE booking_requests ADD COLUMN IF NOT EXISTS docs_ready integer NOT NULL DEFAULT 0`); } catch { /* ignore */ }
     try { await pool.query(`ALTER TABLE booking_requests ADD COLUMN IF NOT EXISTS booking_number text`); } catch { /* ignore */ }
     try { await pool.query(`ALTER TABLE booking_requests ADD COLUMN IF NOT EXISTS source text DEFAULT ''`); } catch { /* ignore */ }
+    try { await pool.query(`ALTER TABLE booking_requests ADD COLUMN IF NOT EXISTS event_slug text DEFAULT ''`); } catch { /* ignore */ }
+    try { await pool.query(`ALTER TABLE booking_requests ADD COLUMN IF NOT EXISTS package_slug text DEFAULT ''`); } catch { /* ignore */ }
     try { await pool.query(`INSERT INTO counters (name, value) SELECT 'booking_number', 1000 WHERE NOT EXISTS (SELECT 1 FROM counters WHERE name = 'booking_number')`); } catch { /* ignore */ }
 
     // Kundenportal-Tabellen (in PG zusätzlich anlegen – Migration introspektiert nur Bestandstabellen).


### PR DESCRIPTION
## Was
Drei Fixes aus dem Live-Test der Rechnungsstrecke:

### 1. Reisezeitraum (Root Cause gefunden)
Die Buchung hat `event_slug`/`package_slug` **nie gespeichert** — die Spalten existierten in `booking_requests` gar nicht. Deshalb fanden Rechnungs-PDF und Editor-Prefill das Package nicht: Reisetermin fiel aufs heutige Datum zurück, Positionen auf die Pauschale, das CRM zeigte „EVENT n/a".
- Neue Spalten mit idempotenten Migrationen (SQLite + Postgres, laufen beim App-Start)
- **Fallback für alle Bestandsbuchungen**: Package wird global über Slug/Titel gefunden, Event über dessen `event_id` hergeleitet — auch deine bisherigen Testanfragen zeigen damit sofort den korrekten Reisezeitraum („Do. 11.02. – Mo. 15.02.2027") und die echten Leistungen

### 2. Anrede groß
`normalizeSalutation`: „herr" → **Herr**, „mrs" → **Frau**, sonst kapitalisiert — beim Speichern in den Kundenstamm, in der Buchungs-API und im PDF-Empfängerblock (wirkt damit auch für Bestandskunden mit klein gespeicherter Anrede).

### 3. CRM-Sidebar breiter
Detail-Sidebar von 512px auf **768px** (`max-w-3xl`) — kein Querscrollen mehr.

## Verifiziert
SQLite-Migration + 20-Spalten-Insert gegen echte DB (PASS), `normalizeSalutation` 6/6, `tsc` grün.

✅ **PR ist komplett — Auto-Merge gesetzt.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
