### PR TITLE
Auto-Antwort: mehrere PDF-Anhänge (je max. 3,5 MB)

### DIFF
--- a/src/app/admin/events/page.tsx
+++ b/src/app/admin/events/page.tsx
@@ -117,8 +117,8 @@ interface EventFormState {
   auto_reply_enabled: boolean;
   auto_reply_subject: string;
   auto_reply_message: string;
-  auto_reply_pdf: string;
-  auto_reply_pdf_name: string;
+  /** Mehrere PDF-Anhänge (Legacy-Einzelfelder auto_reply_pdf/auto_reply_pdf_name werden beim Laden hierher normalisiert). */
+  auto_reply_pdfs: Array<{ file: string; name: string; size?: number }>;
 }
 
 const DEFAULT_MODULE_ORDER = ['leistungen', 'about', 'duell', 'spielorte', 'spielplan', 'wissenswertes', 'stadionplan', 'lageplan', 'ticket_categories', 'packages', 'faq', 'related'];
@@ -211,8 +211,7 @@ const emptyForm: EventFormState = {
   auto_reply_enabled: false,
   auto_reply_subject: '',
   auto_reply_message: '',
-  auto_reply_pdf: '',
-  auto_reply_pdf_name: ''
+  auto_reply_pdfs: []
 };
 
 function normalizeEventFormState(event?: Partial<EventFormState> | null): EventFormState {
@@ -293,9 +292,22 @@ function normalizeEventFormState(event?: Partial<EventFormState> | null): EventF
     auto_reply_enabled: (event as Partial<EventFormState> | null | undefined)?.auto_reply_enabled ?? false,
     auto_reply_subject: (event as Partial<EventFormState> | null | undefined)?.auto_reply_subject ?? '',
     auto_reply_message: (event as Partial<EventFormState> | null | undefined)?.auto_reply_message ?? '',
-    auto_reply_pdf: (event as Partial<EventFormState> | null | undefined)?.auto_reply_pdf ?? '',
-    auto_reply_pdf_name: (event as Partial<EventFormState> | null | undefined)?.auto_reply_pdf_name ?? ''
+    auto_reply_pdfs: normalizeAutoReplyPdfs(event)
   };
