### PR TITLE
Tickets: Warte-Status, Ersteller-Tracking, Benachrichtigungs-Glocke & @Erwähnungen

### DIFF
--- a/src/app/admin/aufgaben/page.tsx
+++ b/src/app/admin/aufgaben/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState, type ReactNode, type CSSProperties } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactNode, type CSSProperties } from 'react';
 import AdminShell from '@/components/admin/AdminShell';
 import {
   PageHeader, Card, SectionCard, Button, Field, TextInput, SelectInput, TextArea, Badge, Spinner, COLORS,
@@ -10,16 +10,19 @@ import Link from 'next/link';
 import { DndContext, useDraggable, useDroppable, PointerSensor, useSensor, useSensors, type DragEndEvent } from '@dnd-kit/core';
 import TaskDrawer from '@/components/admin/TaskDrawer';
 
+type TaskStatus = 'offen' | 'in_arbeit' | 'warten_requester' | 'warten_dritte' | 'erledigt';
+
 interface StaffTask {
   id: string;
   ticket_number: number | null;
+  created_at?: string;
   title: string;
   description: string;
   assignee_id: string | null;
   booking_id: string | null;
   due_date: string | null;
   priority: 'niedrig' | 'normal' | 'hoch';
-  status: 'offen' | 'in_arbeit' | 'erledigt';
+  status: TaskStatus;
   created_by: string | null;
 }
 
@@ -32,6 +35,8 @@ interface EmployeeLite { id: string; name: string }
 const COLUMNS: Array<{ id: StaffTask['status']; label: string }> = [
   { id: 'offen', label: 'Offen' },
   { id: 'in_arbeit', label: 'In Arbeit' },
+  { id: 'warten_requester', label: 'Warten auf Requester' },
+  { id: 'warten_dritte', label: 'Warten auf Dritte' },
   { id: 'erledigt', label: 'Erledigt' },
 ];
 
@@ -94,6 +99,7 @@ function TaskCard({
         </div>
         <div className="mt-3 flex flex-wrap items-center gap-2 text-xs" style={{ color: COLORS.textMuted }}>
           <span>👤 {empName(t.assignee_id)}</span>
+          {t.created_by && <span title="Erstellt von">✍️ {t.created_by}</span>}
           {t.due_date && (
             <span style={{ color: t.due_date < today && t.status !== 'erledigt' ? COLORS.danger : undefined }}>📅 {t.due_date}</span>
           )}
@@ -148,6 +154,17 @@ export default function AufgabenPage() {
   }, []);
 
   useEffect(() => { load(); }, [load]);
+
+  // Deep-Link ?task=<id> (z.B. aus dem Benachrichtigungs-Center) → Drawer öffnen.
+  const deepLinkDone = useRef(false);
+  useEffect(() => {
+    if (deepLinkDone.current || !tasks.length) return;
+    const id = new URLSearchParams(window.location.search).get('task');
+    deepLinkDone.current = true;
+    if (!id) return;
+    const t = tasks.find((x) => x.id === id);
+    if (t) setSelected(t);
+  }, [tasks]);
 
   const empName = (id: string | null) => employees.find((e) => e.id === id)?.name || '–';
 
@@ -263,7 +280,7 @@ export default function AufgabenPage() {
         <div className="flex justify-center py-16"><Spinner /></div>
       ) : (
         <DndContext sensors={sensors} onDragEnd={onDragEnd}>
-          <div className="mt-6 grid gap-4 lg:grid-cols-3">
+          <div className="mt-6 grid gap-4 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-5">
             {COLUMNS.map((col) => {
               const colTasks = tasks.filter((t) => t.status === col.id);
               return (

--- a/src/app/api/admin/notifications/route.ts
+++ b/src/app/api/admin/notifications/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { getSessionEmployee } from '@/lib/serverSession';
+import { listNotifications, countUnreadNotifications, markNotificationsRead } from '@/lib/staffStore';
+
+/**
+ * GET ?unread=1&limit=20 → Benachrichtigungen des angemeldeten Mitarbeiters.
+ * Lokale Admin-Sessions haben keinen Mitarbeiter-Datensatz → leere Liste.
+ */
+export async function GET(req: Request) {
+  const ctx = await getSessionEmployee();
+  if (!ctx) return NextResponse.json({ success: false, error: 'Nicht angemeldet' }, { status: 401 });
+  if (!ctx.employee) return NextResponse.json({ success: true, data: [], unread: 0 });
+
+  const url = new URL(req.url);
+  const unreadOnly = url.searchParams.get('unread') === '1';
+  const limit = Number(url.searchParams.get('limit') || 30) || 30;
+  const [data, unread] = await Promise.all([
+    listNotifications(ctx.employee.id, { unreadOnly, limit }),
+    countUnreadNotifications(ctx.employee.id),
+  ]);
+  return NextResponse.json({ success: true, data, unread });
+}
+
+/** PATCH { ids?: string[] } → als gelesen markieren (ohne ids: alle). */
+export async function PATCH(req: Request) {
+  const ctx = await getSessionEmployee();
+  if (!ctx) return NextResponse.json({ success: false, error: 'Nicht angemeldet' }, { status: 401 });
+  if (!ctx.employee) return NextResponse.json({ success: true, changed: 0 });
+
+  const body = await req.json().catch(() => ({}));
+  const ids = Array.isArray(body?.ids) ? body.ids.map(String) : undefined;
+  const changed = await markNotificationsRead(ctx.employee.id, ids);
+  return NextResponse.json({ success: true, changed });
+}

--- a/src/app/api/admin/tasks/[id]/messages/route.ts
+++ b/src/app/api/admin/tasks/[id]/messages/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getSessionEmployee } from '@/lib/serverSession';
-import { getStaffTask, listTaskMessages, addTaskMessage, formatTicketNo } from '@/lib/staffStore';
+import { getStaffTask, listTaskMessages, addTaskMessage, formatTicketNo, notifyTaskParticipants } from '@/lib/staffStore';
 import { sendGraphMail, isGraphConfigured, getMailbox, getFromName } from '@/lib/graphMailer';
 import { taskEmailHtml, taskSubjectTag } from '@/lib/emailTemplates';
 
@@ -41,6 +41,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
       body: text,
       created_by: agentName || '',
     });
+    await notifyTaskParticipants(task, { type: 'task_note', body: text, actorName: agentName || '' }).catch(() => {});
     return NextResponse.json({ success: true, data: saved });
   }
 
@@ -70,5 +71,6 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
     body: text,
     created_by: agentName || '',
   });
+  await notifyTaskParticipants(task, { type: 'task_message', body: text, actorName: agentName || '' }).catch(() => {});
   return NextResponse.json({ success: true, data: saved });
 }

