### PR TITLE
feat(admin): Projekte — Tickets/Zeiten zuordnen, filtern, Rapport-Gruppierung

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,8 @@ Ablauf pro PR (externe API, Basis `https://next.faltintravel.com`, Auth-Header
 
 1. **Ticket anlegen** (bei Arbeitsbeginn): `POST /api/ext/tasks`
    `{ "title": "<Kurzbeschreibung>", "description": "<Kontext/Anforderung>", "priority": "normal" }`
+   — optional `"project_id"` zur Projekt-Zuordnung (Projekte: `GET/POST /api/ext/projects`;
+   Zeiten werden im Rapport nach Projekt → Ticket gruppiert).
 2. **Status pflegen**: `PATCH /api/ext/tasks/<id>` `{ "status": "in_arbeit" }` —
    Werte: `offen | in_arbeit | warten_requester | warten_dritte | erledigt`.
 3. **PR verlinken**: `POST /api/ext/tasks/<id>/messages` `{ "kind": "note", "body": "PR: <url> – Claude" }`

--- a/src/app/admin/aufgaben/page.tsx
+++ b/src/app/admin/aufgaben/page.tsx
@@ -24,7 +24,11 @@ interface StaffTask {
   priority: 'niedrig' | 'normal' | 'hoch';
   status: TaskStatus;
   created_by: string | null;
+  project_id?: string | null;
+  project_name?: string | null;
 }
+
+interface ProjectLite { id: string; name: string }
 
 function ticketNo(n: number | null): string {
   return n && n > 0 ? `TASK-${String(n).padStart(5, '0')}` : '';
@@ -139,6 +143,15 @@ function TaskCard({
         )}
         <div className="mt-3 flex flex-wrap items-center gap-2 text-xs" style={{ color: COLORS.textMuted }}>
           <span>👤 {empName(t.assignee_id)}</span>
+          {t.project_name && (
+            <span
+              className="rounded-full border px-2 py-0.5 text-[11px] font-semibold"
+              style={{ borderColor: '#c7d7ea', background: '#eef4fb', color: COLORS.navy }}
+              title="Projekt"
+            >
+              🗂 {t.project_name}
+            </span>
+          )}
           {t.created_by && <span title="Erstellt von">✍️ {t.created_by}</span>}
           {t.due_date && (
             <span style={{ color: t.due_date < today && t.status !== 'erledigt' ? COLORS.danger : undefined }}>📅 {t.due_date}</span>
@@ -168,9 +181,11 @@ function TaskCard({
 export default function AufgabenPage() {
   const [tasks, setTasks] = useState<StaffTask[]>([]);
   const [employees, setEmployees] = useState<EmployeeLite[]>([]);
+  const [projects, setProjects] = useState<ProjectLite[]>([]);
   const [loading, setLoading] = useState(true);
   const [filterAssignee, setFilterAssignee] = useState('');
-  const [form, setForm] = useState({ title: '', description: '', assignee_id: '', due_date: '', priority: 'normal' });
+  const [filterProject, setFilterProject] = useState('');
+  const [form, setForm] = useState({ title: '', description: '', assignee_id: '', due_date: '', priority: 'normal', project_id: '' });
   const [saving, setSaving] = useState(false);
   const [selected, setSelected] = useState<StaffTask | null>(null);
 
@@ -179,19 +194,39 @@ export default function AufgabenPage() {
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      const q = filterAssignee ? `?assignee=${encodeURIComponent(filterAssignee)}` : '';
-      const r = await fetch(`/api/admin/tasks${q}`).then((x) => x.json());
+      const q = new URLSearchParams();
+      if (filterAssignee) q.set('assignee', filterAssignee);
+      if (filterProject) q.set('project', filterProject);
+      const r = await fetch(`/api/admin/tasks?${q}`).then((x) => x.json());
       if (r.success) setTasks(r.data);
     } finally {
       setLoading(false);
     }
-  }, [filterAssignee]);
+  }, [filterAssignee, filterProject]);
+
+  const loadProjects = useCallback(async () => {
+    const r = await fetch('/api/admin/projects').then((x) => x.json()).catch(() => null);
+    if (r?.success) setProjects(r.data.map((p: ProjectLite) => ({ id: p.id, name: p.name })));
+  }, []);
 
   useEffect(() => {
     fetch('/api/admin/team').then((r) => r.json()).then((r) => {
       if (r.success) setEmployees(r.data.map((e: EmployeeLite) => ({ id: e.id, name: e.name })));
     }).catch(() => {});
-  }, []);
+    loadProjects();
+  }, [loadProjects]);
+
+  /** "+ Neues Projekt…" in Selects: Name abfragen, anlegen, direkt auswählen. */
+  const newProject = async (): Promise<string> => {
+    const name = (window.prompt('Name des neuen Projekts:') || '').trim();
+    if (!name) return '';
+    const r = await fetch('/api/admin/projects', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name }),
+    }).then((x) => x.json());
+    if (!r.success) { alert(r.error || 'Projekt konnte nicht angelegt werden'); return ''; }
+    await loadProjects();
+    return r.data.id;
+  };
 
   useEffect(() => { load(); }, [load]);
 
@@ -221,9 +256,10 @@ export default function AufgabenPage() {
           assignee_id: form.assignee_id || null,
           due_date: form.due_date || null,
           priority: form.priority,
+          project_id: form.project_id || null,
         }),
       });
