### PR TITLE
CRM: vollständiges Buchungs-Dossier (Reisezeitraum, Belegung, Reisende, Adresse)

### DIFF
--- a/src/app/admin/buchungen/page.tsx
+++ b/src/app/admin/buchungen/page.tsx
@@ -490,6 +490,42 @@ export default function AdminDashboard() {
                 </div>
               </div>
 
+              {/* Reisedaten */}
+              <div>
+                <h3 className="mb-2 text-sm font-bold uppercase tracking-wider text-gray-500">Reisedaten</h3>
+                <div className="rounded-xl bg-gray-50 p-4 text-sm text-gray-800 space-y-1">
+                  {selectedBooking.travel_period && <div><span className="text-gray-500">Reisezeitraum:</span> <strong>{selectedBooking.travel_period}</strong></div>}
+                  <div><span className="text-gray-500">Personen:</span> {selectedBooking.number_of_persons}</div>
+                  <div>
+                    <span className="text-gray-500">Belegung:</span>{' '}
+                    {[
+                      selectedBooking.double_rooms ? `${selectedBooking.double_rooms}× Doppelbelegung` : '',
+                      selectedBooking.single_rooms ? `${selectedBooking.single_rooms}× Einzelbelegung` : '',
+                    ].filter(Boolean).join(', ') || '–'}
+                  </div>
+                  {selectedBooking.total_price > 0 && <div><span className="text-gray-500">Richtpreis:</span> {selectedBooking.total_price.toLocaleString('de-DE')} €</div>}
+                </div>
+              </div>
+
+              {/* Rechnungsadresse */}
+              <div>
+                <h3 className="mb-2 text-sm font-bold uppercase tracking-wider text-gray-500">Rechnungsadresse</h3>
+                <div className="rounded-xl bg-gray-50 p-4 text-sm text-gray-800">
+                  <div className="font-semibold">{[selectedBooking.customer_salutation, selectedBooking.customer_name].filter(Boolean).join(' ') || selectedBooking.email}</div>
+                  {selectedBooking.customer_street ? (
+                    <>
+                      <div>{selectedBooking.customer_street}</div>
+                      <div>{[selectedBooking.customer_zip, selectedBooking.customer_city].filter(Boolean).join(' ')}{selectedBooking.customer_country ? `, ${selectedBooking.customer_country}` : ''}</div>
+                    </>
+                  ) : (
+                    <div className="text-amber-600">Keine Adresse hinterlegt</div>
+                  )}
+                  {selectedBooking.customer_id && (
+                    <a href={`/admin/kunden/${selectedBooking.customer_id}`} className="mt-1 inline-block text-xs font-bold text-blue-600 hover:underline">Kundenkarte öffnen →</a>
+                  )}
+                </div>
+              </div>
+
               {/* Message */}
               {selectedBooking.message && (
                 <div>

--- a/src/app/admin/crm/page.tsx
+++ b/src/app/admin/crm/page.tsx
@@ -34,7 +34,18 @@ interface Lead {
   created_at?: string;
   offer_sent?: number;
   docs_ready?: number;
-  travelers?: string | Array<{ firstName?: string; lastName?: string; first_name?: string; last_name?: string }>;
+  travelers?: string | Array<{ salutation?: string; firstName?: string; lastName?: string; first_name?: string; last_name?: string; birthDate?: string; passportNumber?: string }>;
+  double_rooms?: number;
+  single_rooms?: number;
+  travel_period?: string;
+  source?: string;
+  customer_id?: string | null;
+  customer_name?: string;
+  customer_salutation?: string;
+  customer_street?: string;
+  customer_zip?: string;
+  customer_city?: string;
+  customer_country?: string;
 }
 
 interface MsgAttachment { id: string; filename: string; mime: string; size: number }
@@ -671,13 +682,82 @@ function DetailDrawer({
                     <span className="text-gray-700">{lead.package_title}</span>
                   </div>
                 )}
+                {lead.travel_period && (
+                  <div className="flex items-center gap-2 text-sm">
+                    <Calendar className="w-4 h-4 text-gray-400" />
+                    <span className="font-semibold" style={{ color: '#143047' }}>{lead.travel_period}</span>
+                  </div>
+                )}
+                {((lead.double_rooms || 0) > 0 || (lead.single_rooms || 0) > 0) && (
+                  <div className="flex items-center gap-2 text-sm">
+                    <Package className="w-4 h-4 text-gray-400" />
+                    <span className="text-gray-700">
+                      {[
+                        lead.double_rooms ? `${lead.double_rooms}× Doppelbelegung` : '',
+                        lead.single_rooms ? `${lead.single_rooms}× Einzelbelegung` : '',
+                      ].filter(Boolean).join(', ')}
+                    </span>
+                  </div>
+                )}
                 {lead.total_price && lead.total_price > 0 && (
                   <div className="flex items-center gap-2 text-sm">
                     <Euro className="w-4 h-4 text-gray-400" />
                     <span className="font-bold" style={{ color: '#143047' }}>{formatCurrency(lead.total_price)}</span>
                   </div>
                 )}
+                {lead.source && (
+                  <div className="flex items-center gap-2 text-sm">
+                    <Mail className="w-4 h-4 text-gray-400" />
+                    <span className="text-gray-500">Eingegangen über: {lead.source}</span>
+                  </div>
+                )}
               </div>
+
+              {/* Rechnungsadresse / Kunde */}
+              {(lead.customer_name || lead.customer_street) && (
+                <div>
+                  <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">Rechnungsadresse</h3>
+                  <div className="rounded-xl p-4 text-sm text-gray-700" style={{ background: '#f5f7fa', border: '1px solid #e5e8ed' }}>
+                    <div className="font-semibold text-gray-900">{[lead.customer_salutation, lead.customer_name].filter(Boolean).join(' ')}</div>
+                    {lead.customer_street && <div>{lead.customer_street}</div>}
+                    {(lead.customer_zip || lead.customer_city) && (
+                      <div>{[lead.customer_zip, lead.customer_city].filter(Boolean).join(' ')}{lead.customer_country ? `, ${lead.customer_country}` : ''}</div>
+                    )}
+                    {!lead.customer_street && <div className="text-amber-600">Keine Adresse hinterlegt</div>}
+                    {lead.customer_id && (
+                      <a href={`/admin/kunden/${lead.customer_id}`} className="mt-2 inline-block text-xs font-bold text-blue-600 hover:underline">Kundenkarte öffnen →</a>
+                    )}
+                  </div>
+                </div>
+              )}
+
+              {/* Reisende */}
+              {(() => {
+                let travelers: Array<{ salutation?: string; firstName?: string; lastName?: string; birthDate?: string; passportNumber?: string }> = [];
+                try {
+                  const t = typeof lead.travelers === 'string' ? JSON.parse(lead.travelers) : lead.travelers;
+                  if (Array.isArray(t)) travelers = t;
+                } catch { /* ignore */ }
+                if (!travelers.length) return null;
+                return (
+                  <div>
+                    <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">Reisende ({travelers.length})</h3>
+                    <div className="rounded-xl p-4 space-y-2" style={{ background: '#f5f7fa', border: '1px solid #e5e8ed' }}>
+                      {travelers.map((t, i) => (
+                        <div key={i} className="text-sm">
+                          <span className="font-semibold text-gray-900">
+                            {[t.salutation, t.firstName, t.lastName].filter(Boolean).join(' ') || '– (ohne Name)'}
+                          </span>
+                          <span className="text-gray-500">
+                            {t.birthDate ? ` · geb. ${t.birthDate}` : ''}
+                            {t.passportNumber ? ` · Pass: ${t.passportNumber}` : ''}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })()}
 
               {lead.message && (
                 <div>

--- a/src/app/api/bookings/route.ts
+++ b/src/app/api/bookings/route.ts
@@ -37,6 +37,11 @@ export async function POST(request: Request) {
       );
     }
 
+    // Paket für Reisezeitraum/Nächte (wird an der Buchung fixiert + Team-Mail)
+    const pkgRecord = body.eventSlug && body.packageSlug ? await getPackageBySlug(body.eventSlug, body.packageSlug) : null;
+    const travelPeriodDisplay = [pkgRecord?.travel_period, pkgRecord?.nights ? `${pkgRecord.nights} Nächte` : '']
+      .filter(Boolean).join(' · ') || undefined;
+
     const booking = await createBooking({
       eventSlug: body.eventSlug,
       packageSlug: body.packageSlug,
@@ -51,7 +56,8 @@ export async function POST(request: Request) {
       phone: body.phone,
       message: body.message || '',
       totalPrice: body.totalPrice || 0,
-      source: typeof body.source === 'string' ? body.source.slice(0, 200) : ''
+      source: typeof body.source === 'string' ? body.source.slice(0, 200) : '',
+      travelPeriod: travelPeriodDisplay || ''
     });
 
     const consent = !!body.consent;
@@ -88,10 +94,6 @@ export async function POST(request: Request) {
       }
     }
     const eventName = event?.name || event?.title || body.packageTitle || undefined;
-    // Paket für Reisezeitraum/Nächte (Anzeige in Team-Mail)
-    const pkgRecord = body.eventSlug && body.packageSlug ? await getPackageBySlug(body.eventSlug, body.packageSlug) : null;
-    const travelPeriodDisplay = [pkgRecord?.travel_period, pkgRecord?.nights ? `${pkgRecord.nights} Nächte` : '']
-      .filter(Boolean).join(' · ') || undefined;
     const customerAddress = [body.street, [body.zip, body.city].filter(Boolean).join(' '), body.country]
       .filter((x: unknown) => typeof x === 'string' && (x as string).trim()).join(', ') || undefined;
 

--- a/src/lib/bookingStore.ts
+++ b/src/lib/bookingStore.ts
@@ -47,6 +47,8 @@ export interface BookingInput {
   totalPrice: number;
   /** Affiliate-/Herkunfts-Quelle (Host der einbettenden Website), wird in notes gespeichert. */
   source?: string;
+  /** Anzeige-Reisezeitraum des Pakets, wird an der Buchung fixiert. */
+  travelPeriod?: string;
 }
 
 export async function createBooking(input: BookingInput) {
@@ -54,6 +56,7 @@ export async function createBooking(input: BookingInput) {
     return insertBooking({
       event_slug: input.eventSlug || '',
       package_slug: input.packageSlug || '',
+      travel_period: input.travelPeriod || '',
       package_id: input.packageId,
       package_title: input.packageTitle,
       start_date: input.startDate,

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -46,6 +46,7 @@ export function initDatabase() {
       booking_number TEXT,
       event_slug TEXT DEFAULT '',
       package_slug TEXT DEFAULT '',
+      travel_period TEXT DEFAULT '',
       package_id TEXT NOT NULL,
       package_title TEXT NOT NULL,
       start_date TEXT NOT NULL,
@@ -429,6 +430,7 @@ export function initDatabase() {
   if (!cols.some((c) => c.name === 'source')) addColumn('booking_requests', "source TEXT DEFAULT ''");
   if (!cols.some((c) => c.name === 'event_slug')) addColumn('booking_requests', "event_slug TEXT DEFAULT ''");
   if (!cols.some((c) => c.name === 'package_slug')) addColumn('booking_requests', "package_slug TEXT DEFAULT ''");
+  if (!cols.some((c) => c.name === 'travel_period')) addColumn('booking_requests', "travel_period TEXT DEFAULT ''");
   const icols = sqlite.prepare(`PRAGMA table_info(incentive_plans)`).all() as Array<{ name: string }>;
   if (icols.length && !icols.some((c) => c.name === 'error')) addColumn('incentive_plans', "error TEXT NOT NULL DEFAULT ''");
   if (icols.length && !icols.some((c) => c.name === 'progress')) addColumn('incentive_plans', "progress TEXT NOT NULL DEFAULT ''");
@@ -538,14 +540,15 @@ export async function insertBooking(booking: Omit<BookingRequest, 'id' | 'create
 
   await dbRun(
     `INSERT INTO booking_requests (
-      id, created_at, updated_at, request_number, event_slug, package_slug, package_id, package_title, start_date,
+      id, created_at, updated_at, request_number, event_slug, package_slug, travel_period, package_id, package_title, start_date,
       number_of_persons, double_rooms, single_rooms, travelers,
       email, phone, message, status, total_price, notes, source
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     [
       id, now, now, requestNumber,
       (booking as { event_slug?: string }).event_slug || '',
       (booking as { package_slug?: string }).package_slug || '',
+      (booking as { travel_period?: string }).travel_period || '',
       booking.package_id, booking.package_title, booking.start_date,
       booking.number_of_persons, booking.double_rooms, booking.single_rooms,
       booking.travelers, booking.email, booking.phone, booking.message,
@@ -601,13 +604,19 @@ export async function messageExistsByGraphId(graphId: string): Promise<boolean> 
   return !!row;
 }
 
+const BOOKING_WITH_CUSTOMER_SQL = `
+  SELECT b.*, c.name AS customer_name, c.salutation AS customer_salutation,
+         c.street AS customer_street, c.zip AS customer_zip,
+         c.city AS customer_city, c.country AS customer_country
+  FROM booking_requests b LEFT JOIN customers c ON b.customer_id = c.id`;
+
 export async function getAllBookings(): Promise<BookingRequest[]> {
-  const rows = await dbAll<BookingRow>('SELECT * FROM booking_requests ORDER BY created_at DESC');
+  const rows = await dbAll<BookingRow>(`${BOOKING_WITH_CUSTOMER_SQL} ORDER BY b.created_at DESC`);
   return rows.map((row) => ({ ...row, travelers: JSON.parse(row.travelers) as Traveler[] }));
 }
 
 export async function getBookingById(id: string): Promise<BookingRequest | undefined> {
-  const row = await dbGet<BookingRow>('SELECT * FROM booking_requests WHERE id = ?', [id]);
+  const row = await dbGet<BookingRow>(`${BOOKING_WITH_CUSTOMER_SQL} WHERE b.id = ?`, [id]);
   if (!row) return undefined;
   return { ...row, travelers: JSON.parse(row.travelers) as Traveler[] };
 }

--- a/src/lib/dbq.ts
+++ b/src/lib/dbq.ts
@@ -199,6 +199,7 @@ export async function applyPgSchemaEnhancements(): Promise<void> {
     try { await pool.query(`ALTER TABLE booking_requests ADD COLUMN IF NOT EXISTS source text DEFAULT ''`); } catch { /* ignore */ }
     try { await pool.query(`ALTER TABLE booking_requests ADD COLUMN IF NOT EXISTS event_slug text DEFAULT ''`); } catch { /* ignore */ }
     try { await pool.query(`ALTER TABLE booking_requests ADD COLUMN IF NOT EXISTS package_slug text DEFAULT ''`); } catch { /* ignore */ }
+    try { await pool.query(`ALTER TABLE booking_requests ADD COLUMN IF NOT EXISTS travel_period text DEFAULT ''`); } catch { /* ignore */ }
     try { await pool.query(`INSERT INTO counters (name, value) SELECT 'booking_number', 1000 WHERE NOT EXISTS (SELECT 1 FROM counters WHERE name = 'booking_number')`); } catch { /* ignore */ }
 
     // Kundenportal-Tabellen (in PG zusätzlich anlegen – Migration introspektiert nur Bestandstabellen).

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -21,6 +21,15 @@ export interface BookingRequest {
   notes?: string;
   /** Verknüpfter Kundenstammsatz (customers.id). */
   customer_id?: string | null;
+  /** Anzeige-Reisezeitraum, beim Anlegen aus dem Package fixiert (z.B. "Do. 11.02. – Mo. 15.02.2027 · 4 Nächte"). */
+  travel_period?: string;
+  // Anzeige-Felder aus dem Customer-JOIN (nur lesend, nicht persistiert):
+  customer_name?: string;
+  customer_salutation?: string;
+  customer_street?: string;
+  customer_zip?: string;
+  customer_city?: string;
+  customer_country?: string;
   /** Affiliate-/Herkunfts-Quelle: Host der einbettenden Website (WP-Shortcode). */
   source?: string;
   offer_sent?: number;


### PR DESCRIPTION
## Was
**Jede Package-Anfrage ist jetzt ein vollständiges Dossier im CRM** — alle Infos der Buchung zugewiesen und einsehbar:

| Info | Vorher | Jetzt |
|---|---|---|
| Reisezeitraum | ❌ nirgends gespeichert | ✅ beim Anlegen aus dem Package **an der Buchung fixiert** (`travel_period`-Spalte) — bleibt korrekt, auch wenn das Package später geändert wird |
| Belegung (Doppel-/Einzelbelegung) | ❌ nicht angezeigt | ✅ CRM-Übersicht + Buchungs-Detail |
| Reisende (Name, Geburtsdatum, Pass) | teils | ✅ vollständige Liste in der CRM-Übersicht |
| Rechnungsadresse | ❌ nur auf Kundenkarte | ✅ direkt am Vorgang (per Customer-JOIN), mit Link zur Kundenkarte und Warnung, wenn keine Adresse hinterlegt ist |
| Quelle (Affiliate/Mail) | nur Buchungs-Detail | ✅ auch CRM-Übersicht |
| Richtpreis, Package, Event, Personen | ✅ | ✅ |

## Technik
- Neue Spalte `booking_requests.travel_period` mit idempotenten Migrationen (SQLite + Postgres, laufen beim App-Start)
- `getAllBookings`/`getBookingById` liefern Kundendaten per `LEFT JOIN customers` — CRM-Kanban und Buchungsliste nutzen dieselbe Quelle (`/api/bookings`)
- `/api/bookings` fixiert den Reisezeitraum beim Anlegen (Package-Lookup passierte dort schon für die Team-Mail)

## Verifiziert
21-Spalten-Insert + Customer-JOIN gegen echte SQLite-DB (PASS); `tsc` grün. Bestandsbuchungen: Reisezeitraum bleibt dort leer (wird nicht rückwirkend erfunden) — alle **neuen** Anfragen kommen vollständig rein.

✅ **PR ist komplett — Auto-Merge gesetzt.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
