### PR TITLE
FT Arcade: /games mit Space Shooter und Hospitality Hunt

### DIFF
--- a/public/games/targets/README.md
+++ b/public/games/targets/README.md
@@ -1,0 +1,8 @@
+# Hospitality-Hunt-Ziele
+
+Freigestellte PNGs (transparenter Hintergrund, Hochformat, ~300–600px hoch)
+hier ablegen als:
+
+  target-1.png … target-7.png
+
+Fehlende Dateien werden im Spiel automatisch durch Emoji-Figuren ersetzt.

--- a/src/app/games/hostess/page.tsx
+++ b/src/app/games/hostess/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+import HostessGame from '@/components/games/HostessGame';
+
+export const metadata: Metadata = {
+  title: 'Hospitality Hunt | FT Arcade',
+  robots: { index: false, follow: false },
+};
+
+export default function HostessGamePage() {
+  return <HostessGame />;
+}

--- a/src/app/games/page.tsx
+++ b/src/app/games/page.tsx
@@ -1,0 +1,68 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'FT Arcade | Faltin Travel',
+  robots: { index: false, follow: false },
+};
+
+const NAVY = '#143047';
+const ORANGE = '#d9531e';
+
+const GAMES = [
+  {
+    href: '/games/space',
+    emoji: '🚀',
+    title: 'Faltin One',
+    subtitle: 'Space Shooter',
+    desc: 'Steuere den FT-Raumgleiter durchs Event-Universum und schieße entgegenfliegende Footballs, Pokale und Koffer ab, bevor sie dich erwischen.',
+    controls: 'Pfeiltasten/WASD oder Maus · Leertaste/Klick schießt',
+  },
+  {
+    href: '/games/hostess',
+    emoji: '🎯',
+    title: 'Hospitality Hunt',
+    subtitle: 'Moorhuhn-Style',
+    desc: 'Das Promo-Team poppt überall im Stadion auf — triff so viele wie möglich in 60 Sekunden. Keine Sorge: Sie kommen alle wieder.',
+    controls: 'Zielen & klicken (oder tippen)',
+  },
+];
+
+export default function GamesPage() {
+  return (
+    <div className="min-h-screen px-4 py-14" style={{ background: `radial-gradient(1200px 600px at 50% -10%, #1d4468 0%, ${NAVY} 55%, #0c2138 100%)` }}>
+      <div className="mx-auto max-w-4xl">
+        <p className="text-center text-xs font-bold uppercase tracking-[0.3em]" style={{ color: ORANGE }}>Inoffiziell · Feierabend-Modus</p>
+        <h1 className="mt-2 text-center text-4xl font-black text-white md:text-5xl">
+          FT <span style={{ color: ORANGE }}>Arcade</span>
+        </h1>
+        <p className="mx-auto mt-3 max-w-xl text-center text-sm leading-relaxed text-white/60">
+          Zwei Minuten Pause zwischen zwei Buchungsanfragen? Highscores werden lokal gespeichert — der Flurfunk regelt den Rest.
+        </p>
+
+        <div className="mt-10 grid gap-6 md:grid-cols-2">
+          {GAMES.map((g) => (
+            <Link
+              key={g.href}
+              href={g.href}
+              className="group rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur transition-all hover:-translate-y-1 hover:border-white/25 hover:bg-white/10"
+            >
+              <div className="text-5xl transition-transform group-hover:scale-110">{g.emoji}</div>
+              <div className="mt-3 text-xs font-bold uppercase tracking-widest" style={{ color: ORANGE }}>{g.subtitle}</div>
+              <div className="mt-1 text-2xl font-extrabold text-white">{g.title}</div>
+              <p className="mt-2 text-sm leading-relaxed text-white/60">{g.desc}</p>
+              <p className="mt-4 text-[11px] font-semibold uppercase tracking-wide text-white/40">{g.controls}</p>
+              <div className="mt-4 inline-flex items-center gap-1.5 rounded-lg px-4 py-2 text-sm font-bold text-white" style={{ background: ORANGE }}>
+                Spielen →
+              </div>
+            </Link>
+          ))}
+        </div>
+
+        <p className="mt-10 text-center text-[11px] text-white/30">
+          Faltin Travel AG · streng geheime Abteilung für Produktivitätsforschung
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/games/space/page.tsx
+++ b/src/app/games/space/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+import SpaceGame from '@/components/games/SpaceGame';
+
+export const metadata: Metadata = {
+  title: 'Faltin One – Space Shooter | FT Arcade',
+  robots: { index: false, follow: false },
+};
+
+export default function SpaceGamePage() {
+  return <SpaceGame />;
+}

--- a/src/components/FooterWrapper.tsx
+++ b/src/components/FooterWrapper.tsx
@@ -4,7 +4,7 @@ import { Suspense } from 'react';
 import { usePathname, useSearchParams } from 'next/navigation';
 import Footer from './Footer';
 
-const EXCLUDED_PREFIXES = ['/admin', '/embed', '/wordpress-preview', '/shortcode-test', '/tippspiel'];
+const EXCLUDED_PREFIXES = ['/admin', '/embed', '/wordpress-preview', '/shortcode-test', '/tippspiel', '/games'];
 
 /** Buchungsseite im Embed-Modus (?embed=1): ohne Site-Footer (reiner Funnel). */
 function BookingFooterGate() {

--- a/src/components/NavBarWrapper.tsx
+++ b/src/components/NavBarWrapper.tsx
@@ -4,7 +4,7 @@ import { Suspense } from 'react';
 import { usePathname, useSearchParams } from 'next/navigation';
 import NavBar, { type NavItem } from './NavBar';
 
-const EXCLUDED_PREFIXES = ['/admin', '/embed', '/wordpress-preview', '/shortcode-test', '/tippspiel'];
+const EXCLUDED_PREFIXES = ['/admin', '/embed', '/wordpress-preview', '/shortcode-test', '/tippspiel', '/games'];
 
 /**
  * Buchungsseite im Embed-Modus (?embed=1, gesetzt von den WordPress-

--- a/src/components/games/HostessGame.tsx
+++ b/src/components/games/HostessGame.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+/**
+ * Hospitality Hunt – Moorhuhn-Style im Stadion.
+ * Ziele poppen zufällig auf, ein Klick/Tap "erwischt" sie (Comic-Pop +
+ * Punkte), danach respawnen sie an anderer Stelle — sie kommen also immer
+ * wieder. 60-Sekunden-Runden, Combo-Bonus, Highscore in localStorage.
+ *
+ * Eigene Gesichter/Figuren: freigestellte PNGs unter
+ *   public/games/targets/target-1.png … target-7.png
+ * ablegen (transparenter Hintergrund, Hochformat). Fehlt ein Bild,
+ * springt automatisch ein Emoji-Ersatz ein.
+ */
+import { useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
+
+const NAVY = '#143047';
+const ORANGE = '#d9531e';
+const ROUND_SECONDS = 60;
+const TARGET_COUNT = 7;
+const FALLBACK = ['💁‍♀️', '🙋‍♀️', '💃', '🙆‍♀️', '🤷‍♀️', '🕺', '🤵'];
+
+interface Target {
+  id: number;
+  x: number;      // Prozent
+  y: number;      // Prozent
+  visible: boolean;
+  popping: boolean;
+  spriteOk: boolean;
+  scale: number;
+  flip: boolean;
+}
+
+export default function HostessGame() {
+  const [targets, setTargets] = useState<Target[]>([]);
+  const [score, setScore] = useState(0);
+  const [combo, setCombo] = useState(0);
+  const [timeLeft, setTimeLeft] = useState(ROUND_SECONDS);
+  const [running, setRunning] = useState(false);
+  const [gameOver, setGameOver] = useState(false);
+  const [highscore, setHighscore] = useState(0);
+  const [floaters, setFloaters] = useState<Array<{ id: number; x: number; y: number; text: string }>>([]);
+  const comboTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const floaterId = useRef(0);
+
+  useEffect(() => {
+    setHighscore(Number(localStorage.getItem('ft-hunt-hs') || 0));
+  }, []);
+
+  const randomPos = () => ({
+    x: 6 + Math.random() * 82,
+    y: 18 + Math.random() * 62,
+  });
+
+  const spawnAll = () => {
+    setTargets(Array.from({ length: TARGET_COUNT }, (_, i) => ({
+      id: i,
+      ...randomPos(),
+      visible: true,
+      popping: false,
+      spriteOk: true,
+      scale: 0.85 + Math.random() * 0.4,
+      flip: Math.random() < 0.5,
+    })));
+  };
+
+  // Runden-Timer
+  useEffect(() => {
+    if (!running) return;
+    if (timeLeft <= 0) {
+      setRunning(false);
+      setGameOver(true);
+      setHighscore((hs) => {
+        const next = Math.max(hs, score);
+        localStorage.setItem('ft-hunt-hs', String(next));
+        return next;
+      });
+      return;
+    }
+    const t = setTimeout(() => setTimeLeft((s) => s - 1), 1000);
+    return () => clearTimeout(t);
+  }, [running, timeLeft]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Ziele wandern gelegentlich von selbst (macht's lebendig)
+  useEffect(() => {
+    if (!running) return;
+    const t = setInterval(() => {
+      setTargets((prev) => prev.map((tg) =>
+        tg.visible && !tg.popping && Math.random() < 0.25
+          ? { ...tg, ...randomPos(), flip: Math.random() < 0.5 }
+          : tg
+      ));
+    }, 2200);
+    return () => clearInterval(t);
+  }, [running]);
+
+  const hit = (id: number, e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!running) return;
+    const nextCombo = combo + 1;
+    const points = 10 + Math.min(nextCombo - 1, 5) * 2; // Combo-Bonus bis +10
+    setCombo(nextCombo);
+    if (comboTimer.current) clearTimeout(comboTimer.current);
+    comboTimer.current = setTimeout(() => setCombo(0), 1800);
+    setScore((s) => s + points);
+
+    const fid = ++floaterId.current;
+    const rect = (e.currentTarget.closest('[data-arena]') as HTMLElement).getBoundingClientRect();
+    setFloaters((f) => [...f, {
+      id: fid,
+      x: ((e.clientX - rect.left) / rect.width) * 100,
+      y: ((e.clientY - rect.top) / rect.height) * 100,
+      text: nextCombo >= 3 ? `+${points} 🔥` : `+${points}`,
+    }]);
+    setTimeout(() => setFloaters((f) => f.filter((x) => x.id !== fid)), 900);
+
+    // Pop-Animation → verschwinden → an neuer Stelle wieder auftauchen
+    setTargets((prev) => prev.map((t) => (t.id === id ? { ...t, popping: true } : t)));
+    setTimeout(() => {
+      setTargets((prev) => prev.map((t) => (t.id === id ? { ...t, visible: false, popping: false } : t)));
+    }, 260);
+    setTimeout(() => {
+      setTargets((prev) => prev.map((t) =>
+        t.id === id ? { ...t, ...randomPos(), visible: true, scale: 0.85 + Math.random() * 0.4, flip: Math.random() < 0.5 } : t
+      ));
+    }, 900 + Math.random() * 1400);
+  };
+
+  const start = () => {
+    setScore(0);
+    setCombo(0);
+    setTimeLeft(ROUND_SECONDS);
+    setGameOver(false);
+    spawnAll();
+    setRunning(true);
+  };
+
+  return (
+    <div className="min-h-screen px-4 py-8" style={{ background: `radial-gradient(1200px 600px at 50% -10%, #1d4468 0%, ${NAVY} 55%, #0c2138 100%)` }}>
+      <div className="mx-auto max-w-4xl">
+        <div className="mb-4 flex items-center justify-between">
+          <Link href="/games" className="text-sm font-bold text-white/70 hover:text-white">← FT Arcade</Link>
+          <div className="flex items-center gap-4 text-sm font-bold text-white">
+            <span>⭐ {score}</span>
+            {combo >= 3 && <span style={{ color: ORANGE }}>Combo ×{combo} 🔥</span>}
+            <span>⏱ {timeLeft}s</span>
+            <span className="text-white/50">Best: {highscore}</span>
+          </div>
+        </div>
+
+        <div
+          data-arena
+          className="relative overflow-hidden rounded-2xl border border-white/15 shadow-2xl select-none"
+          style={{
+            height: 520,
+            cursor: running ? 'crosshair' : 'default',
+            background: 'linear-gradient(180deg, #10314f 0%, #143047 42%, #1a5c38 42.5%, #14522f 70%, #1a5c38 100%)',
+          }}
+        >
+          {/* Stadion-Deko */}
+          <div className="pointer-events-none absolute inset-x-0 top-0 h-[42%] opacity-40" style={{ backgroundImage: 'repeating-linear-gradient(90deg, rgba(255,255,255,0.16) 0 3px, transparent 3px 14px)' }} />
+          <div className="pointer-events-none absolute inset-x-8 top-[42%] h-1 rounded bg-white/40" />
+          <div className="pointer-events-none absolute left-1/2 top-[62%] h-28 w-56 -translate-x-1/2 rounded-[50%] border-4 border-white/25" />
+          <div className="pointer-events-none absolute left-4 top-3 rounded bg-white/10 px-2 py-0.5 text-[10px] font-black uppercase tracking-widest text-white/50">Faltin Travel Arena</div>
+
+          {/* Ziele */}
+          {running && targets.map((t) => t.visible && (
+            <button
+              key={t.id}
+              type="button"
+              onClick={(e) => hit(t.id, e)}
+              className="absolute -translate-x-1/2 -translate-y-1/2 transition-transform"
+              style={{
+                left: `${t.x}%`,
+                top: `${t.y}%`,
+                transform: `translate(-50%,-50%) scale(${t.popping ? 1.6 : t.scale}) ${t.flip ? 'scaleX(-1)' : ''} ${t.popping ? 'rotate(14deg)' : ''}`,
+                opacity: t.popping ? 0 : 1,
+                transition: 'transform .25s ease, opacity .25s ease, left 1.1s ease, top 1.1s ease',
+                filter: 'drop-shadow(0 6px 8px rgba(0,0,0,.4))',
+              }}
+              aria-label="Ziel"
+            >
+              {t.spriteOk ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={`/games/targets/target-${t.id + 1}.png`}
+                  alt=""
+                  draggable={false}
+                  className="pointer-events-none h-28 w-auto md:h-36"
+                  onError={() => setTargets((prev) => prev.map((x) => (x.id === t.id ? { ...x, spriteOk: false } : x)))}
+                />
+              ) : (
+                <span className="text-6xl md:text-7xl">{FALLBACK[t.id % FALLBACK.length]}</span>
+              )}
+            </button>
+          ))}
+
+          {/* Punkte-Floater */}
+          {floaters.map((f) => (
+            <div key={f.id} className="pointer-events-none absolute animate-bounce text-xl font-black" style={{ left: `${f.x}%`, top: `${f.y}%`, color: ORANGE, textShadow: '0 2px 4px rgba(0,0,0,.5)' }}>
+              {f.text}
+            </div>
+          ))}
+
+          {/* Start / Game Over */}
+          {!running && (
+            <div className="absolute inset-0 flex flex-col items-center justify-center gap-4" style={{ background: 'rgba(12,33,56,0.82)' }}>
+              <div className="text-6xl">🎯</div>
+              <h1 className="text-3xl font-black text-white">Hospitality Hunt</h1>
+              {gameOver && (
+                <p className="text-lg font-bold" style={{ color: ORANGE }}>
+                  Zeit! {score} Punkte{score >= highscore && score > 0 ? ' · Neuer Rekord! 🏆' : ''}
+                </p>
+              )}
+              <p className="max-w-md text-center text-sm text-white/60">
+                Das Promo-Team poppt überall in der Arena auf — erwische so viele wie möglich in {ROUND_SECONDS} Sekunden.
+                Schnelle Serien geben Combo-Bonus. Und keine Sorge: <strong className="text-white/80">Alle kommen wieder.</strong>
+              </p>
+              <button onClick={start} className="rounded-xl px-8 py-3 text-lg font-black text-white transition-transform hover:scale-105" style={{ background: ORANGE }}>
+                {gameOver ? 'Revanche!' : 'Start'}
+              </button>
+              <p className="px-6 text-center text-[11px] text-white/35">
+                Eigene Ziele: freigestellte PNGs als <code>public/games/targets/target-1.png … target-{TARGET_COUNT}.png</code> ablegen — sonst springt das Emoji-Team ein.
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/games/SpaceGame.tsx
+++ b/src/components/games/SpaceGame.tsx
@@ -1,0 +1,278 @@
+'use client';
+
+/**
+ * Faltin One – Space Shooter im FT-Corporate-Style.
+ * Canvas + requestAnimationFrame, keine Assets: Gegner sind Emoji-"Geraffel"
+ * (Footballs, Pokale, Koffer …), das von rechts entgegenfliegt.
+ * Steuerung: Pfeile/WASD oder Maus/Touch, Leertaste/Klick schießt.
+ * Highscore in localStorage ("ft-space-hs").
+ */
+import { useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
+
+const NAVY = '#143047';
+const ORANGE = '#d9531e';
+const ENEMIES = ['🏈', '🎾', '⚽', '🏆', '🧳', '🎫', '🏟️', '🥨'];
+
+interface Enemy { x: number; y: number; vx: number; wobble: number; size: number; emoji: string; hp: number }
+interface Shot { x: number; y: number }
+interface Particle { x: number; y: number; vx: number; vy: number; life: number; color: string }
+interface Star { x: number; y: number; s: number; v: number }
+
+export default function SpaceGame() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [score, setScore] = useState(0);
+  const [lives, setLives] = useState(3);
+  const [gameOver, setGameOver] = useState(false);
+  const [running, setRunning] = useState(false);
+  const [highscore, setHighscore] = useState(0);
+  const restartRef = useRef(0);
+
+  useEffect(() => {
+    setHighscore(Number(localStorage.getItem('ft-space-hs') || 0));
+  }, []);
+
+  useEffect(() => {
+    if (!running) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const W = canvas.width;
+    const H = canvas.height;
+    const ship = { x: 70, y: H / 2, cooldown: 0 };
+    let enemies: Enemy[] = [];
+    let shots: Shot[] = [];
+    let particles: Particle[] = [];
+    const stars: Star[] = Array.from({ length: 90 }, () => ({
+      x: Math.random() * W, y: Math.random() * H, s: Math.random() * 1.8 + 0.4, v: Math.random() * 1.2 + 0.3,
+    }));
+    let localScore = 0;
+    let localLives = 3;
+    let spawnTimer = 0;
+    let elapsed = 0;
+    let raf = 0;
+    let alive = true;
+    const keys: Record<string, boolean> = {};
+    let shooting = false;
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ([' ', 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) e.preventDefault();
+      keys[e.key.toLowerCase()] = true;
+      if (e.key === ' ') shooting = true;
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      keys[e.key.toLowerCase()] = false;
+      if (e.key === ' ') shooting = false;
+    };
+    const toLocal = (clientX: number, clientY: number) => {
+      const r = canvas.getBoundingClientRect();
+      return { x: ((clientX - r.left) / r.width) * W, y: ((clientY - r.top) / r.height) * H };
+    };
+    const onMove = (e: PointerEvent) => {
+      const p = toLocal(e.clientX, e.clientY);
+      ship.x = Math.max(30, Math.min(W * 0.6, p.x));
+      ship.y = Math.max(20, Math.min(H - 20, p.y));
+    };
+    const onDown = () => { shooting = true; };
+    const onUp = () => { shooting = false; };
+
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('keyup', onKeyUp);
+    canvas.addEventListener('pointermove', onMove);
+    canvas.addEventListener('pointerdown', onDown);
+    window.addEventListener('pointerup', onUp);
+
+    const boom = (x: number, y: number, color: string, n = 14) => {
+      for (let i = 0; i < n; i++) {
+        const a = Math.random() * Math.PI * 2;
+        const v = Math.random() * 3.5 + 1;
+        particles.push({ x, y, vx: Math.cos(a) * v, vy: Math.sin(a) * v, life: 1, color });
+      }
+    };
+
+    const loop = () => {
+      if (!alive) return;
+      elapsed += 1;
+      const speedup = 1 + Math.min(elapsed / 3600, 1.6); // wird über ~1 Min. schneller
+
+      // Steuerung (Tastatur)
+      const spd = 5.2;
+      if (keys['arrowup'] || keys['w']) ship.y -= spd;
+      if (keys['arrowdown'] || keys['s']) ship.y += spd;
+      if (keys['arrowleft'] || keys['a']) ship.x -= spd;
+      if (keys['arrowright'] || keys['d']) ship.x += spd;
+      ship.x = Math.max(30, Math.min(W * 0.6, ship.x));
+      ship.y = Math.max(20, Math.min(H - 20, ship.y));
+
+      // Schießen
+      if (ship.cooldown > 0) ship.cooldown -= 1;
+      if (shooting && ship.cooldown <= 0) {
+        shots.push({ x: ship.x + 26, y: ship.y });
+        ship.cooldown = 9;
+      }
+
+      // Spawnen
+      spawnTimer -= 1;
+      if (spawnTimer <= 0) {
+        const size = Math.random() < 0.18 ? 46 : 30;
+        enemies.push({
+          x: W + 40,
+          y: 30 + Math.random() * (H - 60),
+          vx: (Math.random() * 1.6 + 1.6) * speedup,
+          wobble: Math.random() * Math.PI * 2,
+          size,
+          emoji: ENEMIES[Math.floor(Math.random() * ENEMIES.length)],
+          hp: size > 40 ? 2 : 1,
+        });
+        spawnTimer = Math.max(14, 42 - elapsed / 90);
+      }
+
+      // Bewegung
+      shots = shots.filter((s) => (s.x += 10.5) < W + 20);
+      enemies.forEach((e) => { e.x -= e.vx; e.wobble += 0.05; e.y += Math.sin(e.wobble) * 1.2; });
+      particles.forEach((p) => { p.x += p.vx; p.y += p.vy; p.vy += 0.06; p.life -= 0.025; });
+      particles = particles.filter((p) => p.life > 0);
+      stars.forEach((st) => { st.x -= st.v * speedup; if (st.x < 0) { st.x = W; st.y = Math.random() * H; } });
+
+      // Treffer Schuss → Gegner
+      for (const s of shots) {
+        for (const e of enemies) {
+          if (Math.abs(s.x - e.x) < e.size * 0.6 && Math.abs(s.y - e.y) < e.size * 0.6) {
+            e.hp -= 1; s.x = W + 999;
+            if (e.hp <= 0) {
+              localScore += e.size > 40 ? 25 : 10;
+              setScore(localScore);
+              boom(e.x, e.y, ORANGE);
+              e.x = -999;
+            } else {
+              boom(s.x, s.y, '#ffffff', 5);
+            }
+          }
+        }
+      }
+      // Gegner entkommen / Kollision mit Schiff
+      for (const e of enemies) {
+        if (e.x < -50) { e.x = -999; localLives -= 1; setLives(localLives); boom(30, e.y, '#e11d48', 8); }
+        else if (Math.abs(e.x - ship.x) < e.size * 0.55 + 14 && Math.abs(e.y - ship.y) < e.size * 0.55 + 10) {
+          e.x = -999; localLives -= 1; setLives(localLives); boom(ship.x, ship.y, '#e11d48', 20);
+        }
+      }
+      enemies = enemies.filter((e) => e.x > -100);
+
+      // ── Zeichnen ──
+      ctx.fillStyle = '#0c2138';
+      ctx.fillRect(0, 0, W, H);
+      const grad = ctx.createRadialGradient(W * 0.7, H * 0.3, 60, W * 0.7, H * 0.3, 600);
+      grad.addColorStop(0, 'rgba(29,68,104,0.55)');
+      grad.addColorStop(1, 'rgba(12,33,56,0)');
+      ctx.fillStyle = grad;
+      ctx.fillRect(0, 0, W, H);
+      ctx.fillStyle = 'rgba(255,255,255,0.75)';
+      stars.forEach((st) => ctx.fillRect(st.x, st.y, st.s, st.s));
+
+      // Schiff: FT-Gleiter
+      ctx.save();
+      ctx.translate(ship.x, ship.y);
+      ctx.fillStyle = ORANGE;                      // Triebwerk
+      ctx.beginPath();
+      ctx.moveTo(-24, -6); ctx.lineTo(-38 - Math.random() * 8, 0); ctx.lineTo(-24, 6); ctx.closePath();
+      ctx.fill();
+      ctx.fillStyle = '#ffffff';                   // Rumpf
+      ctx.beginPath();
+      ctx.moveTo(28, 0); ctx.lineTo(-22, -14); ctx.lineTo(-14, 0); ctx.lineTo(-22, 14); ctx.closePath();
+      ctx.fill();
+      ctx.fillStyle = NAVY;
+      ctx.font = 'bold 10px sans-serif';
+      ctx.fillText('FT', -10, 4);
+      ctx.restore();
+
+      // Schüsse
+      ctx.fillStyle = ORANGE;
+      shots.forEach((s) => ctx.fillRect(s.x - 8, s.y - 2, 14, 4));
+
+      // Gegner
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      enemies.forEach((e) => { ctx.font = `${e.size}px serif`; ctx.fillText(e.emoji, e.x, e.y); });
+
+      // Partikel
+      particles.forEach((p) => {
+        ctx.globalAlpha = Math.max(p.life, 0);
+        ctx.fillStyle = p.color;
+        ctx.fillRect(p.x, p.y, 3, 3);
+      });
+      ctx.globalAlpha = 1;
+
+      if (localLives <= 0) {
+        alive = false;
+        setGameOver(true);
+        setRunning(false);
+        setHighscore((hs) => {
+          const next = Math.max(hs, localScore);
+          localStorage.setItem('ft-space-hs', String(next));
+          return next;
+        });
+        return;
+      }
+      raf = requestAnimationFrame(loop);
+    };
+    raf = requestAnimationFrame(loop);
+
+    return () => {
+      alive = false;
+      cancelAnimationFrame(raf);
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('keyup', onKeyUp);
+      canvas.removeEventListener('pointermove', onMove);
+      canvas.removeEventListener('pointerdown', onDown);
+      window.removeEventListener('pointerup', onUp);
+    };
+  }, [running, restartRef.current]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const start = () => {
+    setScore(0);
+    setLives(3);
+    setGameOver(false);
+    restartRef.current += 1;
+    setRunning(true);
+  };
+
+  return (
+    <div className="min-h-screen px-4 py-8" style={{ background: `radial-gradient(1200px 600px at 50% -10%, #1d4468 0%, ${NAVY} 55%, #0c2138 100%)` }}>
+      <div className="mx-auto max-w-4xl">
+        <div className="mb-4 flex items-center justify-between">
+          <Link href="/games" className="text-sm font-bold text-white/70 hover:text-white">← FT Arcade</Link>
+          <div className="flex items-center gap-4 text-sm font-bold text-white">
+            <span>⭐ {score}</span>
+            <span>{'❤️'.repeat(Math.max(lives, 0)) || '💀'}</span>
+            <span className="text-white/50">Best: {highscore}</span>
+          </div>
+        </div>
+
+        <div className="relative overflow-hidden rounded-2xl border border-white/15 shadow-2xl">
+          <canvas ref={canvasRef} width={900} height={520} className="block h-auto w-full touch-none select-none" style={{ cursor: running ? 'crosshair' : 'default' }} />
+          {!running && (
+            <div className="absolute inset-0 flex flex-col items-center justify-center gap-4" style={{ background: 'rgba(12,33,56,0.82)' }}>
+              <div className="text-6xl">🚀</div>
+              <h1 className="text-3xl font-black text-white">Faltin One</h1>
+              {gameOver && (
+                <p className="text-lg font-bold" style={{ color: ORANGE }}>
+                  Game Over — {score} Punkte{score >= highscore && score > 0 ? ' · Neuer Rekord! 🏆' : ''}
+                </p>
+              )}
+              <p className="max-w-md text-center text-sm text-white/60">
+                Pfeiltasten/WASD oder Maus zum Steuern · Leertaste oder Klick zum Schießen.<br />
+                Lass kein Geraffel an dir vorbei — 3 Leben.
+              </p>
+              <button onClick={start} className="rounded-xl px-8 py-3 text-lg font-black text-white transition-transform hover:scale-105" style={{ background: ORANGE }}>
+                {gameOver ? 'Nochmal!' : 'Start'}
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Was
🎮 **FT Arcade** unter `/games` (noindex, ohne Site-Menü — reine Feierabend-Zone):

1. **Faltin One** (`/games/space`): Canvas-Space-Shooter im Corporate-Style — FT-Raumgleiter (Navy/Orange), entgegenfliegendes Event-Geraffel (🏈🎾🏆🧳 …), Pfeile/WASD/Maus + Leertaste/Klick zum Schießen, Partikel-Explosionen, 3 Leben, steigendes Tempo, lokaler Highscore.
2. **Hospitality Hunt** (`/games/hostess`): Moorhuhn-Style in der „Faltin Travel Arena" — Ziele poppen auf, wandern, ein Klick erwischt sie (Comic-Pop, Punkte-Floater, Combo-Bonus 🔥) und **sie respawnen immer wieder**. 60-Sekunden-Runden, lokaler Highscore.

**Eigene Gesichter als Ziele:** freigestellte PNGs nach `public/games/targets/target-1.png … target-7.png` legen (README liegt dabei) — fehlende Slots übernimmt automatisch das Emoji-Promo-Team. Kein Deploy nötig fürs Tauschen der Bilder, nur Dateien ins Volume/Repo.

## Technik
Reine Client-Komponenten (Canvas bzw. DOM), keine neuen Dependencies, keine API-Berührung; `tsc` grün. Highscores nur in `localStorage`.

✅ **PR ist komplett — Auto-Merge gesetzt.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