-      setForm({ title: '', description: '', assignee_id: '', due_date: '', priority: 'normal' });
+      setForm({ title: '', description: '', assignee_id: '', due_date: '', priority: 'normal', project_id: form.project_id });
       await load();
     } finally {
       setSaving(false);
@@ -289,10 +325,17 @@ export default function AufgabenPage() {
         title="Aufgaben"
         description="Interne Tasks – per Drag & Drop verschieben, zuweisen, mit Fälligkeit und Priorität."
         actions={
-          <SelectInput value={filterAssignee} onChange={(e) => setFilterAssignee(e.target.value)} className="w-48">
-            <option value="">Alle Mitarbeiter</option>
-            {employees.map((e) => <option key={e.id} value={e.id}>{e.name}</option>)}
-          </SelectInput>
+          <div className="flex flex-wrap items-center gap-2">
+            <SelectInput value={filterProject} onChange={(e) => setFilterProject(e.target.value)} className="w-52">
+              <option value="">Alle Projekte</option>
+              <option value="none">Ohne Projekt</option>
+              {projects.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
+            </SelectInput>
+            <SelectInput value={filterAssignee} onChange={(e) => setFilterAssignee(e.target.value)} className="w-48">
+              <option value="">Alle Mitarbeiter</option>
+              {employees.map((e) => <option key={e.id} value={e.id}>{e.name}</option>)}
+            </SelectInput>
+          </div>
         }
       />
 
@@ -311,8 +354,26 @@ export default function AufgabenPage() {
           <Field label="Fällig am">
             <TextInput type="date" value={form.due_date} onChange={(e) => setForm({ ...form, due_date: e.target.value })} />
           </Field>
-          <Field label="Beschreibung" className="sm:col-span-3">
+          <Field label="Beschreibung" className="sm:col-span-2">
             <TextArea rows={2} value={form.description} onChange={(e) => setForm({ ...form, description: e.target.value })} />
+          </Field>
+          <Field label="Projekt">
+            <SelectInput
+              value={form.project_id}
+              onChange={async (e) => {
+                const v = e.target.value;
+                if (v === '__new__') {
+                  const id = await newProject();
+                  setForm((f) => ({ ...f, project_id: id }));
+                } else {
+                  setForm({ ...form, project_id: v });
+                }
+              }}
+            >
+              <option value="">Kein Projekt</option>
+              {projects.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
+              <option value="__new__">＋ Neues Projekt…</option>
+            </SelectInput>
           </Field>
           <Field label="Priorität">
             <SelectInput value={form.priority} onChange={(e) => setForm({ ...form, priority: e.target.value })}>

--- a/src/app/admin/rapporte/page.tsx
+++ b/src/app/admin/rapporte/page.tsx
@@ -20,9 +20,13 @@ interface TimeEntry {
   ticket_number: number | null;
   task_title: string;
   employee_name: string | null;
+  project_id: string | null;
+  project_name: string | null;
   report_number: number | null;
   report_status: 'entwurf' | 'final' | null;
 }
+
+interface ProjectLite { id: string; name: string }
 
 interface Stats { open_count: number; open_minutes: number; reported_count: number; reported_minutes: number }
 
@@ -79,6 +83,8 @@ export default function RapportePage() {
   const [from, setFrom] = useState('');
   const [to, setTo] = useState('');
   const [employee, setEmployee] = useState('');
+  const [project, setProject] = useState('');
+  const [projects, setProjects] = useState<ProjectLite[]>([]);
 
   // Auswahl + Rapport-Anlage
   const [sel, setSel] = useState<Set<string>>(new Set());
@@ -107,6 +113,7 @@ export default function RapportePage() {
       if (from) q.set('from', from);
       if (to) q.set('to', to);
       if (employee) q.set('employee', employee);
+      if (project) q.set('project', project);
       const [re, rr] = await Promise.all([
         fetch(`/api/admin/time-entries?${q}`).then((x) => x.json()),
         fetch('/api/admin/time-reports').then((x) => x.json()),
@@ -116,13 +123,16 @@ export default function RapportePage() {
     } finally {
       setLoading(false);
     }
-  }, [from, to, employee]);
+  }, [from, to, employee, project]);
 
   useEffect(() => { load(); }, [load]);
 
   useEffect(() => {
     fetch('/api/admin/team').then((r) => r.json()).then((r) => {
       if (r.success) setEmployees(r.data.map((e: EmployeeLite) => ({ id: e.id, name: e.name })));
+    }).catch(() => {});
+    fetch('/api/admin/projects').then((r) => r.json()).then((r) => {
+      if (r.success) setProjects(r.data.map((p: ProjectLite) => ({ id: p.id, name: p.name })));
     }).catch(() => {});
   }, []);
 
@@ -360,8 +370,15 @@ export default function RapportePage() {
               {employees.map((e) => <option key={e.id} value={e.id}>{e.name}</option>)}
             </SelectInput>
           </Field>
-          {(from || to || employee) && (
-            <Button size="sm" variant="ghost" onClick={() => { setFrom(''); setTo(''); setEmployee(''); }}>
+          <Field label="Projekt">
+            <SelectInput value={project} onChange={(e) => setProject(e.target.value)} className="w-52">
+              <option value="">Alle</option>
+              <option value="none">Ohne Projekt</option>
+              {projects.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
+            </SelectInput>
+          </Field>
+          {(from || to || employee || project) && (
+            <Button size="sm" variant="ghost" onClick={() => { setFrom(''); setTo(''); setEmployee(''); setProject(''); }}>
               <X className="h-3.5 w-3.5" /> Filter zurücksetzen
             </Button>
           )}
@@ -371,7 +388,7 @@ export default function RapportePage() {
           <div className="flex justify-center py-10"><Spinner /></div>
         ) : openEntries.length === 0 ? (
           <p className="text-sm" style={{ color: COLORS.textMuted }}>
-            Keine offenen Zeiten {from || to || employee ? 'im gewählten Filter' : ''} — alles rapportiert. 🎉
+            Keine offenen Zeiten {from || to || employee || project ? 'im gewählten Filter' : ''} — alles rapportiert. 🎉
           </p>
         ) : (
           <>
@@ -409,6 +426,7 @@ export default function RapportePage() {
                         <td className="py-2 pr-4">
                           <span className="font-semibold whitespace-nowrap" style={{ color: COLORS.navy }}>{ticketNo(e.ticket_number) || '–'}</span>
                           <span className="ml-2 hidden text-xs sm:inline" style={{ color: COLORS.textMuted }}>{e.task_title}</span>
+                          {e.project_name && <div className="text-[11px] font-medium" style={{ color: COLORS.accent }}>🗂 {e.project_name}</div>}
                         </td>
                         {isEdit && editCell ? editCell.emp : (
                           <td className="py-2 pr-4 whitespace-nowrap">{e.employee_name || <span style={{ color: COLORS.textMuted }}>Extern (API)</span>}</td>
@@ -614,6 +632,7 @@ export default function RapportePage() {
                         <td className="py-2 pr-4">
                           <span className="font-semibold whitespace-nowrap" style={{ color: COLORS.navy }}>{ticketNo(e.ticket_number) || '–'}</span>
                           <span className="ml-2 hidden text-xs sm:inline" style={{ color: COLORS.textMuted }}>{e.task_title}</span>
+                          {e.project_name && <div className="text-[11px] font-medium" style={{ color: COLORS.accent }}>🗂 {e.project_name}</div>}
                         </td>
                         {isEdit && editCell ? editCell.emp : (
                           <td className="py-2 pr-4 whitespace-nowrap">{e.employee_name || <span style={{ color: COLORS.textMuted }}>Extern (API)</span>}</td>

--- a/src/app/api/admin/projects/[id]/route.ts
+++ b/src/app/api/admin/projects/[id]/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { updateProject, deleteProject } from '@/lib/staffStore';
+
+/** PATCH { name?, description?, status? (aktiv|archiviert) } */
+export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const body = await req.json().catch(() => ({}));
+  const result = await updateProject(id, body);
+  if (!result) return NextResponse.json({ success: false, error: 'Projekt nicht gefunden' }, { status: 404 });
+  if ('error' in result) return NextResponse.json({ success: false, error: result.error }, { status: 400 });
+  return NextResponse.json({ success: true, data: result });
+}
+
+/** DELETE — Tickets bleiben, ihre Projekt-Zuordnung wird entfernt. */
+export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const ok = await deleteProject(id);
+  if (!ok) return NextResponse.json({ success: false, error: 'Projekt nicht gefunden' }, { status: 404 });
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/admin/projects/route.ts
+++ b/src/app/api/admin/projects/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { listProjects, createProject } from '@/lib/staffStore';
+
+/** GET /api/admin/projects → Projektliste mit Aufgaben-/Zeitsummen. */
+export async function GET() {
+  const projects = await listProjects();
+  return NextResponse.json({ success: true, data: projects });
+}
+
+/** POST /api/admin/projects { name, description? } */
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => ({}));
+  const result = await createProject({ name: String(body?.name || ''), description: body?.description });
+  if ('error' in result) return NextResponse.json({ success: false, error: result.error }, { status: 400 });
+  return NextResponse.json({ success: true, data: result });
+}

--- a/src/app/api/admin/tasks/route.ts
+++ b/src/app/api/admin/tasks/route.ts
@@ -2,13 +2,14 @@ import { NextResponse } from 'next/server';
 import { getSessionEmployee } from '@/lib/serverSession';
 import { listStaffTasks, createStaffTask, addNotification, formatTicketNo } from '@/lib/staffStore';
 
-/** GET ?assignee=<id>&status=<status>&booking=<id> → Aufgabenliste. */
+/** GET ?assignee=<id>&status=<status>&booking=<id>&project=<id|none> → Aufgabenliste. */
 export async function GET(req: Request) {
   const url = new URL(req.url);
   const tasks = await listStaffTasks({
     assignee_id: url.searchParams.get('assignee') || undefined,
     status: url.searchParams.get('status') || undefined,
     booking_id: url.searchParams.get('booking') || undefined,
+    project_id: url.searchParams.get('project') || undefined,
   });
   return NextResponse.json({ success: true, data: tasks });
 }

--- a/src/app/api/admin/time-entries/route.ts
+++ b/src/app/api/admin/time-entries/route.ts
@@ -2,19 +2,20 @@ import { NextResponse } from 'next/server';
 import { listTaskTimeEntries } from '@/lib/staffStore';
 
 /**
- * GET /api/admin/time-entries?from=&to=&employee=&reported=open|reported
+ * GET /api/admin/time-entries?from=&to=&employee=&project=&reported=open|reported
  * → { entries, stats } — Zeitbuchungen über alle Tickets inkl. Rapport-Status.
- * stats werden über den Zeitraum-/Mitarbeiter-Filter berechnet (unabhängig vom reported-Filter),
- * damit die Übersicht "offen vs. rapportiert" immer stimmt.
+ * stats werden über den Zeitraum-/Mitarbeiter-/Projekt-Filter berechnet (unabhängig vom
+ * reported-Filter), damit die Übersicht "offen vs. rapportiert" immer stimmt.
  */
 export async function GET(req: Request) {
   const url = new URL(req.url);
   const from = url.searchParams.get('from') || undefined;
   const to = url.searchParams.get('to') || undefined;
   const employee_id = url.searchParams.get('employee') || undefined;
+  const project_id = url.searchParams.get('project') || undefined;
   const reported = url.searchParams.get('reported');
 
-  const all = await listTaskTimeEntries({ from, to, employee_id });
+  const all = await listTaskTimeEntries({ from, to, employee_id, project_id });
   const open = all.filter((e) => !e.report_id);
   const done = all.filter((e) => e.report_id);
   const entries = reported === 'open' ? open : reported === 'reported' ? done : all;

--- a/src/app/api/admin/time-reports/[id]/pdf/route.ts
+++ b/src/app/api/admin/time-reports/[id]/pdf/route.ts
@@ -152,46 +152,69 @@ async function renderPdf(_req: Request, { params }: { params: Promise<{ id: stri
   }
   y += 4;
 
-  // ─── Positionen, gruppiert nach Ticket ───
-  const groups = new Map<string, { label: string; items: TimeEntryDetail[] }>();
+  // ─── Positionen: Projekt → Ticket → Einträge ───
+  const projectGroups = new Map<string, { label: string; tickets: Map<string, { label: string; items: TimeEntryDetail[] }> }>();
   for (const e of entries) {
-    const key = e.task_id;
-    if (!groups.has(key)) {
-      const ticket = formatTicketNo(e.ticket_number);
-      groups.set(key, { label: `${ticket ? `${ticket} · ` : ''}${e.task_title || 'Ohne Ticket'}`, items: [] });
+    const pKey = e.project_id || '__none__';
+    if (!projectGroups.has(pKey)) {
+      projectGroups.set(pKey, { label: e.project_name || 'Ohne Projekt', tickets: new Map() });
     }
-    groups.get(key)!.items.push(e);
+    const tickets = projectGroups.get(pKey)!.tickets;
+    if (!tickets.has(e.task_id)) {
+      const ticket = formatTicketNo(e.ticket_number);
+      tickets.set(e.task_id, { label: `${ticket ? `${ticket} · ` : ''}${e.task_title || 'Ohne Ticket'}`, items: [] });
+    }
+    tickets.get(e.task_id)!.items.push(e);
   }
+  // Projekt-Ebene nur zeigen, wenn mindestens ein Eintrag einem Projekt zugeordnet ist.
+  const showProjects = [...projectGroups.keys()].some((k) => k !== '__none__');
 
   tableHead();
   doc.setFontSize(9);
 
-  for (const group of groups.values()) {
-    ensureSpace(14);
-    // Gruppenkopf
-    doc.setFillColor(244, 246, 249);
-    doc.rect(M - 2, y - 4, CONTENT_W + 4, 6.5, 'F');
-    doc.setFont('helvetica', 'bold');
-    doc.setTextColor(...NAVY);
-    const groupSum = group.items.reduce((s, e) => s + (e.minutes || 0), 0);
-    doc.text(doc.splitTextToSize(group.label, CONTENT_W - 30)[0], M, y);
-    doc.text(fmtHM(groupSum), COL_TIME_R, y, { align: 'right' });
-    y += 7;
-
-    for (const e of group.items) {
-      const noteLines = doc.splitTextToSize(e.note || '–', NOTE_W);
-      const rowH = Math.max(noteLines.length * 4.2, 4.2) + 2.2;
-      ensureSpace(rowH + 2);
-      doc.setFont('helvetica', 'normal');
-      doc.setTextColor(...NAVY);
-      doc.text(fmtDate(e.work_date), COL_DATE, y);
-      doc.text(employeeLabel(e), COL_EMP, y);
-      doc.text(noteLines, COL_NOTE, y);
+  for (const pg of projectGroups.values()) {
+    if (showProjects) {
+      ensureSpace(16);
+      const pSum = [...pg.tickets.values()].reduce((s, g) => s + g.items.reduce((x, e) => x + (e.minutes || 0), 0), 0);
+      doc.setFillColor(...ORANGE);
+      doc.rect(M - 2, y - 4.2, 2.2, 7, 'F');
       doc.setFont('helvetica', 'bold');
-      doc.text(fmtHM(e.minutes || 0), COL_TIME_R, y, { align: 'right' });
-      y += rowH;
+      doc.setFontSize(10.5);
+      doc.setTextColor(...NAVY);
+      doc.text(doc.splitTextToSize(`Projekt: ${pg.label}`, CONTENT_W - 34)[0], M + 3, y);
+      doc.text(fmtHM(pSum), COL_TIME_R, y, { align: 'right' });
+      doc.setFontSize(9);
+      y += 8;
     }
-    y += 2;
+
+    for (const group of pg.tickets.values()) {
+      ensureSpace(14);
+      // Ticket-Gruppenkopf
+      doc.setFillColor(244, 246, 249);
+      doc.rect(M - 2, y - 4, CONTENT_W + 4, 6.5, 'F');
+      doc.setFont('helvetica', 'bold');
+      doc.setTextColor(...NAVY);
+      const groupSum = group.items.reduce((s, e) => s + (e.minutes || 0), 0);
+      doc.text(doc.splitTextToSize(group.label, CONTENT_W - 30)[0], M, y);
+      doc.text(fmtHM(groupSum), COL_TIME_R, y, { align: 'right' });
+      y += 7;
+
+      for (const e of group.items) {
+        const noteLines = doc.splitTextToSize(e.note || '–', NOTE_W);
+        const rowH = Math.max(noteLines.length * 4.2, 4.2) + 2.2;
+        ensureSpace(rowH + 2);
+        doc.setFont('helvetica', 'normal');
+        doc.setTextColor(...NAVY);
+        doc.text(fmtDate(e.work_date), COL_DATE, y);
+        doc.text(employeeLabel(e), COL_EMP, y);
+        doc.text(noteLines, COL_NOTE, y);
+        doc.setFont('helvetica', 'bold');
+        doc.text(fmtHM(e.minutes || 0), COL_TIME_R, y, { align: 'right' });
+        y += rowH;
+      }
+      y += 2;
+    }
+    if (showProjects) y += 3;
   }
 
   // ─── Summen ───

--- a/src/app/api/ext/projects/route.ts
+++ b/src/app/api/ext/projects/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { apiKeyOr401 } from '@/lib/extAuth';
+import { listProjects, createProject } from '@/lib/staffStore';
+
+/** GET /api/ext/projects → Projektliste (API-Key-Auth). */
+export async function GET(req: Request) {
+  const a = await apiKeyOr401(req); if ('res' in a) return a.res;
+  const projects = await listProjects();
+  return NextResponse.json({ success: true, data: projects });
+}
+
+/** POST /api/ext/projects { name, description? } — legt ein Projekt an (idempotent per Name: 400 bei Duplikat). */
+export async function POST(req: Request) {
+  const a = await apiKeyOr401(req); if ('res' in a) return a.res;
+  const body = await req.json().catch(() => ({}));
+  const result = await createProject({ name: String(body?.name || ''), description: body?.description });
+  if ('error' in result) return NextResponse.json({ success: false, error: result.error }, { status: 400 });
+  return NextResponse.json({ success: true, data: result });
+}

--- a/src/app/api/ext/tasks/route.ts
+++ b/src/app/api/ext/tasks/route.ts
@@ -4,7 +4,7 @@ import { listStaffTasks, createStaffTask, formatTicketNo, type StaffTask } from 
 
 const withTicket = (t: StaffTask) => ({ ...t, ticket_no: formatTicketNo(t.ticket_number) });
 
-/** GET /api/ext/tasks?status=&assignee=&booking= → Ticket-Liste. */
+/** GET /api/ext/tasks?status=&assignee=&booking=&project= → Ticket-Liste. */
 export async function GET(req: Request) {
   const a = await apiKeyOr401(req); if ('res' in a) return a.res;
   const url = new URL(req.url);
@@ -12,11 +12,12 @@ export async function GET(req: Request) {
     status: url.searchParams.get('status') || undefined,
     assignee_id: url.searchParams.get('assignee') || undefined,
     booking_id: url.searchParams.get('booking') || undefined,
+    project_id: url.searchParams.get('project') || undefined,
   });
   return NextResponse.json({ success: true, data: tasks.map(withTicket) });
 }
 
-/** POST /api/ext/tasks { title, description?, priority?, due_date?, assignee_id?, booking_id? } */
+/** POST /api/ext/tasks { title, description?, priority?, due_date?, assignee_id?, booking_id?, project_id? } */
 export async function POST(req: Request) {
   const a = await apiKeyOr401(req); if ('res' in a) return a.res;
   const body = await req.json().catch(() => ({}));
@@ -28,6 +29,7 @@ export async function POST(req: Request) {
     due_date: body.due_date || null,
     assignee_id: body.assignee_id || null,
     booking_id: body.booking_id || null,
+    project_id: body.project_id || null,
     created_by: `API: ${a.key.name}`,
   });
   return NextResponse.json({ success: true, data: withTicket(task) });

--- a/src/components/admin/TaskDrawer.tsx
+++ b/src/components/admin/TaskDrawer.tsx
@@ -18,7 +18,10 @@ interface Task {
   booking_id?: string | null;
   created_by?: string | null;
   created_at?: string;
+  project_id?: string | null;
 }
+
+interface ProjectLite { id: string; name: string }
 interface Subtask { id: string; title: string; done: number }
 interface Att { id: string; filename: string; mime: string; size: number }
 interface TimeEntry { id: string; minutes: number; note: string; work_date?: string; report_id?: string | null; report_number?: number | null }
@@ -52,6 +55,8 @@ export default function TaskDrawer({ task, onClose, onChanged }: { task: Task; o
   const [desc, setDesc] = useState(task.description || '');
   const [savingDesc, setSavingDesc] = useState(false);
   const [status, setStatus] = useState<TaskStatus>(task.status);
+  const [projectId, setProjectId] = useState<string>(task.project_id || '');
+  const [projects, setProjects] = useState<ProjectLite[]>([]);
   const [subs, setSubs] = useState<Subtask[]>([]);
   const [newSub, setNewSub] = useState('');
   const [loading, setLoading] = useState(true);
@@ -92,6 +97,13 @@ export default function TaskDrawer({ task, onClose, onChanged }: { task: Task; o
   };
   useEffect(() => { loadSubs(); loadAtts(); loadTimes(); loadMsgs(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [task.id]);
 
+  useEffect(() => {
+    setProjectId(task.project_id || '');
+    fetch('/api/admin/projects').then((r) => r.json()).then((r) => {
+      if (r.success) setProjects(r.data.map((p: ProjectLite) => ({ id: p.id, name: p.name })));
+    }).catch(() => {});
+  }, [task.id, task.project_id]);
+
   // Mitarbeiter laden + Standard-Empfänger vorbelegen: Ticket-Ersteller > Assignee > erster aktiver.
   useEffect(() => {
     fetch('/api/admin/team').then((r) => r.json()).then((r) => {
@@ -111,6 +123,14 @@ export default function TaskDrawer({ task, onClose, onChanged }: { task: Task; o
     setStatus(s);
     await fetch(`/api/admin/tasks/${task.id}`, {
       method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ status: s }),
+    }).catch(() => {});
+    onChanged?.();
+  };
+
+  const changeProject = async (p: string) => {
+    setProjectId(p);
+    await fetch(`/api/admin/tasks/${task.id}`, {
+      method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ project_id: p || null }),
     }).catch(() => {});
     onChanged?.();
   };
@@ -216,6 +236,16 @@ export default function TaskDrawer({ task, onClose, onChanged }: { task: Task; o
             {(Object.keys(STATUS_LABEL) as TaskStatus[]).map((s) => (
               <option key={s} value={s}>{STATUS_LABEL[s]}</option>
             ))}
+          </select>
+          <select
+            value={projectId}
+            onChange={(e) => changeProject(e.target.value)}
+            className="rounded-lg border px-2 py-1 text-xs font-medium focus:outline-none"
+            style={{ borderColor: COLORS.stroke, color: COLORS.navy }}
+            title="Projekt zuordnen"
+          >
+            <option value="">🗂 Kein Projekt</option>
+            {projects.map((p) => <option key={p.id} value={p.id}>🗂 {p.name}</option>)}
           </select>
           <Badge tone={PRIO_TONE[task.priority]}>{task.priority}</Badge>
           {task.due_date && <span className="text-xs" style={{ color: COLORS.textMuted }}>📅 {task.due_date}</span>}

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -333,6 +333,14 @@ export function initDatabase() {
       finalized_at TEXT
     );
 
+    CREATE TABLE IF NOT EXISTS projects (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      description TEXT NOT NULL DEFAULT '',
+      status TEXT NOT NULL DEFAULT 'aktiv' CHECK(status IN ('aktiv','archiviert')),
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
     CREATE TABLE IF NOT EXISTS task_messages (
       id TEXT PRIMARY KEY,
       task_id TEXT NOT NULL,
@@ -495,6 +503,8 @@ export function initDatabase() {
   const ttcols = sqlite.prepare(`PRAGMA table_info(task_time)`).all() as Array<{ name: string }>;
   if (ttcols.length && !ttcols.some((c) => c.name === 'work_date')) addColumn('task_time', "work_date TEXT NOT NULL DEFAULT ''");
   if (ttcols.length && !ttcols.some((c) => c.name === 'report_id')) addColumn('task_time', 'report_id TEXT');
+  const stcols2 = sqlite.prepare(`PRAGMA table_info(staff_tasks)`).all() as Array<{ name: string }>;
+  if (stcols2.length && !stcols2.some((c) => c.name === 'project_id')) addColumn('staff_tasks', 'project_id TEXT');
   // Backfill: bestehende Tasks ohne Nummer fortlaufend ab 10 nummerieren (nach Erstellzeit).
   try {
     const missing = sqlite.prepare(`SELECT id FROM staff_tasks WHERE ticket_number IS NULL ORDER BY created_at, id`).all() as Array<{ id: string }>;

--- a/src/lib/dbq.ts
+++ b/src/lib/dbq.ts
@@ -299,6 +299,16 @@ export async function applyPgSchemaEnhancements(): Promise<void> {
         finalized_at text
       )`);
 
+      // Projekte (Zuordnung von Tickets/Zeiten für Rapporte und Übersichten)
+      await pool.query(`CREATE TABLE IF NOT EXISTS projects (
+        id text PRIMARY KEY,
+        name text NOT NULL,
+        description text NOT NULL DEFAULT '',
+        status text NOT NULL DEFAULT 'aktiv',
+        created_at timestamptz NOT NULL DEFAULT now()
+      )`);
+      await pool.query(`ALTER TABLE staff_tasks ADD COLUMN IF NOT EXISTS project_id text`);
+
       // Ticket-System: fortlaufende Ticketnummer + Mail-Verlauf
       await pool.query(`ALTER TABLE staff_tasks ADD COLUMN IF NOT EXISTS ticket_number integer`);
       await pool.query(`CREATE TABLE IF NOT EXISTS task_messages (

--- a/src/lib/staffStore.ts
+++ b/src/lib/staffStore.ts
@@ -388,6 +388,9 @@ export interface StaffTask {
   priority: 'niedrig' | 'normal' | 'hoch';
   status: TaskStatus;
   created_by: string | null;
+  project_id: string | null;
+  /** Aus dem Join in listStaffTasks (LEFT JOIN projects). */
+  project_name?: string | null;
 }
 
 /** Formatiert die fortlaufende Ticketnummer, z.B. 10 → "TASK-00010". */
@@ -403,11 +406,12 @@ export async function createStaffTask(input: Partial<StaffTask> & { title: strin
     const row = await q.get<{ n: number }>(`SELECT COALESCE(MAX(ticket_number), 9) + 1 AS n FROM staff_tasks`);
     const next = row?.n ?? 10;
     await q.run(`
-      INSERT INTO staff_tasks (id, ticket_number, title, description, assignee_id, booking_id, due_date, priority, status, created_by)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO staff_tasks (id, ticket_number, title, description, assignee_id, booking_id, due_date, priority, status, created_by, project_id)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `, [id, next, input.title, input.description || '', input.assignee_id || null,
       input.booking_id || null, input.due_date || null,
-      input.priority || 'normal', input.status || 'offen', input.created_by || null]);
+      input.priority || 'normal', input.status || 'offen', input.created_by || null,
+      input.project_id || null]);
   });
   return (await dbGet<StaffTask>('SELECT * FROM staff_tasks WHERE id = ?', [id]))!;
 }
@@ -423,14 +427,15 @@ export async function updateStaffTask(id: string, u: Partial<StaffTask>): Promis
   await dbRun(`
     UPDATE staff_tasks SET
       title = ?, description = ?, assignee_id = ?, booking_id = ?, due_date = ?,
-      priority = ?, status = ?, updated_at = datetime('now')
+      priority = ?, status = ?, project_id = ?, updated_at = datetime('now')
     WHERE id = ?
   `, [
     u.title ?? cur.title, u.description ?? cur.description,
     u.assignee_id !== undefined ? u.assignee_id : cur.assignee_id,
     u.booking_id !== undefined ? u.booking_id : cur.booking_id,
     u.due_date !== undefined ? u.due_date : cur.due_date,
-    u.priority ?? cur.priority, u.status ?? cur.status, id,
+    u.priority ?? cur.priority, u.status ?? cur.status,
+    u.project_id !== undefined ? u.project_id : cur.project_id, id,
   ]);
   return (await dbGet<StaffTask>('SELECT * FROM staff_tasks WHERE id = ?', [id])) ?? null;
 }
@@ -443,14 +448,20 @@ export async function deleteStaffTask(id: string): Promise<boolean> {
   return (await dbRun('DELETE FROM staff_tasks WHERE id = ?', [id])).changes > 0;
 }
 
-export async function listStaffTasks(filter?: { assignee_id?: string; status?: string; booking_id?: string }): Promise<StaffTask[]> {
+export async function listStaffTasks(filter?: { assignee_id?: string; status?: string; booking_id?: string; project_id?: string }): Promise<StaffTask[]> {
   const where: string[] = [];
   const params: string[] = [];
-  if (filter?.assignee_id) { where.push('assignee_id = ?'); params.push(filter.assignee_id); }
-  if (filter?.status) { where.push('status = ?'); params.push(filter.status); }
-  if (filter?.booking_id) { where.push('booking_id = ?'); params.push(filter.booking_id); }
-  const sql = `SELECT * FROM staff_tasks ${where.length ? 'WHERE ' + where.join(' AND ') : ''}
-    ORDER BY CASE status WHEN 'erledigt' THEN 1 ELSE 0 END, due_date IS NULL, due_date, created_at DESC`;
+  if (filter?.assignee_id) { where.push('t.assignee_id = ?'); params.push(filter.assignee_id); }
+  if (filter?.status) { where.push('t.status = ?'); params.push(filter.status); }
+  if (filter?.booking_id) { where.push('t.booking_id = ?'); params.push(filter.booking_id); }
+  if (filter?.project_id) {
+    if (filter.project_id === 'none') where.push('t.project_id IS NULL');
+    else { where.push('t.project_id = ?'); params.push(filter.project_id); }
+  }
+  const sql = `SELECT t.*, p.name AS project_name
+    FROM staff_tasks t LEFT JOIN projects p ON p.id = t.project_id
+    ${where.length ? 'WHERE ' + where.join(' AND ') : ''}
+    ORDER BY CASE t.status WHEN 'erledigt' THEN 1 ELSE 0 END, t.due_date IS NULL, t.due_date, t.created_at DESC`;
   return dbAll<StaffTask>(sql, params);
 }
 
@@ -590,6 +601,66 @@ export async function updateTaskTime(
   });
 }
 
+// ==================== PROJEKTE (Zuordnung von Tickets/Zeiten) ====================
+
+export interface Project {
+  id: string;
+  name: string;
+  description: string;
+  status: 'aktiv' | 'archiviert';
+  created_at: string;
+}
+
+export interface ProjectSummary extends Project {
+  task_count: number;
+  total_minutes: number;
+}
+
+export async function listProjects(): Promise<ProjectSummary[]> {
+  return dbAll<ProjectSummary>(`
+    SELECT p.*, COUNT(DISTINCT s.id) AS task_count, COALESCE(SUM(t.minutes), 0) AS total_minutes
+    FROM projects p
+    LEFT JOIN staff_tasks s ON s.project_id = p.id
+    LEFT JOIN task_time t ON t.task_id = s.id
+    GROUP BY p.id
+    ORDER BY lower(p.name)
+  `);
+}
+
+export async function getProject(id: string): Promise<Project | null> {
+  return (await dbGet<Project>('SELECT * FROM projects WHERE id = ?', [id])) ?? null;
+}
+
+export async function createProject(input: { name: string; description?: string }): Promise<Project | { error: string }> {
+  const name = (input.name || '').trim();
+  if (!name) return { error: 'Projektname erforderlich' };
+  const existing = await dbGet<Project>('SELECT * FROM projects WHERE lower(name) = lower(?)', [name]);
+  if (existing) return { error: `Projekt "${existing.name}" existiert bereits` };
+  const id = crypto.randomUUID();
+  await dbRun('INSERT INTO projects (id, name, description) VALUES (?, ?, ?)', [id, name, (input.description || '').trim()]);
+  return (await dbGet<Project>('SELECT * FROM projects WHERE id = ?', [id]))!;
+}
+
+export async function updateProject(id: string, u: { name?: string; description?: string; status?: string }): Promise<Project | { error: string } | null> {
+  const cur = await getProject(id);
+  if (!cur) return null;
+  const name = u.name !== undefined ? String(u.name).trim() : cur.name;
+  if (!name) return { error: 'Projektname erforderlich' };
+  const status = u.status !== undefined ? String(u.status) : cur.status;
+  if (!['aktiv', 'archiviert'].includes(status)) return { error: 'Ungültiger Status' };
+  await dbRun('UPDATE projects SET name = ?, description = ?, status = ? WHERE id = ?',
+    [name, u.description !== undefined ? String(u.description) : cur.description, status, id]);
+  return getProject(id);
+}
+
+/** Projekt löschen — zugeordnete Tickets bleiben bestehen (Zuordnung wird entfernt). */
+export async function deleteProject(id: string): Promise<boolean> {
+  return withTx(async (q) => {
+    await q.run('UPDATE staff_tasks SET project_id = NULL WHERE project_id = ?', [id]);
+    return (await q.run('DELETE FROM projects WHERE id = ?', [id])).changes > 0;
+  });
+}
+
 // ==================== ZEIT-RAPPORTE (abrechenbare Zeiten) ====================
 
 export type TimeReportStatus = 'entwurf' | 'final';
@@ -619,6 +690,8 @@ export interface TimeEntryDetail extends TaskTimeEntry {
   ticket_number: number | null;
   task_title: string;
   employee_name: string | null;
+  project_id: string | null;
+  project_name: string | null;
 }
 
 export function formatReportNo(n?: number | null): string {
@@ -627,20 +700,26 @@ export function formatReportNo(n?: number | null): string {
 
 const TIME_ENTRY_DETAIL_SQL = `
   SELECT t.*, s.ticket_number AS ticket_number, s.title AS task_title,
+         s.project_id AS project_id, p.name AS project_name,
          e.name AS employee_name, r.report_number AS report_number, r.status AS report_status
   FROM task_time t
   LEFT JOIN staff_tasks s ON s.id = t.task_id
+  LEFT JOIN projects p ON p.id = s.project_id
   LEFT JOIN employees e ON e.id = t.employee_id
   LEFT JOIN time_reports r ON r.id = t.report_id
 `;
 
-/** Alle Ticket-Zeitbuchungen (über alle Tickets), filterbar nach Zeitraum/Mitarbeiter/Rapport-Status. */
-export async function listTaskTimeEntries(f: { from?: string; to?: string; employee_id?: string; reported?: 'open' | 'reported' } = {}): Promise<TimeEntryDetail[]> {
+/** Alle Ticket-Zeitbuchungen (über alle Tickets), filterbar nach Zeitraum/Mitarbeiter/Projekt/Rapport-Status. */
+export async function listTaskTimeEntries(f: { from?: string; to?: string; employee_id?: string; project_id?: string; reported?: 'open' | 'reported' } = {}): Promise<TimeEntryDetail[]> {
   const where: string[] = [];
   const params: unknown[] = [];
   if (f.from) { where.push('t.work_date >= ?'); params.push(f.from); }
   if (f.to) { where.push('t.work_date <= ?'); params.push(f.to); }
   if (f.employee_id) { where.push('t.employee_id = ?'); params.push(f.employee_id); }
+  if (f.project_id) {
+    if (f.project_id === 'none') where.push('s.project_id IS NULL');
+    else { where.push('s.project_id = ?'); params.push(f.project_id); }
+  }
   if (f.reported === 'open') where.push('t.report_id IS NULL');
   if (f.reported === 'reported') where.push('t.report_id IS NOT NULL');
   return dbAll<TimeEntryDetail>(


### PR DESCRIPTION
## Was ist neu (TASK-00038)
**Projekte** als Klammer über Tickets und Zeiten:

- **Aufgaben:** Projekt-Auswahl direkt im Anlegen-Formular (inkl. `＋ Neues Projekt…`), Projekt-Filter in der Kopfzeile, Projekt-Chip auf den Board-Karten, Projekt-Zuordnung im Ticket-Drawer änderbar
- **Zeit-Rapporte:** Projekt-Filter für offene Zeiten, Projekt an jedem Eintrag sichtbar, **PDF gruppiert nach Projekt → Ticket** mit Projekt-Zwischensummen (Projekt-Ebene erscheint nur, wenn Zuordnungen existieren)
- **ext API** (für KI-Sessions): `GET/POST /api/ext/projects`, `project_id` beim Ticket-Anlegen, `?project=`-Filter

## Technik
- Tabelle `projects` + `staff_tasks.project_id`, idempotente Migrationen für SQLite und Postgres
- Projekt-Löschen entfernt nur die Zuordnung (Tickets/Zeiten bleiben)

## Verifikation
- `tsc --noEmit` ✅, `npm run build` ✅ (Routen registriert)
- 7/7 Offline-SQL-Tests (Aggregate ohne Join-Fanout, Filter inkl. 'none', Duplikat-Schutz, Lösch-Semantik)
- PDF-Harness mit echtem jsPDF: Projekt-Header, „Ohne Projekt"-Gruppe, Ticket-Gruppen und Summen vorhanden

Nächster Schritt (separat, nach Deploy): historischer Backfill aller Commits/PRs als Tasks mit Zeitlogs; Arbeit vor 01.07. → Projekt „Initiale Entwicklung Project NEXT FT".

🤖 Generated with [Claude Code](https://claude.com/claude-code)