+}
+
+/** Normalisiert die PDF-Anhänge: neue Mehrfach-Liste hat Vorrang, sonst Legacy-Einzelfeld einwickeln. */
+function normalizeAutoReplyPdfs(event?: Partial<EventFormState> | null): Array<{ file: string; name: string; size?: number }> {
+  const raw = event as (Partial<EventFormState> & { auto_reply_pdf?: string | null; auto_reply_pdf_name?: string | null }) | null | undefined;
+  if (Array.isArray(raw?.auto_reply_pdfs) && raw.auto_reply_pdfs.length > 0) {
+    return raw.auto_reply_pdfs
+      .filter((p): p is { file: string; name: string; size?: number } => !!p && !!p.file)
+      .map((p) => ({ file: p.file, name: p.name || p.file, size: typeof p.size === 'number' ? p.size : undefined }));
+  }
+  if (raw?.auto_reply_pdf) {
+    return [{ file: raw.auto_reply_pdf, name: raw.auto_reply_pdf_name || raw.auto_reply_pdf }];
+  }
+  return [];
 }
 
 function parseFlexibleDate(value?: string | null): Date | null {
@@ -315,6 +327,13 @@ function parseFlexibleDate(value?: string | null): Date | null {
 
   const date = new Date(trimmed);
   return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/** Dateigröße lesbar formatieren (z.B. "1,2 MB" / "480 KB"). */
+function formatFileSize(bytes?: number): string {
+  if (typeof bytes !== 'number' || !Number.isFinite(bytes) || bytes <= 0) return '';
+  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1).replace('.', ',')} MB`;
+  return `${Math.max(1, Math.round(bytes / 1024))} KB`;
 }
 
 function formatPreviewDate(value?: string | null) {
@@ -374,16 +393,22 @@ export default function AdminEventsPage() {
     requestAnimationFrame(() => { el.focus(); const p = start + token.length; el.setSelectionRange(p, p); });
   }
 
-  async function handleAutoReplyPdfUpload(file: File) {
+  async function handleAutoReplyPdfUpload(files: File[]) {
     setPdfUploading(true);
     try {
-      const fd = new FormData();
-      fd.append('file', file);
-      if (form.slug) fd.append('eventSlug', form.slug);
-      const res = await fetch('/api/admin/auto-reply', { method: 'POST', body: fd });
-      const json = await res.json();
-      if (!json.success) throw new Error(json.error || 'Upload fehlgeschlagen');
-      setForm((prev) => ({ ...prev, auto_reply_pdf: json.data.file, auto_reply_pdf_name: json.data.name }));
+      // Dateien nacheinander hochladen (Endpoint nimmt eine Datei pro Request)
+      for (const file of files) {
+        const fd = new FormData();
+        fd.append('file', file);
+        if (form.slug) fd.append('eventSlug', form.slug);
+        const res = await fetch('/api/admin/auto-reply', { method: 'POST', body: fd });
+        const json = await res.json();
+        if (!json.success) throw new Error(json.error || 'Upload fehlgeschlagen');
+        setForm((prev) => ({
+          ...prev,
+          auto_reply_pdfs: [...prev.auto_reply_pdfs, { file: json.data.file, name: json.data.name, size: json.data.size }],
+        }));
+      }
     } catch (e) {
       alert('PDF-Upload fehlgeschlagen: ' + (e as Error).message);
     } finally {
@@ -550,8 +575,10 @@ export default function AdminEventsPage() {
       auto_reply_enabled: form.auto_reply_enabled,
       auto_reply_subject: form.auto_reply_subject.trim() || null,
       auto_reply_message: form.auto_reply_message.trim() || null,
-      auto_reply_pdf: form.auto_reply_pdf || null,
-      auto_reply_pdf_name: form.auto_reply_pdf_name || null
+      auto_reply_pdfs: form.auto_reply_pdfs.length > 0 ? form.auto_reply_pdfs : null,
+      // Abwärtskompatibilität: erster Anhang zusätzlich in den Legacy-Einzelfeldern
+      auto_reply_pdf: form.auto_reply_pdfs[0]?.file || null,
+      auto_reply_pdf_name: form.auto_reply_pdfs[0]?.name || null
     };
 
     const response = await fetch(`/api/admin/events${form.id ? `/${form.id}` : ''}`, {
@@ -1004,7 +1031,7 @@ export default function AdminEventsPage() {
               <SectionCard
                 icon={<Mail className="h-5 w-5" />}
                 title="Automatische Antwort"
-                description="Statt der Standard-Bestätigung wird bei einer Anfrage zu diesem Event eine eigene Nachricht (optional mit PDF-Anhang) an den Kunden gesendet. Ist der Schalter aus oder kein Text gepflegt, gilt die Standard-Bestätigung."
+                description="Statt der Standard-Bestätigung wird bei einer Anfrage zu diesem Event eine eigene Nachricht (optional mit einem oder mehreren PDF-Anhängen) an den Kunden gesendet. Ist der Schalter aus oder kein Text gepflegt, gilt die Standard-Bestätigung."
               >
                 <div className="grid gap-4">
                   <div className="flex items-center justify-between gap-4 rounded-xl border px-3 py-3" style={{ borderColor: COLORS.stroke }}>
@@ -1058,32 +1085,42 @@ export default function AdminEventsPage() {
 
                       <div className="rounded-xl border px-3 py-3" style={{ borderColor: COLORS.stroke }}>
                         <div className="flex items-center gap-2 text-sm font-semibold" style={{ color: COLORS.navy }}>
-                          <Paperclip className="h-4 w-4" /> PDF-Anhang (optional, max. 3 MB)
+                          <Paperclip className="h-4 w-4" /> PDF-Anhänge (optional, mehrere möglich, max. 3,5 MB pro Datei)
                         </div>
-                        {form.auto_reply_pdf ? (
-                          <div className="mt-2 flex items-center justify-between gap-3 rounded-lg px-3 py-2 text-sm" style={{ background: '#f0fdf4', color: COLORS.navy }}>
-                            <span className="truncate">📎 {form.auto_reply_pdf_name || form.auto_reply_pdf}</span>
-                            <button
-                              type="button"
-                              className="shrink-0 text-xs font-semibold underline"
-                              style={{ color: COLORS.danger }}
-                              onClick={() => setForm((prev) => ({ ...prev, auto_reply_pdf: '', auto_reply_pdf_name: '' }))}
-                            >
-                              Entfernen
-                            </button>
+                        {form.auto_reply_pdfs.length > 0 ? (
+                          <div className="mt-2 grid gap-2">
+                            {form.auto_reply_pdfs.map((pdf, idx) => (
+                              <div key={`${pdf.file}-${idx}`} className="flex items-center justify-between gap-3 rounded-lg px-3 py-2 text-sm" style={{ background: '#f0fdf4', color: COLORS.navy }}>
+                                <span className="min-w-0 truncate">
+                                  📎 {pdf.name || pdf.file}
+                                  {formatFileSize(pdf.size) && (
+                                    <span className="ml-1.5 text-xs" style={{ color: COLORS.textMuted }}>· {formatFileSize(pdf.size)}</span>
+                                  )}
+                                </span>
+                                <button
+                                  type="button"
+                                  className="shrink-0 text-xs font-semibold underline"
+                                  style={{ color: COLORS.danger }}
+                                  onClick={() => setForm((prev) => ({ ...prev, auto_reply_pdfs: prev.auto_reply_pdfs.filter((_, i) => i !== idx) }))}
+                                >
+                                  Entfernen
+                                </button>
+                              </div>
+                            ))}
                           </div>
                         ) : (
-                          <div className="mt-2 text-xs" style={{ color: COLORS.textMuted }}>Noch keine PDF hinterlegt.</div>
+                          <div className="mt-2 text-xs" style={{ color: COLORS.textMuted }}>Noch keine PDFs hinterlegt.</div>
                         )}
                         <input
                           ref={autoReplyPdfInputRef}
                           type="file"
                           accept="application/pdf,.pdf"
+                          multiple
                           disabled={pdfUploading}
                           className="hidden"
                           onChange={(e) => {
-                            const f = e.target.files?.[0];
-                            if (f) handleAutoReplyPdfUpload(f);
+                            const files = Array.from(e.target.files || []);
+                            if (files.length > 0) handleAutoReplyPdfUpload(files);
                             e.target.value = '';
                           }}
                         />
@@ -1095,13 +1132,15 @@ export default function AdminEventsPage() {
                             disabled={pdfUploading}
                           >
                             <Upload className="h-4 w-4" />
-                            PDF auswählen
+                            PDFs hinzufügen
                           </Button>
                           <span className="min-w-0 text-sm" style={{ color: COLORS.textMuted }}>
-                            {form.auto_reply_pdf_name || form.auto_reply_pdf || 'Keine Datei ausgewählt'}
+                            {form.auto_reply_pdfs.length > 0
+                              ? `${form.auto_reply_pdfs.length} ${form.auto_reply_pdfs.length === 1 ? 'Datei' : 'Dateien'} angehängt`
+                              : 'Keine Datei ausgewählt'}
                           </span>
                         </div>
-                        {pdfUploading && <div className="mt-2 text-xs" style={{ color: COLORS.accent }}>PDF wird hochgeladen …</div>}
+                        {pdfUploading && <div className="mt-2 text-xs" style={{ color: COLORS.accent }}>PDFs werden hochgeladen …</div>}
                       </div>
                     </>
                   )}

--- a/src/app/api/bookings/route.ts
+++ b/src/app/api/bookings/route.ts
@@ -124,7 +124,7 @@ export async function POST(request: Request) {
         let subject: string;
         let html: string;
         let attachments: { name: string; contentType: string; contentBytes: string }[] | undefined;
-        let pdfAttached = false;
+        let pdfCount = 0;
 
         if (useAutoReply) {
           subject = (event!.auto_reply_subject || '').trim() || autoReplySubjectDefault(eventName, requestNumber);
@@ -132,19 +132,26 @@ export async function POST(request: Request) {
           if (!/RQ-\d/i.test(subject)) subject = `${subject} ${subjectTag(requestNumber)}`;
           html = autoReplyHtml({ message: event!.auto_reply_message || '', firstName, lastName, salutation, eventName, requestNumber, consent });
 
-          if (event!.auto_reply_pdf) {
-            const pdf = await readAutoReplyPdfBase64(event!.auto_reply_pdf);
+          // Anhänge: neue Mehrfach-Liste (auto_reply_pdfs) hat Vorrang, sonst Legacy-Einzelfeld.
+          const pdfList = Array.isArray(event!.auto_reply_pdfs) && event!.auto_reply_pdfs.length > 0
+            ? event!.auto_reply_pdfs
+            : (event!.auto_reply_pdf
+                ? [{ file: event!.auto_reply_pdf, name: event!.auto_reply_pdf_name || 'Angebot.pdf' }]
+                : []);
+
+          for (const pdfMeta of pdfList) {
+            const pdf = await readAutoReplyPdfBase64(pdfMeta.file);
             if (pdf) {
-              attachments = [{
-                name: event!.auto_reply_pdf_name || 'Angebot.pdf',
+              (attachments ||= []).push({
+                name: pdfMeta.name || 'Angebot.pdf',
                 contentType: 'application/pdf',
                 contentBytes: pdf.base64,
-              }];
-              pdfAttached = true;
+              });
             } else {
-              console.warn('[AutoReply] PDF nicht gefunden:', event!.auto_reply_pdf);
+              console.warn('[AutoReply] PDF nicht gefunden:', pdfMeta.file);
             }
           }
+          pdfCount = attachments?.length ?? 0;
         } else {
           subject = confirmationSubject(requestNumber, eventName);
           html = confirmationEmailHtml({ firstName, lastName, salutation, requestNumber, eventName, message: body.message || '', consent });
@@ -160,7 +167,7 @@ export async function POST(request: Request) {
             to_email: body.email,
             subject,
             body: useAutoReply
-              ? `Automatische Event-Antwort gesendet${pdfAttached ? ' (mit PDF-Anhang)' : ''}.`
+              ? `Automatische Event-Antwort gesendet${pdfCount > 0 ? ` (mit ${pdfCount === 1 ? 'PDF-Anhang' : `${pdfCount} PDF-Anhängen`})` : ''}.`
               : 'Automatische Bestätigung der Anfrage gesendet.',
             graph_message_id: null,
           });

--- a/src/lib/autoReplyStore.ts
+++ b/src/lib/autoReplyStore.ts
@@ -16,6 +16,9 @@ import path from 'path';
 
 const DATA_DIR = path.join(process.cwd(), 'data', 'uploads', 'auto-reply');
 
+/** Max. Größe pro PDF-Anhang (3,5 MB). Große Mails gehen via Graph Draft + Upload-Session raus. */
+export const MAX_AUTO_REPLY_PDF_BYTES = Math.floor(3.5 * 1024 * 1024);
+
 export interface AutoReplyPdfMeta {
   /** Gespeicherter Dateiname (im Event-Datensatz hinterlegt) */
   file: string;
@@ -49,9 +52,10 @@ export async function saveAutoReplyPdf(file: File, eventSlug?: string): Promise<
   }
 
   const bytes = Buffer.from(await file.arrayBuffer());
-  // Graph fileAttachment (inline) ist auf ~3 MB begrenzt.
-  if (bytes.length > 3 * 1024 * 1024) {
-    throw new Error('PDF ist zu groß (max. 3 MB für den Mail-Anhang).');
+  // Versand großer Anhänge läuft über die Graph Upload-Session (graphMailer.ts),
+  // daher gilt nur noch das eigene Limit pro Datei.
+  if (bytes.length > MAX_AUTO_REPLY_PDF_BYTES) {
+    throw new Error('PDF ist zu groß (max. 3,5 MB pro Anhang).');
   }
 
   await mkdir(DATA_DIR, { recursive: true });

--- a/src/lib/contentStore.ts
+++ b/src/lib/contentStore.ts
@@ -119,6 +119,8 @@ export interface ContentEventRecord {
   auto_reply_message?: string | null;
   auto_reply_pdf?: string | null;
   auto_reply_pdf_name?: string | null;
+  /** Mehrere Auto-Antwort-PDFs (je { file, name, size? }). Hat Vorrang vor den Legacy-Feldern auto_reply_pdf/auto_reply_pdf_name. */
+  auto_reply_pdfs?: Array<{ file: string; name: string; size?: number }> | null;
 }
 
 export interface ContentPackageInclude {

--- a/src/lib/eventData.ts
+++ b/src/lib/eventData.ts
@@ -153,10 +153,12 @@ export interface EventRecord {
   auto_reply_subject?: string | null;
   /** Nachrichtentext der Auto-Antwort (wird ins Markendesign gepackt). */
   auto_reply_message?: string | null;
-  /** Gespeicherter Dateiname der angehängten PDF (data/uploads/auto-reply/). */
+  /** Gespeicherter Dateiname der angehängten PDF (data/uploads/auto-reply/). Legacy-Einzelfeld. */
   auto_reply_pdf?: string | null;
-  /** Anzeigename der PDF (wird als Anhang-Name in der Mail genutzt). */
+  /** Anzeigename der PDF (wird als Anhang-Name in der Mail genutzt). Legacy-Einzelfeld. */
   auto_reply_pdf_name?: string | null;
+  /** Mehrere Auto-Antwort-PDFs (je { file, name, size? }). Hat Vorrang vor den Legacy-Feldern. */
+  auto_reply_pdfs?: Array<{ file: string; name: string; size?: number }> | null;
 }
 
 export interface SeriesRecord {

--- a/src/lib/graphMailer.ts
+++ b/src/lib/graphMailer.ts
@@ -122,8 +122,27 @@ export interface SendMailInput {
   html: string;
   /** Optional Plaintext-Variante (sonst aus HTML grob abgeleitet) */
   text?: string;
-  /** Optionale Datei-Anhänge (Graph fileAttachment, inline base64, je < ~3 MB) */
+  /**
+   * Optionale Datei-Anhänge. Kleine Mails gehen inline (base64) über /sendMail;
+   * überschreiten die Anhänge in Summe ~2,5 MB, wird automatisch der Pfad
+   * Draft → Anhänge (ggf. Upload-Session) → Senden genutzt (Graph-Limit:
+   * /sendMail-Request max. 4 MB).
+   */
   attachments?: MailAttachment[];
+}
+
+// Ab dieser Summe an Roh-Bytes (dekodiert) wechseln wir von /sendMail (inline)
+// auf Draft + Upload-Session. Gleichzeitig die Grenze, ab der ein EINZELNER
+// Anhang am Draft per Upload-Session statt inline hochgeladen wird.
+const INLINE_ATTACHMENT_LIMIT_BYTES = Math.floor(2.5 * 1024 * 1024);
+
+// Chunk-Größe für Upload-Sessions: muss ein Vielfaches von 320 KiB sein
+// (Graph-Vorgabe); 10 × 320 KiB = 3.276.800 Bytes.
+const UPLOAD_CHUNK_BYTES = 10 * 320 * 1024;
+
+/** Ungefähre Roh-Größe (dekodierte Bytes) eines Base64-Strings. */
+function base64RawSize(b64: string): number {
+  return Math.floor((b64 || '').length * 0.75);
 }
 
 export async function sendGraphMail(
@@ -153,8 +172,17 @@ export async function sendGraphMail(
     ],
   };
 
-  if (input.attachments && input.attachments.length > 0) {
-    message.attachments = input.attachments.map((a) => ({
+  const attachments = input.attachments || [];
+  const totalRawBytes = attachments.reduce((sum, a) => sum + base64RawSize(a.contentBytes), 0);
+
+  // Große Mails: /sendMail (JSON) ist auf ~4 MB Request-Größe begrenzt —
+  // ab ~2,5 MB Anhang-Summe daher Draft + Upload-Session statt inline.
+  if (attachments.length > 0 && totalRawBytes > INLINE_ATTACHMENT_LIMIT_BYTES) {
+    return sendGraphMailViaDraft(token, mailbox, clientId, message, attachments);
+  }
+
+  if (attachments.length > 0) {
+    message.attachments = attachments.map((a) => ({
       '@odata.type': '#microsoft.graph.fileAttachment',
       name: a.name,
       contentType: a.contentType,
@@ -178,6 +206,118 @@ export async function sendGraphMail(
   const txt = await res.text().catch(() => '');
   console.error(`[Graph] sendMail Fehler (App ${clientId}, Postfach ${mailbox}):`, res.status, txt);
   return { success: false, error: `${res.status} (App ${clientId}, Postfach ${mailbox}): ${txt}` };
+}
+
+/**
+ * Versand großer Mails (Anhänge in Summe > ~2,5 MB):
+ *   1. Draft anlegen (POST /users/{mailbox}/messages)
+ *   2. Anhänge einzeln anhängen — kleine inline, große per Upload-Session
+ *      (Chunks als Vielfache von 320 KiB, PUT ohne Authorization-Header)
+ *   3. Draft senden (POST /users/{mailbox}/messages/{id}/send)
+ * Ergebnis-Shape identisch zu sendGraphMail, damit Call-Sites unverändert bleiben.
+ */
+async function sendGraphMailViaDraft(
+  token: string,
+  mailbox: string,
+  clientId: string,
+  message: Record<string, unknown>,
+  attachments: MailAttachment[]
+): Promise<{ success: boolean; skipped?: boolean; error?: string }> {
+  const userBase = `${GRAPH_BASE}/users/${encodeURIComponent(mailbox)}`;
+  const authHeaders = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+
+  // 1) Draft anlegen (Betreff/Body/Empfänger wie beim Inline-Versand)
+  const draftRes = await fetch(`${userBase}/messages`, {
+    method: 'POST',
+    headers: authHeaders,
+    body: JSON.stringify(message),
+  });
+  if (!draftRes.ok) {
+    const txt = await draftRes.text().catch(() => '');
+    console.error(`[Graph] Draft-Erstellung Fehler (App ${clientId}, Postfach ${mailbox}):`, draftRes.status, txt);
+    return { success: false, error: `Draft-Erstellung ${draftRes.status} (App ${clientId}, Postfach ${mailbox}): ${txt}` };
+  }
+  const draft = (await draftRes.json()) as { id?: string };
+  if (!draft.id) {
+    return { success: false, error: 'Draft-Erstellung: keine Message-ID erhalten' };
+  }
+
+  // 2) Anhänge einzeln an den Draft hängen
+  for (const att of attachments) {
+    const raw = Buffer.from(att.contentBytes, 'base64');
+
+    if (raw.length <= INLINE_ATTACHMENT_LIMIT_BYTES) {
+      // Kleiner Anhang: direkt als fileAttachment ans Draft (Limit hier ~3 MB)
+      const attRes = await fetch(`${userBase}/messages/${draft.id}/attachments`, {
+        method: 'POST',
+        headers: authHeaders,
+        body: JSON.stringify({
+          '@odata.type': '#microsoft.graph.fileAttachment',
+          name: att.name,
+          contentType: att.contentType,
+          contentBytes: att.contentBytes,
+        }),
+      });
+      if (!attRes.ok) {
+        const txt = await attRes.text().catch(() => '');
+        console.error(`[Graph] Anhang "${att.name}" Fehler (Postfach ${mailbox}):`, attRes.status, txt);
+        return { success: false, error: `Anhang "${att.name}" ${attRes.status}: ${txt}` };
+      }
+      continue;
+    }
+
+    // Großer Anhang: Upload-Session anlegen …
+    const sessionRes = await fetch(`${userBase}/messages/${draft.id}/attachments/createUploadSession`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({
+        AttachmentItem: { attachmentType: 'file', name: att.name, size: raw.length },
+      }),
+    });
+    if (!sessionRes.ok) {
+      const txt = await sessionRes.text().catch(() => '');
+      console.error(`[Graph] UploadSession "${att.name}" Fehler (Postfach ${mailbox}):`, sessionRes.status, txt);
+      return { success: false, error: `UploadSession "${att.name}" ${sessionRes.status}: ${txt}` };
+    }
+    const session = (await sessionRes.json()) as { uploadUrl?: string };
+    if (!session.uploadUrl) {
+      return { success: false, error: `UploadSession "${att.name}": keine uploadUrl erhalten` };
+    }
+
+    // … und Bytes in Chunks hochladen (Vielfache von 320 KiB, letzter Chunk beliebig)
+    for (let start = 0; start < raw.length; start += UPLOAD_CHUNK_BYTES) {
+      const end = Math.min(start + UPLOAD_CHUNK_BYTES, raw.length);
+      const chunk = new Uint8Array(raw.subarray(start, end));
+      const putRes = await fetch(session.uploadUrl, {
+        method: 'PUT',
+        headers: {
+          // WICHTIG: KEIN Authorization-Header — die uploadUrl ist vor-autorisiert.
+          'Content-Type': 'application/octet-stream',
+          'Content-Range': `bytes ${start}-${end - 1}/${raw.length}`,
+        },
+        body: chunk,
+      });
+      if (!putRes.ok) {
+        const txt = await putRes.text().catch(() => '');
+        console.error(`[Graph] Chunk-Upload "${att.name}" (${start}-${end - 1}) Fehler:`, putRes.status, txt);
+        return { success: false, error: `Chunk-Upload "${att.name}" ${putRes.status}: ${txt}` };
+      }
+    }
+  }
+
+  // 3) Draft versenden (landet automatisch in "Gesendete Elemente")
+  const sendRes = await fetch(`${userBase}/messages/${draft.id}/send`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+    // Leerer Body → Content-Length: 0 (Graph verlangt eine Länge beim POST)
+    body: '',
+  });
+  if (sendRes.ok || sendRes.status === 202) {
+    return { success: true };
+  }
+  const txt = await sendRes.text().catch(() => '');
+  console.error(`[Graph] Draft-Versand Fehler (App ${clientId}, Postfach ${mailbox}):`, sendRes.status, txt);
+  return { success: false, error: `Draft-Versand ${sendRes.status} (App ${clientId}, Postfach ${mailbox}): ${txt}` };
 }
 
 export interface GraphInboxMessage {


### PR DESCRIPTION
## Ticket
TASK-00022 – Multi-Upload für automatische Antwortfunktion (Stefan)
Betrifft auch TASK-00011 / TASK-00015 (Saalplan/Streckenplan als Anhang)

## Änderungen
- Event-Editor: PDF-Anhänge der Auto-Antwort jetzt als Liste – mehrere Dateien hochladen, einzeln entfernen; Limit 3,5 MB **pro Datei** (vorher: genau 1 Datei, 3 MB)
- Datenmodell: neues Feld `auto_reply_pdfs[]`, Legacy-Einzelfeld bleibt lesbar (Rückwärtskompatibilität, kein Migrationsbedarf)
- Versand: Graph `/sendMail` ist auf 4 MB Request begrenzt → ab ~2,5 MB Anhang-Summe automatisch Draft → Anhänge (ggf. Upload-Session in 320-KiB-Chunks) → Senden
- CRM-Protokoll vermerkt die Anzahl der Anhänge

## Verifikation
`npx tsc --noEmit` ✅ · `npm run build` ✅
Hinweis: Der Graph-Upload-Session-Pfad lässt sich nur gegen den echten M365-Tenant testen — Fehler werden pro Schritt (Draft/Anhang/Chunk/Versand) mit Klartext geloggt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)