### PR TITLE
feat(admin): Rapport-Stammdaten editierbar (Währung/Stundensatz/Titel) + Zeitbuchungs-Konvention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,8 +78,11 @@ Ablauf pro PR (externe API, Basis `https://next.faltintravel.com`, Auth-Header
 3. **PR verlinken**: `POST /api/ext/tasks/<id>/messages` `{ "kind": "note", "body": "PR: <url> – Claude" }`
    (Notizen mit „– Claude" signieren; `kind:"note"` verwenden, sonst geht eine Mail raus!)
 4. **Zeit buchen**: `POST /api/ext/tasks/<id>/time` `{ "minutes": <n>, "note": "<was>" }` —
-   ehrlich geschätzte Bearbeitungszeit der Session (Analyse + Umsetzung + Verifikation),
-   gern mehrere Buchungen bei mehreren Arbeitsblöcken.
+   gebucht wird die **ungefähre reale Dauer der KI-Session** (Wall-Clock von Arbeitsbeginn
+   bis fertigem PR, inkl. Verifikation; typisch 15–45 min pro PR). **KEINE**
+   Menschen-Äquivalent-Schätzungen buchen und **kein** „menschl. Äquivalent ~Xh" o. ä.
+   in die Notiz schreiben — Zeit-Notizen landen 1:1 im Kunden-Rapport-PDF.
+   Gern mehrere Buchungen bei mehreren Arbeitsblöcken.
 5. **`erledigt` erst, wenn der PR gemerged UND deployed ist** — nicht beim PR-Erstellen.
 
 Ticket-Nummern (`TASK-XXXXX`) im PR-Text erwähnen. Kein Ticket nötig für reine

--- a/src/app/admin/rapporte/page.tsx
+++ b/src/app/admin/rapporte/page.tsx
@@ -95,6 +95,10 @@ export default function RapportePage() {
   const [edit, setEdit] = useState<{ id: string; minutes: string; note: string; work_date: string; employee_id: string } | null>(null);
   const [savingEdit, setSavingEdit] = useState(false);
 
+  // Stammdaten-Editor am Rapport-Entwurf (Titel/Stundensatz/Währung)
+  const [meta, setMeta] = useState<{ title: string; rate: string; currency: string } | null>(null);
+  const [savingMeta, setSavingMeta] = useState(false);
+
   const load = useCallback(async () => {
     setLoading(true);
     setErr('');
@@ -144,11 +148,32 @@ export default function RapportePage() {
     setDetailBusy(true);
     try {
       const r = await fetch(`/api/admin/time-reports/${id}`).then((x) => x.json());
-      if (r.success) setDetail(r.data); else setErr(r.error || 'Fehler');
+      if (r.success) {
+        setDetail(r.data);
+        setMeta({
+          title: r.data.report.title || '',
+          rate: r.data.report.hourly_rate != null ? String(r.data.report.hourly_rate) : '',
+          currency: r.data.report.currency || 'EUR',
+        });
+      } else setErr(r.error || 'Fehler');
     } finally {
       setDetailBusy(false);
     }
   }, []);
+
+  const saveMeta = async () => {
+    if (!detail || !meta) return;
+    setSavingMeta(true);
+    try {
+      await patchReport(detail.report.id, {
+        title: meta.title.trim(),
+        hourly_rate: meta.rate.trim() === '' ? null : Number(meta.rate.replace(',', '.')),
+        currency: meta.currency,
+      });
+    } finally {
+      setSavingMeta(false);
+    }
+  };
 
   const createReport = async () => {
     if (!selEntries.length) return;
@@ -545,6 +570,28 @@ export default function RapportePage() {
                   </Badge>
                 </span>
               </div>
+
+              {/* Stammdaten (nur Entwurf änderbar) */}
+              {detail.report.status === 'entwurf' && meta && (
+                <div className="mb-4 flex flex-wrap items-end gap-3 rounded-xl border p-3" style={{ borderColor: COLORS.stroke, background: '#fafbfc' }}>
+                  <Field label="Titel">
+                    <TextInput value={meta.title} onChange={(ev) => setMeta({ ...meta, title: ev.target.value })} className="w-64" />
+                  </Field>
+                  <Field label="Stundensatz (leer = ohne)">
+                    <TextInput type="number" min={0} step="0.01" value={meta.rate} onChange={(ev) => setMeta({ ...meta, rate: ev.target.value })} className="w-32" />
+                  </Field>
+                  <Field label="Währung">
+                    <SelectInput value={meta.currency} onChange={(ev) => setMeta({ ...meta, currency: ev.target.value })} className="w-28">
+                      {!['EUR', 'CHF'].includes(meta.currency) && <option value={meta.currency}>{meta.currency}</option>}
+                      <option value="EUR">EUR</option>
+                      <option value="CHF">CHF</option>
+                    </SelectInput>
+                  </Field>
+                  <Button size="sm" variant="secondary" onClick={saveMeta} disabled={savingMeta}>
+                    {savingMeta ? <Spinner className="h-4 w-4" /> : <Check className="h-4 w-4" />} Stammdaten speichern
+                  </Button>
+                </div>
+              )}
               <table className="w-full text-sm">
                 <thead>
                   <tr className="text-left text-xs uppercase tracking-wide" style={{ color: COLORS.textMuted }}>


### PR DESCRIPTION
## Was ist neu (TASK-00037)
- **/admin/rapporte → Rapport-Detail (Entwurf):** neue Stammdaten-Zeile — **Titel**, **Stundensatz** (leer = ohne Betragsberechnung) und **Währung (EUR/CHF)** lassen sich nachträglich ändern; Beträge/PDF rechnen sofort mit den neuen Werten. Finalisierte Rapporte bleiben gesperrt (erst auf Entwurf zurücksetzen).
- **CLAUDE.md:** Zeitbuchungs-Konvention präzisiert — gebucht wird die ungefähre **reale Dauer der KI-Session** (typisch 15–45 min pro PR), keine Menschen-Äquivalent-Schätzungen und keine „(menschl. Äquivalent ~Xh)"-Zusätze in Notizen (die landen 1:1 im Kunden-Rapport-PDF).

## Technik
Kein neuer Endpoint — nutzt `PATCH /api/admin/time-reports/[id]` (unterstützte Felder title/hourly_rate/currency existierten bereits, nur die UI fehlte).

## Verifikation
`tsc --noEmit` ✅, `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)