### PR TITLE
Mail-to-Ticket: Tickets per E-Mail erstellen + interner Poll-Scheduler

### DIFF
--- a/src/app/admin/mail/page.tsx
+++ b/src/app/admin/mail/page.tsx
@@ -25,6 +25,8 @@ interface MailConfig {
   mailbox: string;
   from_name: string;
   inbound_poll_secret: string;
+  ticket_auto_create: boolean;
+  ticket_auto_create_domains: string;
   has_client_secret: boolean;
   has_brevo: boolean;
 }
@@ -39,6 +41,7 @@ export default function MailAdminPage() {
   const [form, setForm] = useState({
     tenant_id: '', client_id: '', client_secret: '', mailbox: '', from_name: '',
     inbound_poll_secret: '', brevo_api_key: '', login_base_url: '', notify_to: '',
+    ticket_auto_create: false, ticket_auto_create_domains: 'faltintravel.com',
   });
 
   const [testTo, setTestTo] = useState('');
@@ -70,6 +73,8 @@ export default function MailAdminPage() {
           inbound_poll_secret: c.data.inbound_poll_secret || '',
           login_base_url: c.data.login_base_url || '',
           notify_to: c.data.notify_to || '',
+          ticket_auto_create: !!c.data.ticket_auto_create,
+          ticket_auto_create_domains: c.data.ticket_auto_create_domains ?? 'faltintravel.com',
           client_secret: '',
           brevo_api_key: '',
         }));
@@ -85,7 +90,7 @@ export default function MailAdminPage() {
     setToast({ ok, msg });
     setTimeout(() => setToast(null), 5000);
   };
-  const set = (k: keyof typeof form, v: string) => setForm((f) => ({ ...f, [k]: v }));
+  const set = (k: keyof typeof form, v: string | boolean) => setForm((f) => ({ ...f, [k]: v }));
   const genSecret = () =>
     set('inbound_poll_secret', (crypto.randomUUID() + crypto.randomUUID()).replace(/-/g, ''));
   const redirectUri = `${(form.login_base_url || (typeof window !== 'undefined' ? window.location.origin : '')).replace(/\/+$/, '')}/api/auth/microsoft/callback`;
