### PR TITLE
fix(wp): Wartungsbox statt Stale-Karten bei 502 + Bild-Fallback (Plugin 1.8.2)

### DIFF
--- a/src/app/api/packages-html/route.ts
+++ b/src/app/api/packages-html/route.ts
@@ -107,7 +107,7 @@ function renderCard(pkg: PackageRecord, base: string, eventSlug: string, linkSuf
   const galleryAttr = `data-ftpk-gallery="${esc(JSON.stringify(images))}" data-ftpk-title="${esc(pkg.hotel || pkg.title || '')}"`;
   const media = images.length
     ? `<div class="ftpk-media${soldOut ? ' ftpk-media--so' : ''}" ${galleryAttr} style="cursor:pointer" title="Fotos ansehen">
-        <img src="${esc(images[0])}" alt="${esc(pkg.hotel || pkg.title || '')}" loading="lazy" style="${S.img}" />
+        <img src="${esc(images[0])}" alt="${esc(pkg.hotel || pkg.title || '')}" loading="lazy" style="${S.img}" onerror="this.style.display='none'" />
         <div class="ftpk-shade"></div>
         <div class="ftpk-badges">
           ${pkg.badge_text ? `<span style="${S.chipBadge}">${esc(pkg.badge_text)}</span>` : ''}
@@ -264,7 +264,7 @@ document.addEventListener('click',function(e){
 
   const html =
     STYLE +
-    `<div class="ftpk-grid" data-ftv="1.6.3">${packages.map((p) => renderCard(p, base, eventSlug, linkSuffix)).join('')}</div>` +
+    `<div class="ftpk-grid" data-ftv="1.6.4">${packages.map((p) => renderCard(p, base, eventSlug, linkSuffix)).join('')}</div>` +
     LIGHTBOX +
     `<script type="application/ld+json">${JSON.stringify(jsonLd)}</script>`;
 

--- a/wordpress-plugin/faltin-events.php
+++ b/wordpress-plugin/faltin-events.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Faltin Travel – Event Shortcodes
  * Description: SEO-freundliche, serverseitig gerenderte Event-Karten, Package-Karten + natives Anfrageformular. Shortcodes: [faltin_events serie="..."], [faltin_event event="..."], [faltin_packages event="..."], [faltin_anfrage event="..."].
- * Version: 1.8.1
+ * Version: 1.8.2
  * Author: Faltin Travel AG
  *
  * 1.8.0: Deploy-/Ausfall-Fallback: (1) Letzter guter API-Stand wird 7 Tage als
@@ -44,28 +44,32 @@ define('FALTIN_EVENTS_DEFAULT_API', 'https://next.faltintravel.com');
 
 /* ─── Daten laden (mit Transient-Cache) ──────────────────────────────────── */
 
+/** Plattform als nicht erreichbar markiert? (gesetzt für 90 s nach einem Fetch-Fehler) */
+function faltin_api_is_down() {
+    return (bool) get_transient('faltin_api_down');
+}
+
 function faltin_events_fetch($url, $cache_seconds = 600) {
     $key = 'faltin_ev_' . md5($url);
-    $bk  = 'faltin_ev_bk_' . md5($url); // Backup: letzter guter Stand (für Deploys/Ausfälle)
     if ($cache_seconds > 0) {
         $cached = get_transient($key);
         if ($cached !== false) return $cached;
     }
+    // Plattform als down markiert → gar nicht erst anfragen. So zeigen ALLE
+    // Shortcodes konsistent die Wartungsbox und die API wird nicht gehämmert.
+    if (faltin_api_is_down()) return null;
     $res = wp_remote_get($url, array('timeout' => 10));
     if (is_wp_error($res) || wp_remote_retrieve_response_code($res) !== 200) {
-        // Plattform gerade nicht erreichbar (z.B. Deploy) → letzten guten Stand ausliefern.
-        $stale = get_transient($bk);
-        if ($stale !== false) {
-            if ($cache_seconds > 0) set_transient($key, $stale, 60); // kurz cachen, API nicht hämmern
-            return $stale;
-        }
+        // Plattform gerade nicht erreichbar (z.B. Deploy) → KEIN Stale-Inhalt:
+        // gecachte Karten würden mit kaputten (hotverlinkten) Bildern und
+        // funktionslosen Formularen erscheinen. Stattdessen Wartungsbox.
+        set_transient('faltin_api_down', 1, 90); // nach 90 s automatisch neuer Versuch
         return null;
     }
     $json = json_decode(wp_remote_retrieve_body($res), true);
     if (empty($json['success'])) return null;
     $data = $json['data'];
     if ($cache_seconds > 0) set_transient($key, $data, $cache_seconds);
-    set_transient($bk, $data, 7 * DAY_IN_SECONDS);
     return $data;
 }
 
@@ -170,7 +174,7 @@ function faltin_events_card($e, $cta) {
     <a class="ft-ev-card" href="<?php echo esc_url($e['url']); ?>">
       <div class="ft-ev-img">
         <?php if (!empty($e['hero_image'])): ?>
-          <img src="<?php echo esc_url($e['hero_image']); ?>" alt="<?php echo esc_attr($e['name'] ?: $e['title']); ?>" loading="lazy" />
+          <img src="<?php echo esc_url($e['hero_image']); ?>" alt="<?php echo esc_attr($e['name'] ?: $e['title']); ?>" loading="lazy" onerror="this.style.display='none'" />
         <?php endif; ?>
         <?php if ($date): ?><span class="ft-ev-date"><?php echo esc_html($date); ?></span><?php endif; ?>
       </div>
@@ -241,7 +245,7 @@ function faltin_event_single_shortcode($atts) {
     <div class="ft-ev-single">
       <div class="ft-ev-img">
         <?php if (!empty($e['hero_image'])): ?>
-          <img src="<?php echo esc_url($e['hero_image']); ?>" alt="<?php echo esc_attr($e['name'] ?: $e['title']); ?>" loading="lazy" />
+          <img src="<?php echo esc_url($e['hero_image']); ?>" alt="<?php echo esc_attr($e['name'] ?: $e['title']); ?>" loading="lazy" onerror="this.style.display='none'" />
         <?php endif; ?>
         <?php if ($date): ?><span class="ft-ev-date"><?php echo esc_html($date); ?></span><?php endif; ?>
       </div>
@@ -325,6 +329,10 @@ function faltin_anfrage_shortcode($atts) {
         'packages' => 'auto', // auto = Package-Karten ausliefern, wenn das Event welche hat; 0/off = immer Formular
         'cache' => 600,
     ), $atts, 'faltin_anfrage');
+
+    // Plattform down → auch das reine Formular nicht rendern (Absenden würde
+    // scheitern); gilt ebenso für packages="0" und die allgemeine Anfrage.
+    if (faltin_api_is_down()) return faltin_events_maintenance_box();
 
     // Wie auf der Faltin-Event-Seite: hat das Event buchbare Packages, zeigen
     // wir die Karten statt des Formulars — bestehende [faltin_anfrage]-


### PR DESCRIPTION
## Problem (TASK-00034)
Während des Deploys von #60 (502 auf next.faltintravel.com) zeigte faltintravel.com weiterhin Paket-Karten — mit kaputten „?"-Bildplatzhaltern — und das Anfrageformular, statt der vereinbarten Wartungsbox.

**Zwei Ursachen:**
1. `faltin_events_fetch()` lieferte bei API-Fehlern bewusst den **Stale-Backup-Stand** (7-Tage-Transient) aus → Karten/Formular trotz 502.
2. Bei **frischem Cache** (600 s) fragt WP die API gar nicht erst — die Karten-HTML kommt aus dem Cache, aber die **Hotelbilder lädt der Browser direkt von next.faltintravel.com** → kaputte Platzhalter während des Deploys.

## Fix
- **Plugin v1.8.2:** Stale-Fallback entfernt. Ein Fetch-Fehler setzt 90 s lang das Flag `faltin_api_down` → **alle** Shortcodes ([faltin_events], [faltin_event], [faltin_packages], [faltin_anfrage] inkl. `packages="0"`/allgemeine Anfrage) zeigen konsistent die Wartungsbox (Telefon/Mail/Öffnungszeiten) und die API wird während des Ausfalls nicht gehämmert. Nach 90 s automatischer neuer Versuch.
- **Bild-Fallback** (`onerror` → ausblenden, Marken-Gradient bleibt sichtbar): in den Plugin-Event-Karten **und** in `/api/packages-html` (`data-ftv` 1.6.4) — deckt das Frisch-Cache-Fenster ab, in dem WP vom Ausfall nichts wissen kann.

## Verifikation
- `tsc --noEmit` ✅
- PHP: Klammer-Balance-Delta identisch zu produktiv laufendem HEAD (kein `php -l` auf dem Host verfügbar); Änderungen sind lokal begrenzt (Fetch-Funktion, ein Guard, 2 Attribute)
- Kernstellen per Script geprüft (Down-Flag, Guard, 2× onerror, Version 1.8.2)

## Nach dem Merge
⚠️ **Manueller Schritt:** Plugin v1.8.2 unter `/admin/shortcodes` herunterladen und auf faltintravel.com (WP-Admin) aktualisieren — der main-Deploy rollt nur die Plattform-Seite aus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