--- a/src/app/api/admin/tasks/[id]/route.ts
+++ b/src/app/api/admin/tasks/[id]/route.ts
@@ -1,11 +1,38 @@
 import { NextResponse } from 'next/server';
-import { updateStaffTask, deleteStaffTask } from '@/lib/staffStore';
+import {
+  getStaffTask, updateStaffTask, deleteStaffTask,
+  addNotification, formatTicketNo, TASK_STATUS_VALUES, type TaskStatus,
+} from '@/lib/staffStore';
+import { getSessionEmployee } from '@/lib/serverSession';
 
 export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const body = await req.json();
+
+  if (body.status !== undefined && !TASK_STATUS_VALUES.includes(body.status as TaskStatus)) {
+    return NextResponse.json({ success: false, error: 'Ungültiger Status' }, { status: 400 });
+  }
+
+  const before = await getStaffTask(id);
   const updated = await updateStaffTask(id, body);
   if (!updated) return NextResponse.json({ success: false, error: 'Aufgabe nicht gefunden' }, { status: 404 });
+
+  // Neue Zuweisung → Benachrichtigung an den Assignee (außer er hat sie selbst vorgenommen).
+  if (body.assignee_id && before && body.assignee_id !== before.assignee_id) {
+    const ctx = await getSessionEmployee().catch(() => null);
+    const actorName = ctx?.employee?.name || ctx?.session.name || '';
+    if (ctx?.employee?.id !== body.assignee_id) {
+      await addNotification({
+        employee_id: String(body.assignee_id),
+        type: 'task_assigned',
+        task_id: id,
+        title: `${formatTicketNo(updated.ticket_number) || 'Ticket'} wurde dir zugewiesen – ${updated.title}`,
+        body: (updated.description || '').slice(0, 300),
+        created_by: actorName,
+      }).catch(() => { /* Benachrichtigung nie blockierend */ });
+    }
+  }
+
   return NextResponse.json({ success: true, data: updated });
 }
 