@@ -125,7 +130,7 @@ export default function MailAdminPage() {
     try {
       const res = await fetch('/api/admin/mail/poll', { method: 'POST' });
       const data = await res.json();
-      if (data.success) flash(true, `Poll fertig: ${data.scanned} geprüft, ${data.matched} zugeordnet, ${data.skipped} übersprungen.`);
+      if (data.success) flash(true, `Poll fertig: ${data.scanned} geprüft, ${data.matched} zugeordnet, ${data.created || 0} Tickets erstellt, ${data.skipped} übersprungen.`);
       else flash(false, data.error || 'Poll fehlgeschlagen.');
     } catch { flash(false, 'Verbindungsfehler.'); }
     finally { setPolling(false); }
@@ -220,6 +225,29 @@ export default function MailAdminPage() {
                   <Button type="button" variant="secondary" onClick={genSecret}>Generieren</Button>
                 </div>
               </Field>
+              <div className="rounded-xl border border-gray-200 p-4">
+                <Toggle
+                  checked={form.ticket_auto_create}
+                  onChange={(v) => set('ticket_auto_create', v)}
+                  label="Tickets aus unzugeordneten Mails erstellen"
+                />
+                <p className="mt-1.5 text-xs" style={{ color: '#9ca3af' }}>
+                  Eingehende Mails ohne RQ-/TASK-Nummer werden automatisch als Ticket angelegt; der Absender erhält eine Bestätigung mit der TASK-Nummer im Betreff.
+                </p>
+                <div className="mt-3">
+                  <Field
+                    label="Absender-Domains (Komma-getrennt, leer = alle)"
+                    hint="Nur Mails von diesen Domains erzeugen Tickets, z.B. faltintravel.com. Autoresponder/No-Reply-Absender werden immer ignoriert."
+                  >
+                    <TextInput
+                      value={form.ticket_auto_create_domains}
+                      onChange={(e) => set('ticket_auto_create_domains', e.target.value)}
+                      placeholder="faltintravel.com"
+                      disabled={!form.ticket_auto_create}
+                    />
+                  </Field>
+                </div>
+              </div>
               <InputField
                 label="Brevo API-Key (Listen)"
                 type="password"

--- a/src/app/api/admin/mail/config/route.ts
+++ b/src/app/api/admin/mail/config/route.ts
@@ -14,6 +14,8 @@ export async function GET() {
       inbound_poll_secret: m.inbound_poll_secret,
       login_base_url: m.login_base_url || '',
       notify_to: m.notify_to || '',
+      ticket_auto_create: !!m.ticket_auto_create,
+      ticket_auto_create_domains: m.ticket_auto_create_domains ?? 'faltintravel.com',
       has_client_secret: !!(m.client_secret || process.env.GRAPH_CLIENT_SECRET),
       has_brevo: !!(m.brevo_api_key || process.env.BREVO_API_KEY),
       env_fallback: {
@@ -32,9 +34,10 @@ export async function POST(request: Request) {
     const body = await request.json();
     const updates: Partial<MailSettings> = {};
 
-    for (const key of ['tenant_id', 'client_id', 'mailbox', 'from_name', 'inbound_poll_secret', 'login_base_url', 'notify_to'] as const) {
+    for (const key of ['tenant_id', 'client_id', 'mailbox', 'from_name', 'inbound_poll_secret', 'login_base_url', 'notify_to', 'ticket_auto_create_domains'] as const) {
       if (key in body) updates[key] = String(body[key] ?? '');
     }
+    if ('ticket_auto_create' in body) updates.ticket_auto_create = !!body.ticket_auto_create;
     // Secrets nur setzen, wenn nicht leer (leer = unverändert lassen)
     if (body.client_secret) updates.client_secret = String(body.client_secret);
     if (body.brevo_api_key) updates.brevo_api_key = String(body.brevo_api_key);

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,43 @@
+/**
+ * instrumentation.ts (Next.js Instrumentation Hook)
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Startet in Produktion einen internen Scheduler für das Inbound-Mail-Polling
+ * (alle 120 s), sodass kein externer Cron-Job auf /api/inbound/poll nötig ist.
+ * Läuft nur im Node.js-Runtime-Prozess; Fehler werden geloggt, crashen aber
+ * niemals den Server. runInboundPoll() beendet sich sofort billig, wenn
+ * Microsoft Graph nicht konfiguriert ist.
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+
+const POLL_INTERVAL_MS = 120_000;
+const GLOBAL_KEY = Symbol.for('faltin.inboundPollTimer');
+
+export async function register() {
+  if (process.env.NEXT_RUNTIME !== 'nodejs') return;
+  if (process.env.NODE_ENV !== 'production') return;
+
+  // Doppelte Registrierung verhindern (z.B. bei mehrfachem register()-Aufruf).
+  const g = globalThis as Record<symbol, unknown>;
+  if (g[GLOBAL_KEY]) return;
+  g[GLOBAL_KEY] = true;
+
+  const { runInboundPoll } = await import('./lib/inboundPoll');
+
+  const timer = setInterval(async () => {
+    try {
+      const result = await runInboundPoll();
+      if (result.configured && (result.matched > 0 || result.created > 0)) {
+        console.log(
+          `[inbound-poll] scanned=${result.scanned} matched=${result.matched} created=${result.created} skipped=${result.skipped}`
+        );
+      }
+    } catch (err) {
+      console.error('[inbound-poll] Automatischer Abruf fehlgeschlagen:', err);
+    }
+  }, POLL_INTERVAL_MS);
+
+  // Timer soll ein sauberes Beenden des Prozesses nicht blockieren.
+  (timer as unknown as { unref?: () => void }).unref?.();
+
+  console.log(`[inbound-poll] Interner Poll-Scheduler aktiv (alle ${POLL_INTERVAL_MS / 1000}s).`);
+}

--- a/src/lib/inboundPoll.ts
+++ b/src/lib/inboundPoll.ts
@@ -2,17 +2,27 @@
  * inboundPoll.ts
  * ─────────────────────────────────────────────────────────────────────────────
  * Kernlogik für das Inbound-Polling: liest ungelesene Mails aus dem
- * request@-Postfach, ordnet sie über die RQ-Nummer im Betreff der passenden
- * Anfrage zu, protokolliert sie im CRM und markiert sie als gelesen.
+ * request@-Postfach, ordnet sie über die RQ-/TASK-Nummer im Betreff der
+ * passenden Anfrage bzw. dem Ticket zu, protokolliert sie im CRM und markiert
+ * sie als gelesen. Optional (settings.mail.ticket_auto_create) werden
+ * unzugeordnete Mails automatisch als neues Ticket angelegt (Mail-to-Ticket).
  *
- * Wird sowohl vom geschützten Cron-Endpoint (/api/inbound/poll) als auch vom
- * Admin-Panel (/api/admin/mail/poll) genutzt.
+ * Wird vom geschützten Cron-Endpoint (/api/inbound/poll), vom Admin-Panel
+ * (/api/admin/mail/poll) und vom internen Scheduler (src/instrumentation.ts)
+ * genutzt.
  * ─────────────────────────────────────────────────────────────────────────────
  */
-import { listInboxMessages, markMessageRead, isGraphConfigured, getMailbox } from './graphMailer';
+import {
+  listInboxMessages, markMessageRead, isGraphConfigured, getMailbox, getFromName,
+  sendGraphMail, type GraphInboxMessage,
+} from './graphMailer';
 import { findBookingByRequestNumber, graphMessageExists, addMessage } from './bookingStore';
-import { findTaskByTicketNumber, taskGraphMessageExists, addTaskMessage } from './staffStore';
+import {
+  findTaskByTicketNumber, taskGraphMessageExists, addTaskMessage,
+  createStaffTask, formatTicketNo,
+} from './staffStore';
 import { parseRequestNumber, parseTicketNumber } from './emailTemplates';
+import { getSettings } from './settingsStore';
 
 /**
  * Entfernt den zitierten Original-Verlauf aus einer eingehenden Antwort, sodass
@@ -47,25 +57,129 @@ export function stripQuotedReply(raw: string): string {
   return textOnly.length < 1 ? raw : head;
 }
 
+/** Grober HTML→Text-Konverter für die Ticket-Beschreibung (kein perfektes Parsing nötig). */
+function htmlToText(html: string): string {
+  if (!html) return '';
+  return html
+    .replace(/<style[\s\S]*?<\/style>/gi, '')
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/(p|div|tr|li|h[1-6]|blockquote)>/gi, '\n')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;| /g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;|&apos;/g, "'")
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+/** Erkennt automatisierte Absender (Bounces, Autoresponder), aus denen kein Ticket entstehen soll. */
+function looksAutomated(fromAddress: string, subject: string): boolean {
+  if (/(noreply|no-reply|mailer-daemon)/i.test(fromAddress)) return true;
+  if (/^(automatische antwort|automatic reply|autoreply|out of office|abwesenheit)/i.test((subject || '').trim())) return true;
+  return false;
+}
+
+/** Prüft, ob die Absender-Domain in der Komma-Allowlist steht (leer = alle erlaubt). */
+function senderDomainAllowed(fromAddress: string, allowlist: string): boolean {
+  const domains = (allowlist || '')
+    .split(',')
+    .map((d) => d.trim().toLowerCase().replace(/^@/, ''))
+    .filter(Boolean);
+  if (domains.length === 0) return true;
+  const at = (fromAddress || '').lastIndexOf('@');
+  if (at < 0) return false;
+  const domain = fromAddress.slice(at + 1).toLowerCase();
+  return domains.includes(domain);
+}
+
+/**
+ * Legt aus einer unzugeordneten Mail ein neues Ticket an, protokolliert die Mail
+ * als Ticket-Nachricht und schickt (best effort) eine Bestätigung mit der
+ * TASK-Nummer im Betreff, damit Antworten künftig automatisch zugeordnet werden.
+ */
+async function createTicketFromMail(m: GraphInboxMessage, mailbox: string): Promise<void> {
+  const subject = (m.subject || '').trim();
+  const rawBody = stripQuotedReply(m.bodyHtml || m.bodyPreview);
+  const textBody = htmlToText(rawBody) || m.bodyPreview || '';
+  const fromLabel = m.fromName ? `${m.fromName} <${m.fromAddress}>` : m.fromAddress;
+
+  const task = await createStaffTask({
+    title: subject || 'Mail ohne Betreff',
+    description: `Von: ${fromLabel}\n\n${textBody}`,
+    created_by: `Mail: ${m.fromAddress}`,
+  });
+
+  await addTaskMessage({
+    task_id: task.id,
+    direction: 'in',
+    from_email: m.fromAddress,
+    to_email: mailbox,
+    subject: m.subject,
+    body: rawBody,
+    graph_message_id: m.id,
+    created_by: m.fromAddress,
+  });
+
+  // Bestätigungsmail (best effort) — TASK-Nummer im Betreff sorgt für Auto-Zuordnung der Antworten.
+  try {
+    const ticketNo = formatTicketNo(task.ticket_number);
+    const confirmSubject = `[${ticketNo}] ${subject || 'Ihre Anfrage'}`;
+    const html =
+      `<p>Guten Tag,</p>` +
+      `<p>vielen Dank für Ihre Nachricht. Ihr Ticket <strong>${ticketNo}</strong> wurde erstellt und wird bearbeitet. ` +
+      `Bitte behalten Sie die Ticketnummer im Betreff, damit Antworten zugeordnet werden.</p>` +
+      `<p>Freundliche Grüsse<br/>${getFromName()}</p>`;
+    const sent = await sendGraphMail({
+      to: m.fromAddress,
+      toName: m.fromName || undefined,
+      subject: confirmSubject,
+      html,
+    });
+    if (sent.success) {
+      await addTaskMessage({
+        task_id: task.id,
+        direction: 'out',
+        from_email: mailbox,
+        to_email: m.fromAddress,
+        subject: confirmSubject,
+        body: html,
+        created_by: 'System (Auto-Create)',
+      });
+    }
+  } catch (err) {
+    console.error('[inbound-poll] Bestätigungsmail fehlgeschlagen:', err);
+  }
+}
+
 export interface InboundPollResult {
   success: boolean;
   configured: boolean;
   scanned: number;
   matched: number;
   skipped: number;
+  /** Anzahl automatisch erstellter Tickets (Mail-to-Ticket) */
+  created: number;
   unmatched: string[];
 }
 
 export async function runInboundPoll(): Promise<InboundPollResult> {
   if (!isGraphConfigured()) {
-    return { success: false, configured: false, scanned: 0, matched: 0, skipped: 0, unmatched: [] };
+    return { success: false, configured: false, scanned: 0, matched: 0, skipped: 0, created: 0, unmatched: [] };
   }
 
   const messages = await listInboxMessages(true, 25);
   const selfAddr = getMailbox().toLowerCase();
   let matched = 0;
   let skipped = 0;
+  let created = 0;
   const unmatched: string[] = [];
+  /** Unzugeordnete Mails als Kandidaten für die automatische Ticket-Erstellung. */
+  const unmatchedMsgs: Array<{ msg: GraphInboxMessage; label: string }> = [];
 
   for (const m of messages) {
     // Eigene/interne Mails (Bestätigungen, Team-Benachrichtigungen) überspringen
@@ -77,7 +191,7 @@ export async function runInboundPoll(): Promise<InboundPollResult> {
     const rq = parseRequestNumber(m.subject) || parseRequestNumber(m.bodyPreview);
     const ticketNo = parseTicketNumber(m.subject) || parseTicketNumber(m.bodyPreview);
     if (!rq && !ticketNo) {
-      unmatched.push(m.subject);
+      unmatchedMsgs.push({ msg: m, label: m.subject });
       continue;
     }
 
@@ -130,8 +244,34 @@ export async function runInboundPoll(): Promise<InboundPollResult> {
       }
     }
 
-    unmatched.push(`${rq || `TASK-${ticketNo}`}: ${m.subject}`);
+    unmatchedMsgs.push({ msg: m, label: `${rq || `TASK-${ticketNo}`}: ${m.subject}` });
   }
 
-  return { success: true, configured: true, scanned: messages.length, matched, skipped, unmatched };
+  // ── Mail-to-Ticket: aus unzugeordneten Mails automatisch Tickets erstellen ──
+  const mailSettings = getSettings().mail;
+  const autoCreate = !!mailSettings.ticket_auto_create;
+  const allowlist = mailSettings.ticket_auto_create_domains ?? '';
+
+  for (const { msg, label } of unmatchedMsgs) {
+    if (!autoCreate || !senderDomainAllowed(msg.fromAddress, allowlist) || looksAutomated(msg.fromAddress, msg.subject)) {
+      unmatched.push(label);
+      continue;
+    }
+    try {
+      // Dedupe: Mail wurde bereits als Ticket-Nachricht verarbeitet.
+      if (await taskGraphMessageExists(msg.id)) {
+        skipped++;
+        await markMessageRead(msg.id);
+        continue;
+      }
+      await createTicketFromMail(msg, selfAddr);
+      await markMessageRead(msg.id);
+      created++;
+    } catch (err) {
+      console.error('[inbound-poll] Ticket-Auto-Create fehlgeschlagen:', err);
+      unmatched.push(label);
+    }
+  }
+
+  return { success: true, configured: true, scanned: messages.length, matched, skipped, created, unmatched };
 }

--- a/src/lib/settingsStore.ts
+++ b/src/lib/settingsStore.ts
@@ -121,6 +121,10 @@ export interface MailSettings {
   brevo_api_key: string;
   login_base_url: string;
   notify_to: string;
+  /** Unzugeordnete Inbound-Mails automatisch als Ticket (StaffTask) anlegen */
+  ticket_auto_create?: boolean;
+  /** Komma-getrennte Absender-Domain-Allowlist für Auto-Create (leer = alle Absender) */
+  ticket_auto_create_domains?: string;
 }
 
 const DEFAULT_SETTINGS: AllSettings = {
@@ -185,6 +189,8 @@ const DEFAULT_SETTINGS: AllSettings = {
     brevo_api_key: '',
     login_base_url: '',
     notify_to: '',
+    ticket_auto_create: false,
+    ticket_auto_create_domains: 'faltintravel.com',
   },
   ai: {
     anthropic_api_key: '',


### PR DESCRIPTION
## Ticket
TASK-00028 – Ticket-Erstellung per Mail

## Was schon ging
Antworten mit TASK-Nummer im Betreff wurden bereits automatisch dem Ticket zugeordnet. NEU: Mails ohne Zuordnung können jetzt automatisch ein Ticket erstellen.

## Änderungen
- Inbound-Poll: unzugeordnete Mails → neues Ticket (Titel = Betreff, Beschreibung = Absender + Text), Mail als Eingangs-Nachricht am Ticket, Bestätigungsmail mit `[TASK-xxxxx]` im Betreff (Antworten matchen dann automatisch)
- Schutzmechanismen: Absender-Domain-Allowlist (Default `faltintravel.com`, leer = alle), Automaten-Filter (noreply/Autoreply/Abwesenheit), Dedupe über graph_message_id
- Admin → E-Mail/M365: Toggle „Tickets aus unzugeordneten Mails erstellen" + Domain-Feld (Default: AUS – bewusst aktivieren)
- `src/instrumentation.ts`: interner Scheduler pollt in Produktion alle 120 s – kein externer Cron mehr nötig

## Verifikation
`npx tsc --noEmit` ✅ · `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)