### PR TITLE
Foto-Lightbox (WP + Buchungsseite), Mobile-Overflow-Fix, Weiter-zur-Buchung-CTA

### DIFF
--- a/src/app/api/packages-html/route.ts
+++ b/src/app/api/packages-html/route.ts
@@ -104,8 +104,9 @@ function renderCard(pkg: PackageRecord, base: string, eventSlug: string, linkSuf
   const price = Number(pkg.price || 0);
   const bookingUrl = `${base}/booking?event=${encodeURIComponent(eventSlug)}&package=${encodeURIComponent(pkg.slug || pkg.id)}&persons=2${linkSuffix}`;
 
+  const galleryAttr = `data-ftpk-gallery="${esc(JSON.stringify(images))}" data-ftpk-title="${esc(pkg.hotel || pkg.title || '')}"`;
   const media = images.length
-    ? `<div class="ftpk-media${soldOut ? ' ftpk-media--so' : ''}">
+    ? `<div class="ftpk-media${soldOut ? ' ftpk-media--so' : ''}" ${galleryAttr} style="cursor:pointer" title="Fotos ansehen">
         <img src="${esc(images[0])}" alt="${esc(pkg.hotel || pkg.title || '')}" loading="lazy" style="${S.img}" />
         <div class="ftpk-shade"></div>
         <div class="ftpk-badges">
@@ -118,7 +119,7 @@ function renderCard(pkg: PackageRecord, base: string, eventSlug: string, linkSuf
             ${pkg.hotel ? `<span style="${S.hotelName}">${esc(pkg.hotel)}</span>` : ''}
             ${stars ? `<span style="${S.stars}">${'★'.repeat(stars)}</span>` : ''}
           </span>
-          ${images.length > 1 ? `<span style="${S.fotos}">📷 ${images.length} Fotos</span>` : ''}
+          ${images.length > 1 ? `<span style="${S.fotos};cursor:pointer">📷 ${images.length} Fotos</span>` : ''}
         </div>
       </div>`
     : '';
@@ -130,7 +131,7 @@ function renderCard(pkg: PackageRecord, base: string, eventSlug: string, linkSuf
 
   const cta = soldOut
     ? `<span style="${S.ctaSo}">Ausgebucht</span>`
-    : `<a class="ftpk-cta" href="${esc(bookingUrl)}" style="${popular ? S.ctaPop : S.cta}">Unverbindlich anfragen →</a>`;
+    : `<a class="ftpk-cta" href="${esc(bookingUrl)}" style="${popular ? S.ctaPop : S.cta}">Weiter zur Buchung →</a>`;
 
   /* Bewusst div/span statt h3/p/ul: Theme-Selektoren auf Überschriften,
      Absätze und Listen können hier gar nicht erst greifen. */
@@ -225,9 +226,46 @@ export async function GET(request: Request) {
 
   const jsonLd = { '@context': 'https://schema.org', '@graph': [sportsEventLd, itemListLd] };
 
+  const LIGHTBOX = `<script>(function(){
+if(window.__ftpkLB)return;window.__ftpkLB=1;
+var imgs=[],idx=0,ov=null,im=null,ct=null,tt=null;
+function stop(fn){return function(e){e.stopPropagation();fn(e);};}
+function build(){
+  ov=document.createElement('div');
+  ov.style.cssText='position:fixed;inset:0;z-index:2147483000;background:rgba(10,22,34,.93);display:flex;align-items:center;justify-content:center;flex-direction:column;padding:24px;box-sizing:border-box';
+  im=document.createElement('img');
+  im.style.cssText='max-width:92vw;max-height:78vh;object-fit:contain;border-radius:12px;box-shadow:0 20px 60px rgba(0,0,0,.5)';
+  tt=document.createElement('div');
+  tt.style.cssText='color:#fff;font:700 15px -apple-system,Segoe UI,Roboto,sans-serif;margin:14px 0 2px;text-align:center';
+  ct=document.createElement('div');
+  ct.style.cssText='color:rgba(255,255,255,.7);font:400 13px -apple-system,Segoe UI,Roboto,sans-serif';
+  var x=btn('\u00d7','position:absolute;top:14px;right:18px;font-size:30px;line-height:1');x.onclick=stop(close);
+  var pv=btn('\u2039','position:absolute;left:10px;top:50%;transform:translateY(-50%);font-size:34px');pv.onclick=stop(function(){go(-1);});
+  var nx=btn('\u203a','position:absolute;right:10px;top:50%;transform:translateY(-50%);font-size:34px');nx.onclick=stop(function(){go(1);});
+  ov.appendChild(im);ov.appendChild(tt);ov.appendChild(ct);ov.appendChild(x);ov.appendChild(pv);ov.appendChild(nx);
+  ov.onclick=close;im.onclick=stop(function(){go(1);});
+  document.body.appendChild(ov);
+  document.addEventListener('keydown',key);
+}
+function btn(txt,extra){var b=document.createElement('button');b.textContent=txt;
+  b.style.cssText='background:rgba(255,255,255,.14);color:#fff;border:0;border-radius:999px;width:46px;height:46px;cursor:pointer;font-family:inherit;'+extra;return b;}
+function key(e){if(!ov)return;if(e.key==='Escape')close();if(e.key==='ArrowRight')go(1);if(e.key==='ArrowLeft')go(-1);}
+function show(){im.src=imgs[idx];ct.textContent=(idx+1)+' / '+imgs.length;}
+function go(d){idx=(idx+d+imgs.length)%imgs.length;show();}
+function close(){if(ov){document.removeEventListener('keydown',key);ov.remove();ov=null;}}
+document.addEventListener('click',function(e){
+  var t=e.target&&e.target.closest?e.target.closest('[data-ftpk-gallery]'):null;
+  if(!t)return;e.preventDefault();e.stopPropagation();
+  try{imgs=JSON.parse(t.getAttribute('data-ftpk-gallery'))||[];}catch(err){return;}
+  if(!imgs.length)return;idx=0;
+  if(!ov)build();tt.textContent=t.getAttribute('data-ftpk-title')||'';show();
+});
+})();</script>`;
+
   const html =
     STYLE +
-    `<div class="ftpk-grid" data-ftv="1.6.2">${packages.map((p) => renderCard(p, base, eventSlug, linkSuffix)).join('')}</div>` +
+    `<div class="ftpk-grid" data-ftv="1.6.3">${packages.map((p) => renderCard(p, base, eventSlug, linkSuffix)).join('')}</div>` +
+    LIGHTBOX +
     `<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>`;
 
   return NextResponse.json({

--- a/src/components/BookingForm.tsx
+++ b/src/components/BookingForm.tsx
@@ -158,6 +158,7 @@ export default function BookingForm() {
   const [isMounted, setIsMounted] = useState(false); // Fix hydration error for dynamic widgets
   const [isSoldOut, setIsSoldOut] = useState(false); // Kontingent 0 → Anfrage gesperrt
   const [refSource, setRefSource] = useState(''); // Affiliate: Host der einbettenden Website (?ref=)
+  const [lightboxIdx, setLightboxIdx] = useState<number | null>(null); // Foto-Lightbox (alle Hotelbilder)
   
   const phoneCountries = [
     { code: 'ch', prefix: '+41', name: 'CH' },
@@ -185,6 +186,19 @@ export default function BookingForm() {
   const watchDoubleRooms = watch('doubleRooms');
   const watchSingleRooms = watch('singleRooms');
   const watchNumberOfPersons = watch('numberOfPersons');
+
+  // Lightbox: ESC schließt, Pfeiltasten blättern
+  useEffect(() => {
+    if (lightboxIdx === null) return;
+    const count = selectedPackage.hotelImages.length;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setLightboxIdx(null);
+      if (e.key === 'ArrowRight') setLightboxIdx((i) => (i === null ? i : (i + 1) % count));
+      if (e.key === 'ArrowLeft') setLightboxIdx((i) => (i === null ? i : (i - 1 + count) % count));
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [lightboxIdx, selectedPackage.hotelImages.length]);
 
   useEffect(() => {
     const eventParam = searchParams.get('event') || '';
@@ -431,7 +445,47 @@ export default function BookingForm() {
   };
 
   return (
-    <div className='min-h-screen bg-gray-50'>
+    <div className='min-h-screen bg-gray-50 overflow-x-clip'>
+      {/* Foto-Lightbox: alle Hotelbilder mit Blättern (Klick, Pfeile, ESC) */}
+      {lightboxIdx !== null && selectedPackage.hotelImages.length > 0 && (
+        <div
+          className='fixed inset-0 z-[100] flex flex-col items-center justify-center p-6'
+          style={{ background: 'rgba(10,22,34,0.93)' }}
+          onClick={() => setLightboxIdx(null)}
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={selectedPackage.hotelImages[Math.min(lightboxIdx, selectedPackage.hotelImages.length - 1)]}
+            alt={selectedPackage.hotel}
+            className='max-h-[78vh] max-w-[92vw] rounded-xl object-contain shadow-2xl'
+            onClick={(e) => { e.stopPropagation(); setLightboxIdx((lightboxIdx + 1) % selectedPackage.hotelImages.length); }}
+          />
+          <div className='mt-3 text-sm font-bold text-white'>{selectedPackage.hotel}</div>
+          <div className='mt-0.5 text-xs text-white/70'>{lightboxIdx + 1} / {selectedPackage.hotelImages.length}</div>
+          <button
+            type='button'
+            aria-label='Schließen'
+            className='absolute right-4 top-4 flex h-11 w-11 items-center justify-center rounded-full bg-white/15 text-3xl leading-none text-white'
+            onClick={(e) => { e.stopPropagation(); setLightboxIdx(null); }}
+          >×</button>
+          {selectedPackage.hotelImages.length > 1 && (
+            <>
+              <button
+                type='button'
+                aria-label='Vorheriges Foto'
+                className='absolute left-3 top-1/2 flex h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full bg-white/15 text-3xl leading-none text-white'
+                onClick={(e) => { e.stopPropagation(); setLightboxIdx((lightboxIdx - 1 + selectedPackage.hotelImages.length) % selectedPackage.hotelImages.length); }}
+              >‹</button>
+              <button
+                type='button'
+                aria-label='Nächstes Foto'
+                className='absolute right-3 top-1/2 flex h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full bg-white/15 text-3xl leading-none text-white'
+                onClick={(e) => { e.stopPropagation(); setLightboxIdx((lightboxIdx + 1) % selectedPackage.hotelImages.length); }}
+              >›</button>
+            </>
+          )}
+        </div>
+      )}
       {/* Back Button: führt dahin zurück, wo der User herkam (auch externe Seiten); Fallback: Event-Seite */}
       <div className='bg-linear-to-r from-orange-500 to-orange-600 shadow-md'>
         <div className='container mx-auto px-4 py-3'>
@@ -459,7 +513,7 @@ export default function BookingForm() {
             <div className='bg-white rounded-xl shadow-lg overflow-hidden'>
               {/* ── Hotel-Galerie: feste Bildboxen (absolute imgs — können nicht ausbrechen) ── */}
               {selectedPackage.hotelImages.length > 0 && (
-                <div className='relative grid grid-cols-3 gap-1 h-52 md:h-64 overflow-hidden'>
+                <div className='relative grid w-full min-w-0 cursor-pointer grid-cols-3 gap-1 h-52 md:h-64 overflow-hidden' onClick={() => setLightboxIdx(0)} title='Alle Fotos ansehen'>
                   <div className={`relative overflow-hidden ${selectedPackage.hotelImages.length > 1 ? 'col-span-2' : 'col-span-3'}`}>
                     {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
@@ -471,7 +525,7 @@ export default function BookingForm() {
                   {selectedPackage.hotelImages.length > 1 && (
                     <div className='grid grid-rows-2 gap-1 min-h-0'>
                       {selectedPackage.hotelImages.slice(1, 3).map((src, i) => (
-                        <div key={i} className='relative overflow-hidden min-h-0'>
+                        <div key={i} className='relative overflow-hidden min-h-0 min-w-0' onClick={(e) => { e.stopPropagation(); setLightboxIdx(i + 1); }}>
                           {/* eslint-disable-next-line @next/next/no-img-element */}
                           <img src={src} alt='' className='absolute inset-0 h-full w-full object-cover' />
                         </div>
@@ -963,7 +1017,7 @@ export default function BookingForm() {
               <div className='space-y-4 mb-6'>
                 {/* Hotel-Miniatur */}
                 {selectedPackage.hotelImages[0] && (
-                  <div className='relative h-28 overflow-hidden rounded-lg'>
+                  <div className='relative h-28 cursor-pointer overflow-hidden rounded-lg' onClick={() => setLightboxIdx(0)} title='Alle Fotos ansehen'>
                     {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img src={selectedPackage.hotelImages[0]} alt={selectedPackage.hotel} className='h-full w-full object-cover' />
                     <div className='absolute inset-x-0 bottom-0 h-12 bg-linear-to-t from-black/55 to-transparent' />


### PR DESCRIPTION
## Was
1. **Foto-Lightbox überall**: Klick auf ein Hotelfoto zeigt **alle** Fotos mit Blättern (Klick, Pfeiltasten, ESC/Backdrop schließt):
   - WP-Package-Karten: selbstenthaltene Vanilla-JS-Lightbox im Endpoint-HTML (kein Framework, idempotent, theme-neutral) — Kartenbild + „📷 N Fotos"-Chip sind klickbar
   - Buchungsseite: React-Lightbox — Galerie, Thumbnails und Sidebar-Miniatur öffnen sie
2. **Mobile-Layout-Fix Buchungsseite**: Das horizontale Wischen kam aus dem Galerie-Bereich — gefixt via `overflow-x-clip` am Seiten-Wrapper (bewusst `clip` statt `hidden`, damit die sticky Sidebar funktionsfähig bleibt) plus `min-w-0` an den Galerie-Zellen.
3. **WP-Karten-CTA**: „Unverbindlich anfragen" → **„Weiter zur Buchung"** (`data-ftv` 1.6.3).

## Verifiziert
Renderer offline getestet (7/7: Galerie-Daten JSON-escaped im Attribut, Klickbarkeit, CTA-Text, Lightbox-Einbindung + Idempotenz-Guard); `tsc` grün.

## Nach dem Merge
Kein Plugin-Update nötig — HTML/JS kommt komplett vom Endpoint (WP-Transient-Cache max. 10 min, zum Sofort-Test `cache="0"`).

✅ **PR ist komplett — Auto-Merge gesetzt.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