--- a/src/app/api/admin/tasks/route.ts
+++ b/src/app/api/admin/tasks/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getSessionEmployee } from '@/lib/serverSession';
-import { listStaffTasks, createStaffTask } from '@/lib/staffStore';
+import { listStaffTasks, createStaffTask, addNotification, formatTicketNo } from '@/lib/staffStore';
 
 /** GET ?assignee=<id>&status=<status>&booking=<id> → Aufgabenliste. */
 export async function GET(req: Request) {
@@ -21,5 +21,18 @@ export async function POST(req: Request) {
   const body = await req.json();
   if (!body.title) return NextResponse.json({ success: false, error: 'title erforderlich' }, { status: 400 });
   const task = await createStaffTask({ ...body, created_by: ctx.session.name });
+
+  // Direkt bei Anlage zugewiesen → Assignee benachrichtigen (außer Selbstzuweisung).
+  if (task.assignee_id && task.assignee_id !== ctx.employee?.id) {
+    await addNotification({
+      employee_id: task.assignee_id,
+      type: 'task_assigned',
+      task_id: task.id,
+      title: `${formatTicketNo(task.ticket_number) || 'Ticket'} wurde dir zugewiesen – ${task.title}`,
+      body: (task.description || '').slice(0, 300),
+      created_by: ctx.session.name,
+    }).catch(() => { /* nie blockierend */ });
+  }
+
   return NextResponse.json({ success: true, data: task });
 }

--- a/src/components/admin/AdminShell.tsx
+++ b/src/components/admin/AdminShell.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState } from 'react';
 import {
   LayoutDashboard, Inbox, KanbanSquare, Wallet,
   CalendarDays, Layers, Package, HelpCircle, Tag, MapPin,
-  Mail, Settings, LogOut, Menu,
+  Mail, Settings, LogOut, Menu, Bell, AtSign, MessageSquare, StickyNote, UserPlus, Check,
   Users, Timer, Plane, ListTodo, Trophy, Sparkles, Contact, Activity, Globe, Code2, Wand2, KeyRound } from 'lucide-react';
 import { COLORS } from './ui';
 
