### PR TITLE
Incentive: Machbarkeits-Check-Bug behoben (KI-Antwort kein gültiges JSON)

### DIFF
--- a/src/lib/aiAssist.ts
+++ b/src/lib/aiAssist.ts
@@ -28,6 +28,8 @@ export interface AiCallResult {
   ok: boolean;
   text?: string;
   error?: string;
+  /** stop_reason der Anthropic-API (z.B. 'end_turn', 'max_tokens') – hilfreich, um Truncation zu erkennen. */
+  stopReason?: string;
 }
 
 export async function anthropicMessage(opts: {
@@ -70,13 +72,13 @@ export async function anthropicMessage(opts: {
       const t = await res.text().catch(() => '');
       return { ok: false, error: `Anthropic ${res.status}: ${t.slice(0, 400)}` };
     }
-    const j = (await res.json()) as { content?: Array<{ type: string; text?: string }> };
+    const j = (await res.json()) as { content?: Array<{ type: string; text?: string }>; stop_reason?: string };
     const text = (j.content || [])
       .filter((b) => b.type === 'text')
       .map((b) => b.text || '')
       .join('\n')
       .trim();
-    return { ok: true, text };
+    return { ok: true, text, stopReason: j.stop_reason ? String(j.stop_reason) : undefined };
   } catch (e) {
     const msg = (e as Error).name === 'AbortError' ? 'Zeitüberschreitung beim KI-Aufruf (>150s).' : (e as Error).message;
     return { ok: false, error: msg };
@@ -89,7 +91,12 @@ export function parseJsonLoose(text: string): any | null {
   if (!text) return null;
   let t = text.trim();
   const fence = t.match(/```(?:json)?\s*([\s\S]*?)```/i);
-  if (fence) t = fence[1].trim();
+  if (fence) {
+    t = fence[1].trim();
+  } else if (t.startsWith('```')) {
+    // Unabgeschlossene Code-Fence (z.B. bei abgeschnittener Antwort): erste Zeile und ggf. schließende Fence entfernen.
+    t = t.replace(/^```[^\n]*\n?/, '').replace(/```\s*$/, '').trim();
+  }
   const start = t.indexOf('{');
   const end = t.lastIndexOf('}');
   if (start === -1 || end === -1 || end < start) return null;

--- a/src/lib/incentive/engine.ts
+++ b/src/lib/incentive/engine.ts
@@ -29,12 +29,16 @@ function briefContext(b: IncentiveBrief, period: DateRange): string {
 
 async function callJson(userText: string, maxTokens: number): Promise<Record<string, unknown>> {
   let lastErr = '';
-  for (let attempt = 0; attempt < 2; attempt++) {
+  let lastStopReason = '';
+  for (let attempt = 0; attempt < 3; attempt++) {
+    // Wurde die vorherige Antwort wegen max_tokens abgeschnitten, Budget für den nächsten Versuch erhöhen.
+    if (attempt > 0 && lastStopReason === 'max_tokens') maxTokens = Math.min(Math.ceil(maxTokens * 1.8), 8000);
     const extra = attempt === 0 ? '' : '\n\nWICHTIG: Antworte AUSSCHLIESSLICH mit EINEM einzigen, vollständigen, gültigen JSON-Objekt. Kein Markdown, keine Code-Fences, keine Kommentare, keine abschließenden Kommata. Halte die Texte kompakt, damit das JSON vollständig bleibt.';
     const res = await anthropicMessage({ system: SYSTEM, userText: userText + extra, maxTokens });
     if (!res.ok) throw new Error(res.error || 'KI-Aufruf fehlgeschlagen');
     const parsed = parseJsonLoose(res.text || '');
     if (parsed) return parsed as Record<string, unknown>;
+    lastStopReason = res.stopReason || '';
     lastErr = 'KI-Antwort war kein gültiges JSON';
   }
   throw new Error(lastErr || 'KI-Antwort war kein gültiges JSON');
@@ -87,7 +91,7 @@ async function buildItinerary(b: IncentiveBrief, dest: DestinationOption, period
 async function feasibilityCheck(b: IncentiveBrief, dest: DestinationOption, itin: { days: DayPlan[]; logistics: string }): Promise<Feasibility> {
   const compact = itin.days.map((d) => `Tag ${d.day}: ${d.title} | ${d.morning} / ${d.afternoon} / ${d.evening} | Transport: ${d.transport || '-'}`).join('\n');
   const userText = `Prüfe diese ${b.days}-tägige Incentive-Reise nach ${dest.name} für ${b.groupSize} Personen auf MACHBARKEIT und KONSISTENZ: realistische Reisezeiten/Wege, sinnvolle Reihenfolge, Saison/Wetter, Gruppentauglichkeit, Budget-Plausibilität (${b.budgetLevel}). Sei kritisch aber konstruktiv.\n\nLOGISTIK: ${itin.logistics}\nABLAUF:\n${compact}\n\nSchema:\n{ "ok": boolean, "score": number (0-100), "issues": string[] (konkrete Risiken/Konflikte, leer wenn keine), "notes": string (1-2 Sätze Gesamteinschätzung) }`;
-  const j = await callJson(userText, 1200);
+  const j = await callJson(userText, 2200);
   return {
     ok: Boolean(j.ok),
     score: Number(j.score) || 0,


### PR DESCRIPTION
## Ticket
TASK-00029 – KI-Reiseplanung schlägt fehl: „[feasibility] KI-Antwort war kein gültiges JSON"

## Ursache
Der Machbarkeits-Check lief mit max_tokens=1200 bei gleichzeitig langem Input (kompletter Tagesplan). Die Antwort wurde mitten im JSON abgeschnitten (stop_reason max_tokens) → Parser findet keine schließende Klammer → nach 2 Versuchen Abbruch.

## Fix
- `feasibilityCheck`: Token-Budget 1200 → 2200
- `callJson`: bis zu 3 Versuche; bei Truncation (stop_reason=max_tokens) wird das Budget automatisch erhöht (×1,8, max. 8000)
- `anthropicMessage`: liefert jetzt `stopReason` mit (additiv, alle Call-Sites kompatibel)
- `parseJsonLoose`: robust gegen unabgeschlossene ```-Code-Fences bei abgeschnittenen Antworten

## Verifikation
`npx tsc --noEmit` ✅ · `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)