@@ -76,6 +76,120 @@ const NAV: NavGroup[] = [
 function isActive(pathname: string, item: NavItem): boolean {
   if (item.exact) return pathname === item.href;
   return pathname === item.href || pathname.startsWith(item.href + '/');
+}
+
+// ==================== Benachrichtigungs-Center (Glocke) ====================
+
+interface Notif {
+  id: string;
+  type: 'task_assigned' | 'task_message' | 'task_note' | 'mention' | 'info';
+  task_id: string | null;
+  title: string;
+  body: string;
+  is_read: number;
+  created_at: string;
+}
+
+const NOTIF_ICON: Record<Notif['type'], React.ReactNode> = {
+  task_assigned: <UserPlus className="h-3.5 w-3.5" />,
+  task_message: <MessageSquare className="h-3.5 w-3.5" />,
+  task_note: <StickyNote className="h-3.5 w-3.5" />,
+  mention: <AtSign className="h-3.5 w-3.5" />,
+  info: <Bell className="h-3.5 w-3.5" />,
+};
+
+function NotificationBell() {
+  const [items, setItems] = useState<Notif[]>([]);
+  const [unread, setUnread] = useState(0);
+  const [open, setOpen] = useState(false);
+
+  const load = async () => {
+    try {
+      const r = await fetch('/api/admin/notifications?limit=15').then((x) => x.json());
+      if (r?.success) { setItems(r.data || []); setUnread(r.unread || 0); }
+    } catch { /* Netzwerkfehler still ignorieren */ }
+  };
+
+  useEffect(() => {
+    load();
+    const t = setInterval(load, 45000);
+    return () => clearInterval(t);
+  }, []);
+
+  const openItem = async (n: Notif) => {
+    try {
+      await fetch('/api/admin/notifications', {
+        method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ ids: [n.id] }),
+      });
+    } catch { /* ignore */ }
+    setOpen(false);
+    if (n.task_id) window.location.href = `/admin/aufgaben?task=${n.task_id}`;
+    else load();
+  };
+
+  const markAll = async () => {
+    try {
+      await fetch('/api/admin/notifications', { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: '{}' });
+    } catch { /* ignore */ }
+    load();
+  };
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="relative rounded-lg p-2 text-gray-600 transition hover:bg-gray-100"
+        aria-label="Benachrichtigungen"
+        title="Benachrichtigungen"
+      >
+        <Bell className="h-5 w-5" />
+        {unread > 0 && (
+          <span
+            className="absolute -right-0.5 -top-0.5 flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] font-bold text-white"
+            style={{ background: COLORS.danger }}
+          >
+            {unread > 9 ? '9+' : unread}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
+          <div className="absolute right-0 z-50 mt-2 w-80 overflow-hidden rounded-xl border bg-white shadow-xl" style={{ borderColor: COLORS.stroke }}>
+            <div className="flex items-center justify-between border-b px-3 py-2" style={{ borderColor: COLORS.stroke }}>
+              <span className="text-xs font-bold" style={{ color: COLORS.navy }}>Benachrichtigungen</span>
+              {unread > 0 && (
+                <button onClick={markAll} className="flex items-center gap-1 text-[11px] font-medium hover:underline" style={{ color: COLORS.accent }}>
+                  <Check className="h-3 w-3" /> Alle als gelesen
+                </button>
+              )}
+            </div>
+            <div className="max-h-96 overflow-y-auto">
+              {items.length === 0 && (
+                <p className="px-3 py-6 text-center text-xs" style={{ color: 'rgba(20,48,71,0.55)' }}>Keine Benachrichtigungen.</p>
+              )}
+              {items.map((n) => (
+                <button
+                  key={n.id}
+                  onClick={() => openItem(n)}
+                  className="block w-full border-b px-3 py-2.5 text-left transition hover:bg-gray-50"
+                  style={{ borderColor: COLORS.stroke, background: n.is_read ? '#fff' : 'rgba(233,90,12,0.05)' }}
+                >
+                  <div className="flex items-center gap-1.5 text-[11px]" style={{ color: 'rgba(20,48,71,0.55)' }}>
+                    {NOTIF_ICON[n.type] || NOTIF_ICON.info}
+                    <span className="ml-auto tabular-nums">{(n.created_at || '').slice(0, 16).replace('T', ' ')}</span>
+                  </div>
+                  <div className="mt-0.5 text-xs font-semibold" style={{ color: COLORS.navy }}>{n.title}</div>
+                  {n.body && <div className="mt-0.5 line-clamp-2 text-[11px]" style={{ color: 'rgba(20,48,71,0.6)' }}>{n.body}</div>}
+                </button>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
 }
 
 function SidebarContent({ pathname, onNavigate, user }: { pathname: string; onNavigate?: () => void; user: { name: string; src: string } | null }) {
@@ -178,6 +292,7 @@ export default function AdminShell({ title, children }: AdminShellProps) {
                 <Menu className="h-5 w-5" />
               </button>
               <h1 className="text-sm font-bold" style={{ color: COLORS.navy }}>{title}</h1>
+              <div className="ml-auto"><NotificationBell /></div>
             </div>
           </header>
 

--- a/src/components/admin/MyWork.tsx
+++ b/src/components/admin/MyWork.tsx
@@ -59,6 +59,8 @@ const BSTATUS: Record<string, { label: string; tone: 'accent' | 'info' | 'muted'
 const TSTATUS: Record<string, { label: string; tone: 'accent' | 'info' | 'muted' }> = {
   offen: { label: 'Offen', tone: 'accent' },
   in_arbeit: { label: 'In Arbeit', tone: 'info' },
+  warten_requester: { label: 'Warten auf Requester', tone: 'muted' },
+  warten_dritte: { label: 'Warten auf Dritte', tone: 'muted' },
 };
 
 export default function MyWork() {

--- a/src/components/admin/TaskDrawer.tsx
+++ b/src/components/admin/TaskDrawer.tsx
@@ -4,16 +4,20 @@ import { useEffect, useState, useRef } from 'react';
 import { X, Plus, Trash2, Check, Paperclip, Download, Clock, Mail, Send, StickyNote, ArrowDownLeft, ArrowUpRight } from 'lucide-react';
 import { Button, TextArea, Spinner, Badge, COLORS } from './ui';
 
+type TaskStatus = 'offen' | 'in_arbeit' | 'warten_requester' | 'warten_dritte' | 'erledigt';
+
 interface Task {
   id: string;
   ticket_number?: number | null;
   title: string;
   description: string;
-  status: 'offen' | 'in_arbeit' | 'erledigt';
+  status: TaskStatus;
   priority: 'niedrig' | 'normal' | 'hoch';
   due_date: string | null;
   assignee_id?: string | null;
   booking_id?: string | null;
+  created_by?: string | null;
+  created_at?: string;
 }
 interface Subtask { id: string; title: string; done: number }
 interface Att { id: string; filename: string; mime: string; size: number }
@@ -22,7 +26,13 @@ interface Msg { id: string; direction: 'in' | 'out' | 'note'; from_email: string
 interface Emp { id: string; name: string; email?: string; active?: boolean }
 
 const PRIO_TONE = { niedrig: 'muted', normal: 'info', hoch: 'danger' } as const;
-const STATUS_LABEL = { offen: 'Offen', in_arbeit: 'In Arbeit', erledigt: 'Erledigt' } as const;
+const STATUS_LABEL: Record<TaskStatus, string> = {
+  offen: 'Offen',
+  in_arbeit: 'In Arbeit',
+  warten_requester: 'Warten auf Requester',
+  warten_dritte: 'Warten auf Dritte',
+  erledigt: 'Erledigt',
+};
 
 function fmtMin(m: number): string {
   if (!m) return '0 min';
@@ -41,6 +51,7 @@ function todayISO(): string {
 export default function TaskDrawer({ task, onClose, onChanged }: { task: Task; onClose: () => void; onChanged?: () => void }) {
   const [desc, setDesc] = useState(task.description || '');
   const [savingDesc, setSavingDesc] = useState(false);
+  const [status, setStatus] = useState<TaskStatus>(task.status);
   const [subs, setSubs] = useState<Subtask[]>([]);
   const [newSub, setNewSub] = useState('');
   const [loading, setLoading] = useState(true);
@@ -81,18 +92,28 @@ export default function TaskDrawer({ task, onClose, onChanged }: { task: Task; o
   };
   useEffect(() => { loadSubs(); loadAtts(); loadTimes(); loadMsgs(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [task.id]);
 
-  // Mitarbeiter für den Standard-Empfänger (intern) laden + vorbelegen.
+  // Mitarbeiter laden + Standard-Empfänger vorbelegen: Ticket-Ersteller > Assignee > erster aktiver.
   useEffect(() => {
     fetch('/api/admin/team').then((r) => r.json()).then((r) => {
       if (!r.success) return;
       const list: Emp[] = r.data.map((e: Emp) => ({ id: e.id, name: e.name, email: e.email, active: e.active }));
       setEmps(list);
+      const creatorName = (task.created_by || '').trim().toLowerCase();
+      const creator = creatorName ? list.find((e) => e.name.trim().toLowerCase() === creatorName) : null;
       const assignee = task.assignee_id ? list.find((e) => e.id === task.assignee_id) : null;
       const fallback = list.find((e) => e.active && e.email) || list.find((e) => e.email);
-      setToEmail((assignee?.email || fallback?.email || '').trim());
+      setToEmail((creator?.email || assignee?.email || fallback?.email || '').trim());
     }).catch(() => {});
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
   }, [task.id]);
+
+  const changeStatus = async (s: TaskStatus) => {
+    setStatus(s);
+    await fetch(`/api/admin/tasks/${task.id}`, {
+      method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ status: s }),
+    }).catch(() => {});
+    onChanged?.();
+  };
 
   const saveDesc = async () => {
     setSavingDesc(true);
@@ -184,11 +205,26 @@ export default function TaskDrawer({ task, onClose, onChanged }: { task: Task; o
           </button>
         </div>
 
-        <div className="mb-6 flex flex-wrap items-center gap-2">
-          <Badge tone="muted">{STATUS_LABEL[task.status]}</Badge>
+        <div className="mb-2 flex flex-wrap items-center gap-2">
+          <select
+            value={status}
+            onChange={(e) => changeStatus(e.target.value as TaskStatus)}
+            className="rounded-lg border px-2 py-1 text-xs font-medium focus:outline-none"
+            style={{ borderColor: COLORS.stroke, color: COLORS.navy }}
+            title="Status ändern"
+          >
+            {(Object.keys(STATUS_LABEL) as TaskStatus[]).map((s) => (
+              <option key={s} value={s}>{STATUS_LABEL[s]}</option>
+            ))}
+          </select>
           <Badge tone={PRIO_TONE[task.priority]}>{task.priority}</Badge>
           {task.due_date && <span className="text-xs" style={{ color: COLORS.textMuted }}>📅 {task.due_date}</span>}
         </div>
+        {(task.created_by || task.created_at) && (
+          <p className="mb-6 text-xs" style={{ color: COLORS.textMuted }}>
+            Erstellt{task.created_by ? ` von ${task.created_by}` : ''}{task.created_at ? ` am ${task.created_at.slice(0, 10)}` : ''}
+          </p>
+        )}
 
         {/* Beschreibung */}
         <div className="mb-6">
@@ -343,7 +379,7 @@ export default function TaskDrawer({ task, onClose, onChanged }: { task: Task; o
               <input value={subject} onChange={(e) => setSubject(e.target.value)} placeholder={`Betreff (optional) – Ticketnummer wird automatisch ergänzt`} className="w-full rounded-lg border px-3 py-1.5 text-sm focus:outline-none" style={{ borderColor: COLORS.stroke }} />
             </div>
           )}
-          <TextArea rows={3} value={msgBody} onChange={(e) => setMsgBody(e.target.value)} placeholder={mode === 'email' ? 'Nachricht an den Empfänger…' : 'Interne Notiz…'} className="mt-2" />
+          <TextArea rows={3} value={msgBody} onChange={(e) => setMsgBody(e.target.value)} placeholder={mode === 'email' ? 'Nachricht an den Empfänger… (@Name benachrichtigt Kolleg:innen)' : 'Interne Notiz… (@Name benachrichtigt Kolleg:innen)'} className="mt-2" />
           {msgErr && <p className="mt-1 text-xs" style={{ color: COLORS.danger }}>{msgErr}</p>}
           <div className="mt-2">
             <Button size="sm" variant="accent" onClick={sendMsg} disabled={sending || !msgBody.trim() || (mode === 'email' && !toEmail.trim())}>

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -274,7 +274,7 @@ export function initDatabase() {
       booking_id TEXT,
       due_date TEXT,
       priority TEXT NOT NULL DEFAULT 'normal' CHECK(priority IN ('niedrig','normal','hoch')),
-      status TEXT NOT NULL DEFAULT 'offen' CHECK(status IN ('offen','in_arbeit','erledigt')),
+      status TEXT NOT NULL DEFAULT 'offen' CHECK(status IN ('offen','in_arbeit','warten_requester','warten_dritte','erledigt')),
       created_by TEXT
     );
 
@@ -340,6 +340,19 @@ export function initDatabase() {
       revoked INTEGER NOT NULL DEFAULT 0
     );
     CREATE INDEX IF NOT EXISTS idx_api_keys_hash ON api_keys(key_hash);
+
+    CREATE TABLE IF NOT EXISTS admin_notifications (
+      id TEXT PRIMARY KEY,
+      employee_id TEXT NOT NULL,
+      type TEXT NOT NULL DEFAULT 'info',
+      task_id TEXT,
+      title TEXT NOT NULL DEFAULT '',
+      body TEXT NOT NULL DEFAULT '',
+      is_read INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      created_by TEXT NOT NULL DEFAULT ''
+    );
+    CREATE INDEX IF NOT EXISTS idx_admin_notifications_emp ON admin_notifications(employee_id, is_read);
 
     CREATE TABLE IF NOT EXISTS tippspiel_users (
       id TEXT PRIMARY KEY,
@@ -427,6 +440,39 @@ export function initDatabase() {
   // Ticket-System: fortlaufende Ticketnummer + Zeit-Datum (Bestands-DBs nachrüsten)
   const stcols = sqlite.prepare(`PRAGMA table_info(staff_tasks)`).all() as Array<{ name: string }>;
   if (stcols.length && !stcols.some((c) => c.name === 'ticket_number')) addColumn('staff_tasks', 'ticket_number INTEGER');
+
+  // Neue Warte-Status: alter CHECK-Constraint kennt sie nicht → Tabelle einmalig neu aufbauen.
+  try {
+    const ddl = sqlite.prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name='staff_tasks'`).get() as { sql: string } | undefined;
+    if (ddl?.sql && !ddl.sql.includes('warten_requester')) {
+      sqlite.exec(`
+        BEGIN;
+        ALTER TABLE staff_tasks RENAME TO staff_tasks_old;
+        CREATE TABLE staff_tasks (
+          id TEXT PRIMARY KEY,
+          ticket_number INTEGER,
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+          title TEXT NOT NULL,
+          description TEXT NOT NULL DEFAULT '',
+          assignee_id TEXT,
+          booking_id TEXT,
+          due_date TEXT,
+          priority TEXT NOT NULL DEFAULT 'normal' CHECK(priority IN ('niedrig','normal','hoch')),
+          status TEXT NOT NULL DEFAULT 'offen' CHECK(status IN ('offen','in_arbeit','warten_requester','warten_dritte','erledigt')),
+          created_by TEXT
+        );
+        INSERT INTO staff_tasks (id, ticket_number, created_at, updated_at, title, description, assignee_id, booking_id, due_date, priority, status, created_by)
+          SELECT id, ticket_number, created_at, updated_at, title, description, assignee_id, booking_id, due_date, priority, status, created_by FROM staff_tasks_old;
+        DROP TABLE staff_tasks_old;
+        CREATE INDEX IF NOT EXISTS idx_staff_tasks_assignee ON staff_tasks(assignee_id, status);
+        COMMIT;
+      `);
+    }
+  } catch (e) {
+    try { sqlite.exec('ROLLBACK'); } catch { /* keine offene Transaktion */ }
+    console.warn('[sqlite] staff_tasks-Status-Migration:', (e as Error).message);
+  }
   const ttcols = sqlite.prepare(`PRAGMA table_info(task_time)`).all() as Array<{ name: string }>;
   if (ttcols.length && !ttcols.some((c) => c.name === 'work_date')) addColumn('task_time', "work_date TEXT NOT NULL DEFAULT ''");
   // Backfill: bestehende Tasks ohne Nummer fortlaufend ab 10 nummerieren (nach Erstellzeit).

--- a/src/lib/dbq.ts
+++ b/src/lib/dbq.ts
@@ -307,6 +307,25 @@ export async function applyPgSchemaEnhancements(): Promise<void> {
         revoked integer NOT NULL DEFAULT 0
       )`);
       await pool.query(`CREATE INDEX IF NOT EXISTS idx_api_keys_hash ON api_keys(key_hash)`);
+      // Benachrichtigungs-Center (Glocke im Admin)
+      await pool.query(`CREATE TABLE IF NOT EXISTS admin_notifications (
+        id text PRIMARY KEY,
+        employee_id text NOT NULL,
+        type text NOT NULL DEFAULT 'info',
+        task_id text,
+        title text NOT NULL DEFAULT '',
+        body text NOT NULL DEFAULT '',
+        is_read integer NOT NULL DEFAULT 0,
+        created_at timestamptz NOT NULL DEFAULT now(),
+        created_by text NOT NULL DEFAULT ''
+      )`);
+      await pool.query(`CREATE INDEX IF NOT EXISTS idx_admin_notifications_emp ON admin_notifications(employee_id, is_read)`);
+      // Ticket-Status: Warte-Status ergänzen (alter CHECK – falls vorhanden – ersetzen)
+      try {
+        await pool.query(`ALTER TABLE staff_tasks DROP CONSTRAINT IF EXISTS staff_tasks_status_check`);
+        await pool.query(`ALTER TABLE staff_tasks ADD CONSTRAINT staff_tasks_status_check
+          CHECK (status IN ('offen','in_arbeit','warten_requester','warten_dritte','erledigt'))`);
+      } catch (e) { console.warn('[pg] staff_tasks-Status-Constraint:', (e as Error).message); }
       // Backfill: bestehende Tasks ohne Nummer fortlaufend ab 10 nummerieren.
       await pool.query(`
         WITH ordered AS (

--- a/src/lib/staffStore.ts
+++ b/src/lib/staffStore.ts
@@ -371,6 +371,10 @@ export async function vacationPlanner(year: number) {
 
 // ==================== STAFF TASKS ====================
 
+/** Alle gültigen Ticket-Status (Reihenfolge = Board-Spalten). */
+export const TASK_STATUS_VALUES = ['offen', 'in_arbeit', 'warten_requester', 'warten_dritte', 'erledigt'] as const;
+export type TaskStatus = (typeof TASK_STATUS_VALUES)[number];
+
 export interface StaffTask {
   id: string;
   ticket_number: number | null;
@@ -382,7 +386,7 @@ export interface StaffTask {
   booking_id: string | null;
   due_date: string | null;
   priority: 'niedrig' | 'normal' | 'hoch';
-  status: 'offen' | 'in_arbeit' | 'erledigt';
+  status: TaskStatus;
   created_by: string | null;
 }
 
@@ -577,4 +581,123 @@ export async function addTaskMessage(m: {
 export async function taskGraphMessageExists(graphMessageId: string): Promise<boolean> {
   const r = await dbGet<{ id: string }>('SELECT id FROM task_messages WHERE graph_message_id = ?', [graphMessageId]);
   return !!r;
+}
+
+// ==================== NOTIFICATIONS (Benachrichtigungs-Center) ====================
+
+export interface AdminNotification {
+  id: string;
+  employee_id: string;
+  type: 'task_assigned' | 'task_message' | 'task_note' | 'mention' | 'info';
+  task_id: string | null;
+  title: string;
+  body: string;
+  is_read: number; // 0 | 1
+  created_at: string;
+  created_by: string;
+}
+
+export async function addNotification(n: {
+  employee_id: string;
+  type: AdminNotification['type'];
+  task_id?: string | null;
+  title: string;
+  body?: string;
+  created_by?: string;
+}): Promise<void> {
+  await dbRun(
+    `INSERT INTO admin_notifications (id, employee_id, type, task_id, title, body, created_by)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    [crypto.randomUUID(), n.employee_id, n.type, n.task_id || null, n.title, n.body || '', n.created_by || ''],
+  );
+}
+
+export async function listNotifications(employeeId: string, opts?: { unreadOnly?: boolean; limit?: number }): Promise<AdminNotification[]> {
+  const limit = Math.min(Math.max(opts?.limit ?? 30, 1), 100);
+  return dbAll<AdminNotification>(
+    `SELECT * FROM admin_notifications WHERE employee_id = ? ${opts?.unreadOnly ? 'AND is_read = 0' : ''}
+     ORDER BY created_at DESC LIMIT ${limit}`,
+    [employeeId],
+  );
+}
+
+export async function countUnreadNotifications(employeeId: string): Promise<number> {
+  const r = await dbGet<{ n: number }>('SELECT COUNT(*) AS n FROM admin_notifications WHERE employee_id = ? AND is_read = 0', [employeeId]);
+  return r?.n ?? 0;
+}
+
+/** Markiert Benachrichtigungen als gelesen; ohne ids = alle des Mitarbeiters. */
+export async function markNotificationsRead(employeeId: string, ids?: string[]): Promise<number> {
+  if (ids && ids.length) {
+    let changed = 0;
+    for (const id of ids) {
+      changed += (await dbRun('UPDATE admin_notifications SET is_read = 1 WHERE id = ? AND employee_id = ?', [id, employeeId])).changes;
+    }
+    return changed;
+  }
+  return (await dbRun('UPDATE admin_notifications SET is_read = 1 WHERE employee_id = ? AND is_read = 0', [employeeId])).changes;
+}
+
+/** Findet einen Mitarbeiter über den Anzeigenamen (case-insensitive) – z.B. für created_by-Strings. */
+export async function findEmployeeByName(name: string): Promise<Employee | null> {
+  const n = (name || '').trim().toLowerCase();
+  if (!n) return null;
+  const all = await listEmployees(true);
+  return all.find((e) => e.name.trim().toLowerCase() === n) || null;
+}
+
+/**
+ * Erkennt @Erwähnungen in einem Text (voller Name oder Vorname, case-insensitive)
+ * und liefert die passenden aktiven Mitarbeiter.
+ */
+export async function resolveMentions(text: string): Promise<Employee[]> {
+  if (!text || !text.includes('@')) return [];
+  const emps = await listEmployees(false);
+  const esc = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return emps.filter((e) => {
+    const full = e.name.trim();
+    if (!full) return false;
+    const first = full.split(/\s+/)[0];
+    const rxFull = new RegExp(`@${esc(full).replace(/\\?\s+/g, '\\s+')}`, 'i');
+    const rxFirst = new RegExp(`@${esc(first)}(?![\\wäöüß])`, 'i');
+    return rxFull.test(text) || rxFirst.test(text);
+  });
+}
+
+/**
+ * Benachrichtigt die Beteiligten eines Tickets (Ersteller + Assignee) sowie
+ * @Erwähnte über eine neue Nachricht/Notiz. Der Autor selbst wird ausgelassen.
+ */
+export async function notifyTaskParticipants(task: StaffTask, opts: {
+  type: 'task_message' | 'task_note';
+  body: string;
+  actorName: string;
+}): Promise<void> {
+  const ticket = formatTicketNo(task.ticket_number) || 'Ticket';
+  const actorLc = (opts.actorName || '').trim().toLowerCase();
+  const targets = new Map<string, AdminNotification['type']>();
+
+  // Ersteller (created_by ist ein Anzeigename) + Assignee
+  const creator = task.created_by ? await findEmployeeByName(task.created_by) : null;
+  if (creator) targets.set(creator.id, opts.type);
+  if (task.assignee_id) targets.set(task.assignee_id, opts.type);
+
+  // @Erwähnungen gewinnen gegenüber dem generischen Typ
+  for (const m of await resolveMentions(opts.body)) targets.set(m.id, 'mention');
+
+  const label = opts.type === 'task_note' ? 'Neue Notiz' : 'Neue Nachricht';
+  for (const [empId, type] of targets) {
+    const emp = await getEmployee(empId);
+    if (!emp || emp.name.trim().toLowerCase() === actorLc) continue;
+    await addNotification({
+      employee_id: empId,
+      type,
+      task_id: task.id,
+      title: type === 'mention'
+        ? `${opts.actorName || 'Jemand'} hat dich in ${ticket} erwähnt`
+        : `${label} in ${ticket} – ${task.title}`,
+      body: opts.body.slice(0, 300),
+      created_by: opts.actorName || '',
+    }).catch(() => { /* Benachrichtigung darf den Hauptfluss nie brechen */ });
+  }
 }


### PR DESCRIPTION
## Tickets
TASK-00027 – Infos für Tickets ergänzen · TASK-00026 – Benachrichtigungs-Center & Erwähnungen

## Änderungen
**Ticket-Workflow (TASK-00027)**
- Neue Status „Warten auf Requester" und „Warten auf Dritte" (Board-Spalten + Status-Dropdown im Ticket-Drawer)
- Ersteller sichtbar auf der Karte (✍️) und im Drawer („Erstellt von … am …")
- Antwort-Mail im Drawer ist jetzt per Default an den Ticket-Ersteller adressiert (Fallback: Assignee)
- DB: SQLite-CHECK-Rebuild-Migration + PG-Constraint-Update (idempotent beim Start)

**Benachrichtigungs-Center (TASK-00026)**
- Glocke in der Admin-Topbar mit Ungelesen-Badge (45-s-Poll), Panel mit „Alle als gelesen"
- Benachrichtigt bei: Ticket-Zuweisung, neuer Nachricht/Notiz am eigenen/erstellten Ticket, @Erwähnung (voller Name oder Vorname) in Nachrichten/Notizen
- Klick öffnet das Ticket direkt (Deep-Link `/admin/aufgaben?task=<id>`)
- Neue Tabelle `admin_notifications` + `/api/admin/notifications` (GET/PATCH)

Hinweis: Das vertikale Menü aus TASK-00026 existiert bereits (Sidebar); dieser PR ergänzt den Rest (Glocke + Mentions).

## Verifikation
`npx tsc --noEmit` ✅ · `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)