### PR TITLE
feat(aufgaben): Ticket-Vollansicht + Mail-Benachrichtigung an Beteiligte

### DIFF
--- a/src/app/admin/aufgaben/[id]/page.tsx
+++ b/src/app/admin/aufgaben/[id]/page.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import AdminShell from '@/components/admin/AdminShell';
+import TaskDrawer from '@/components/admin/TaskDrawer';
+import { Card, Spinner, COLORS } from '@/components/admin/ui';
+import { ArrowLeft } from 'lucide-react';
+
+type TaskStatus = 'offen' | 'in_arbeit' | 'warten_requester' | 'warten_dritte' | 'erledigt';
+
+interface Task {
+  id: string;
+  ticket_number?: number | null;
+  title: string;
+  description: string;
+  status: TaskStatus;
+  priority: 'niedrig' | 'normal' | 'hoch';
+  due_date: string | null;
+  assignee_id?: string | null;
+  booking_id?: string | null;
+  created_by?: string | null;
+  created_at?: string;
+  project_id?: string | null;
+  project_name?: string | null;
+}
+
+/** Ticket-Vollansicht: /admin/aufgaben/[id] — großes, zweispaltiges Arbeits-Layout. */
+export default function TicketPage() {
+  const params = useParams<{ id: string }>();
+  const id = params?.id;
+  const [task, setTask] = useState<Task | null>(null);
+  const [err, setErr] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    if (!id) return;
+    try {
+      const r = await fetch(`/api/admin/tasks/${id}`).then((x) => x.json());
+      if (r.success) { setTask(r.data); setErr(''); }
+      else setErr(r.error || 'Ticket nicht gefunden');
+    } catch {
+      setErr('Ticket konnte nicht geladen werden');
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => { load(); }, [load]);
+
+  return (
+    <AdminShell title="Ticket" wide>
+      <div className="mb-4">
+        <Link href="/admin/aufgaben" className="inline-flex items-center gap-1.5 text-sm font-semibold hover:underline" style={{ color: COLORS.textMuted }}>
+          <ArrowLeft className="h-4 w-4" /> Zurück zum Aufgaben-Board
+        </Link>
+      </div>
+      {loading ? (
+        <div className="flex justify-center py-16"><Spinner /></div>
+      ) : err || !task ? (
+        <Card><span className="text-sm font-semibold" style={{ color: COLORS.danger }}>{err || 'Ticket nicht gefunden'}</span></Card>
+      ) : (
+        <TaskDrawer task={task} variant="page" onClose={() => {}} onChanged={load} />
+      )}
+    </AdminShell>
+  );
+}

--- a/src/app/admin/aufgaben/page.tsx
+++ b/src/app/admin/aufgaben/page.tsx
@@ -110,9 +110,17 @@ function TaskCard({
             >
               <GripVertical className="h-4 w-4" style={{ color: COLORS.textMuted }} />
             </span>
-            <div className="min-w-0 cursor-pointer" onClick={() => onOpen(t)} title="Details öffnen">
+            <div className="min-w-0 cursor-pointer" onClick={() => onOpen(t)} title="Vorschau öffnen">
               {ticketNo(t.ticket_number) && (
-                <span className="mb-0.5 inline-block font-mono text-[10px] font-bold tracking-wide" style={{ color: COLORS.accent }}>{ticketNo(t.ticket_number)}</span>
+                <Link
+                  href={`/admin/aufgaben/${t.id}`}
+                  onClick={(e) => e.stopPropagation()}
+                  className="mb-0.5 inline-block font-mono text-[10px] font-bold tracking-wide hover:underline"
+                  style={{ color: COLORS.accent }}
+                  title="In Vollansicht öffnen"
+                >
+                  {ticketNo(t.ticket_number)}
+                </Link>
               )}
               <div className="font-semibold" style={{ color: COLORS.navy }}>{t.title}</div>
               {t.description && (

--- a/src/app/api/admin/tasks/[id]/route.ts
+++ b/src/app/api/admin/tasks/[id]/route.ts
@@ -5,6 +5,14 @@ import {
 } from '@/lib/staffStore';
 import { getSessionEmployee } from '@/lib/serverSession';
 
+/** GET → einzelnes Ticket (inkl. Projekt-Name) für die Vollansicht. */
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const task = await getStaffTask(id);
+  if (!task) return NextResponse.json({ success: false, error: 'Aufgabe nicht gefunden' }, { status: 404 });
+  return NextResponse.json({ success: true, data: task });
+}
+
 export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const body = await req.json();

--- a/src/app/api/ext/tasks/[id]/messages/route.ts
+++ b/src/app/api/ext/tasks/[id]/messages/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { apiKeyOr401 } from '@/lib/extAuth';
-import { getStaffTask, listTaskMessages, addTaskMessage, formatTicketNo } from '@/lib/staffStore';
+import { getStaffTask, listTaskMessages, addTaskMessage, formatTicketNo, notifyTaskParticipants } from '@/lib/staffStore';
 import { sendGraphMail, isGraphConfigured, getMailbox, getFromName } from '@/lib/graphMailer';
 import { taskEmailHtml, taskSubjectTag } from '@/lib/emailTemplates';
 
@@ -28,6 +28,8 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
 
   if (kind === 'note') {
     const saved = await addTaskMessage({ task_id: id, direction: 'note', from_email: agentName, body: text, created_by: agentName });
+    // Beteiligte informieren (Glocke + E-Mail) — wie bei Notizen aus dem Admin.
+    await notifyTaskParticipants(task, { type: 'task_note', body: text, actorName: agentName }).catch(() => {});
     return NextResponse.json({ success: true, data: saved });
   }
 

--- a/src/components/admin/TaskDrawer.tsx
+++ b/src/components/admin/TaskDrawer.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { useEffect, useState, useRef } from 'react';
-import { X, Plus, Trash2, Check, Paperclip, Download, Clock, Mail, Send, StickyNote, ArrowDownLeft, ArrowUpRight } from 'lucide-react';
-import { Button, TextArea, Spinner, Badge, COLORS } from './ui';
+import Link from 'next/link';
+import { X, Plus, Trash2, Check, Paperclip, Download, Clock, Mail, Send, StickyNote, ArrowDownLeft, ArrowUpRight, Maximize2 } from 'lucide-react';
+import { Button, TextArea, Spinner, Badge, Card, COLORS } from './ui';
 
 type TaskStatus = 'offen' | 'in_arbeit' | 'warten_requester' | 'warten_dritte' | 'erledigt';
 
@@ -51,7 +52,17 @@ function todayISO(): string {
   return new Intl.DateTimeFormat('sv-SE', { timeZone: 'Europe/Zurich' }).format(new Date());
 }
 
-export default function TaskDrawer({ task, onClose, onChanged }: { task: Task; onClose: () => void; onChanged?: () => void }) {
+/**
+ * Ticket-Detail — zwei Darstellungen:
+ * variant="drawer" (Default): Vorschau als Seitenleiste über dem Board.
+ * variant="page": Vollansicht (zweispaltig) für /admin/aufgaben/[id].
+ */
+export default function TaskDrawer({ task, onClose, onChanged, variant = 'drawer' }: {
+  task: Task;
+  onClose: () => void;
+  onChanged?: () => void;
+  variant?: 'drawer' | 'page';
+}) {
   const [desc, setDesc] = useState(task.description || '');
   const [savingDesc, setSavingDesc] = useState(false);
   const [status, setStatus] = useState<TaskStatus>(task.status);
@@ -208,23 +219,31 @@ export default function TaskDrawer({ task, onClose, onChanged }: { task: Task; o
   const doneCount = subs.filter((s) => s.done).length;
   const pct = subs.length ? Math.round((doneCount / subs.length) * 100) : 0;
 
-  return (
-    <div className="fixed inset-0 z-50 flex justify-end" style={{ background: 'rgba(0,0,0,0.35)' }} onClick={onClose}>
-      <div className="h-full w-full max-w-md overflow-y-auto bg-white p-6 shadow-2xl" onClick={(e) => e.stopPropagation()}>
-        <div className="mb-4 flex items-start justify-between gap-3">
-          <div className="min-w-0">
-            {ticketNo(task.ticket_number) && (
-              <span className="mb-1 inline-block rounded px-1.5 py-0.5 font-mono text-[11px] font-bold tracking-wide" style={{ background: COLORS.surfaceMuted, color: COLORS.accent }}>
-                {ticketNo(task.ticket_number)}
-              </span>
-            )}
-            <h2 className="text-lg font-bold" style={{ color: COLORS.navy }}>{task.title}</h2>
-          </div>
+  const headerEl = (
+    <div className="mb-4 flex items-start justify-between gap-3">
+      <div className="min-w-0">
+        {ticketNo(task.ticket_number) && (
+          <span className="mb-1 inline-block rounded px-1.5 py-0.5 font-mono text-[11px] font-bold tracking-wide" style={{ background: COLORS.surfaceMuted, color: COLORS.accent }}>
+            {ticketNo(task.ticket_number)}
+          </span>
+        )}
+        <h2 className={variant === 'page' ? 'text-2xl font-bold' : 'text-lg font-bold'} style={{ color: COLORS.navy }}>{task.title}</h2>
+      </div>
+      {variant === 'drawer' && (
+        <div className="flex shrink-0 items-center gap-1">
+          <Link href={`/admin/aufgaben/${task.id}`} className="rounded-lg p-1 transition hover:bg-gray-100" title="In Vollansicht öffnen">
+            <Maximize2 className="h-5 w-5" style={{ color: COLORS.textMuted }} />
+          </Link>
           <button onClick={onClose} className="rounded-lg p-1 transition hover:bg-gray-100" title="Schließen">
             <X className="h-5 w-5" style={{ color: COLORS.textMuted }} />
           </button>
         </div>
+      )}
+    </div>
+  );
 
+  const metaEl = (
+    <>
         <div className="mb-2 flex flex-wrap items-center gap-2">
           <select
             value={status}
@@ -251,13 +270,15 @@ export default function TaskDrawer({ task, onClose, onChanged }: { task: Task; o
           {task.due_date && <span className="text-xs" style={{ color: COLORS.textMuted }}>📅 {task.due_date}</span>}
         </div>
         {(task.created_by || task.created_at) && (
-          <p className="mb-6 text-xs" style={{ color: COLORS.textMuted }}>
+          <p className="mt-1 text-xs" style={{ color: COLORS.textMuted }}>
             Erstellt{task.created_by ? ` von ${task.created_by}` : ''}{task.created_at ? ` am ${task.created_at.slice(0, 10)}` : ''}
           </p>
         )}
+    </>
+  );
 
-        {/* Beschreibung */}
-        <div className="mb-6">
+  const descEl = (
+        <div>
           <label className="mb-1 block text-xs font-semibold" style={{ color: COLORS.textMuted }}>Beschreibung</label>
           <TextArea rows={Math.min(16, Math.max(4, desc.split('\n').length + 1))} value={desc} onChange={(e) => setDesc(e.target.value)} placeholder="Notizen, Kontext, Links…" />
           <div className="mt-2">
@@ -266,8 +287,9 @@ export default function TaskDrawer({ task, onClose, onChanged }: { task: Task; o
             </Button>
           </div>
         </div>
+  );
 
-        {/* Subtasks */}
+  const subsEl = (
         <div>
           <div className="mb-2 flex items-center justify-between">
             <label className="text-xs font-semibold" style={{ color: COLORS.textMuted }}>Subtasks</label>
@@ -311,9 +333,10 @@ export default function TaskDrawer({ task, onClose, onChanged }: { task: Task; o
             <Button size="sm" variant="ghost" onClick={addSub} disabled={!newSub.trim()}><Plus className="h-4 w-4" /></Button>
           </div>
         </div>
+  );
 
-        {/* Datei-Anhänge */}
-        <div className="mt-6">
+  const attsEl = (
+        <div>
           <label className="mb-2 block text-xs font-semibold" style={{ color: COLORS.textMuted }}>Dateien</label>
           <input ref={fileRef} type="file" className="hidden" onChange={(e) => { const f = e.target.files?.[0]; e.target.value = ''; if (f) onUpload(f); }} />
           <Button size="sm" variant="secondary" onClick={() => fileRef.current?.click()} disabled={uploading}>
@@ -333,9 +356,10 @@ export default function TaskDrawer({ task, onClose, onChanged }: { task: Task; o
             </div>
           )}
         </div>
+  );
 
-        {/* Zeit */}
-        <div className="mt-6">
+  const timeEl = (
+        <div>
           <div className="mb-2 flex items-center justify-between">
             <label className="text-xs font-semibold" style={{ color: COLORS.textMuted }}>Zeit</label>
             <span className="text-xs font-bold tabular-nums" style={{ color: COLORS.navy }}>{fmtMin(totalMin)} gebucht</span>
@@ -366,9 +390,10 @@ export default function TaskDrawer({ task, onClose, onChanged }: { task: Task; o
             </div>
           )}
         </div>
+  );
 
-        {/* Mails & Verlauf */}
-        <div className="mt-6">
+  const msgEl = (
+        <div>
           <label className="mb-2 block text-xs font-semibold" style={{ color: COLORS.textMuted }}>Mails & Verlauf</label>
 
           {/* Verlauf */}
@@ -425,6 +450,40 @@ export default function TaskDrawer({ task, onClose, onChanged }: { task: Task; o
             </Button>
           </div>
         </div>
+  );
+
+  // ── Vollansicht: zweispaltiges Seiten-Layout (Verlauf links, Meta rechts) ──
+  if (variant === 'page') {
+    return (
+      <div className="grid items-start gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
+        <div className="min-w-0 space-y-6">
+          <Card>
+            {headerEl}
+            {metaEl}
+          </Card>
+          <Card>{descEl}</Card>
+          <Card>{msgEl}</Card>
+        </div>
+        <div className="min-w-0 space-y-6">
+          <Card>{subsEl}</Card>
+          <Card>{attsEl}</Card>
+          <Card>{timeEl}</Card>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Drawer: Vorschau in der Seitenleiste über dem Board ──
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end" style={{ background: 'rgba(0,0,0,0.35)' }} onClick={onClose}>
+      <div className="h-full w-full max-w-md overflow-y-auto bg-white p-6 shadow-2xl" onClick={(e) => e.stopPropagation()}>
+        {headerEl}
+        {metaEl}
+        <div className="mt-4">{descEl}</div>
+        <div className="mt-6">{subsEl}</div>
+        <div className="mt-6">{attsEl}</div>
+        <div className="mt-6">{timeEl}</div>
+        <div className="mt-6">{msgEl}</div>
       </div>
     </div>
   );

--- a/src/lib/emailTemplates.ts
+++ b/src/lib/emailTemplates.ts
@@ -444,6 +444,37 @@ export interface TaskEmailInput {
   agentName?: string;
 }
 
+export interface TaskNotifyEmailInput {
+  bodyText: string;
+  ticketNo: string;       // z.B. "TASK-00010"
+  taskTitle?: string;
+  actorName?: string;
+  kindLabel: string;      // z.B. "Neue Notiz" | "Neue Antwort"
+  ticketUrl: string;      // Vollansicht des Tickets
+}
+
+/**
+ * Interne Benachrichtigungs-Mail an Ticket-Beteiligte (Assignee, Ersteller,
+ * @Erwähnte) bei neuen Notizen/Antworten — mit Button zur Ticket-Vollansicht.
+ * Ticketnummer im Betreff sorgt dafür, dass Antworten am Ticket landen.
+ */
+export function taskNotifyEmailHtml(input: TaskNotifyEmailInput): string {
+  const bodyHtml = escapeHtml(input.bodyText).replace(/\n/g, '<br>');
+  const inner = `
+    <p style="margin:0 0 4px;font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:1px;color:#9ca3af;">
+      ${escapeHtml(input.kindLabel)} · Ticket ${escapeHtml(input.ticketNo)}${input.taskTitle ? ' · ' + escapeHtml(input.taskTitle) : ''}
+    </p>
+    ${input.actorName ? `<p style="margin:8px 0 0;font-size:13px;color:#6b7280;">von <strong style="color:${NAVY};">${escapeHtml(input.actorName)}</strong></p>` : ''}
+    <div style="margin:14px 0 0;padding:14px 16px;background:#f8fafc;border:1px solid #e5e7eb;border-radius:10px;font-size:15px;line-height:1.7;color:#374151;">${bodyHtml}</div>
+    <p style="margin:22px 0 0;">
+      <a href="${input.ticketUrl}" style="display:inline-block;background:#d9531e;color:#ffffff;text-decoration:none;font-weight:700;font-size:14px;padding:11px 22px;border-radius:10px;">Ticket öffnen</a>
+    </p>
+    <p style="margin:22px 0 0;font-size:11px;line-height:1.6;color:#9ca3af;">
+      Interne Benachrichtigung — wer direkt auf diese Mail antwortet, dessen Antwort wird über die Kennung <strong>${escapeHtml(input.ticketNo)}</strong> im Betreff automatisch dem Ticket zugeordnet.
+    </p>`;
+  return layout(inner, `${input.kindLabel} ${input.ticketNo}: ${input.bodyText.slice(0, 100)}`);
+}
+
 /**
  * Marken-Hülle für eine vom Ticket aus gesendete Mail. Die Ticketnummer steht im
  * Betreff (Threading) und als dezenter Hinweis im Footer, damit Antworten via

--- a/src/lib/inboundPoll.ts
+++ b/src/lib/inboundPoll.ts
@@ -19,7 +19,7 @@ import {
 import { findBookingByRequestNumber, graphMessageExists, addMessage } from './bookingStore';
 import {
   findTaskByTicketNumber, taskGraphMessageExists, addTaskMessage,
-  createStaffTask, formatTicketNo,
+  createStaffTask, formatTicketNo, notifyTaskParticipants,
 } from './staffStore';
 import { parseRequestNumber, parseTicketNumber } from './emailTemplates';
 import { getSettings } from './settingsStore';
@@ -253,15 +253,22 @@ export async function runInboundPoll(): Promise<InboundPollResult> {
       }
       const task = await findTaskByTicketNumber(ticketNo);
       if (task) {
+        const replyBody = stripQuotedReply(m.bodyHtml || m.bodyPreview);
         await addTaskMessage({
           task_id: task.id,
           direction: 'in',
           from_email: m.fromAddress,
           to_email: '',
           subject: m.subject,
-          body: stripQuotedReply(m.bodyHtml || m.bodyPreview),
+          body: replyBody,
           graph_message_id: m.id,
         });
+        // Beteiligte (Assignee/Ersteller) über die neue Antwort informieren (Glocke + E-Mail).
+        await notifyTaskParticipants(task, {
+          type: 'task_message',
+          body: replyBody,
+          actorName: m.fromAddress,
+        }).catch(() => { /* nie blockierend */ });
         await markMessageRead(m.id);
         matched++;
         continue;

--- a/src/lib/staffStore.ts
+++ b/src/lib/staffStore.ts
@@ -441,7 +441,10 @@ export async function updateStaffTask(id: string, u: Partial<StaffTask>): Promis
 }
 
 export async function getStaffTask(id: string): Promise<StaffTask | null> {
-  return (await dbGet<StaffTask>('SELECT * FROM staff_tasks WHERE id = ?', [id])) ?? null;
+  return (await dbGet<StaffTask>(`
+    SELECT t.*, p.name AS project_name
+    FROM staff_tasks t LEFT JOIN projects p ON p.id = t.project_id
+    WHERE t.id = ?`, [id])) ?? null;
 }
 
 export async function deleteStaffTask(id: string): Promise<boolean> {
@@ -994,6 +997,8 @@ export async function notifyTaskParticipants(task: StaffTask, opts: {
   type: 'task_message' | 'task_note';
   body: string;
   actorName: string;
+  /** Beteiligte zusätzlich per E-Mail informieren (Standard: an). */
+  email?: boolean;
 }): Promise<void> {
   const ticket = formatTicketNo(task.ticket_number) || 'Ticket';
   const actorLc = (opts.actorName || '').trim().toLowerCase();
@@ -1008,9 +1013,12 @@ export async function notifyTaskParticipants(task: StaffTask, opts: {
   for (const m of await resolveMentions(opts.body)) targets.set(m.id, 'mention');
 
   const label = opts.type === 'task_note' ? 'Neue Notiz' : 'Neue Nachricht';
+  const mailTo: Array<{ name: string; email: string; mentioned: boolean }> = [];
   for (const [empId, type] of targets) {
     const emp = await getEmployee(empId);
-    if (!emp || emp.name.trim().toLowerCase() === actorLc) continue;
+    // Actor nie selbst benachrichtigen — actorName kann Anzeigename ODER (bei
+    // Inbound-Antworten) die E-Mail-Adresse des Absenders sein.
+    if (!emp || emp.name.trim().toLowerCase() === actorLc || (emp.email || '').trim().toLowerCase() === actorLc) continue;
     await addNotification({
       employee_id: empId,
       type,
@@ -1021,5 +1029,34 @@ export async function notifyTaskParticipants(task: StaffTask, opts: {
       body: opts.body.slice(0, 2000),
       created_by: opts.actorName || '',
     }).catch(() => { /* Benachrichtigung darf den Hauptfluss nie brechen */ });
+    if (emp.email) mailTo.push({ name: emp.name, email: emp.email, mentioned: type === 'mention' });
+  }
+
+  // Beteiligte per E-Mail informieren (Assignee, Ersteller, @Erwähnte) — nie blockierend.
+  if (opts.email !== false && mailTo.length) {
+    try {
+      // Dynamische Imports: kein statischer Zyklus staffStore ↔ Mail-Schicht.
+      const { isGraphConfigured, sendGraphMail } = await import('./graphMailer');
+      const { taskNotifyEmailHtml, taskSubjectTag } = await import('./emailTemplates');
+      const { getSettings } = await import('./settingsStore');
+      if (!isGraphConfigured()) return;
+      const base = (getSettings().mail?.login_base_url || 'https://next.faltintravel.com').replace(/\/+$/, '');
+      const ticketUrl = `${base}/admin/aufgaben/${task.id}`;
+      const subject = `${label} ${taskSubjectTag(ticket)} – ${task.title}`.slice(0, 200);
+      for (const rcpt of mailTo) {
+        const html = taskNotifyEmailHtml({
+          bodyText: opts.body,
+          ticketNo: ticket,
+          taskTitle: task.title,
+          actorName: opts.actorName || undefined,
+          kindLabel: rcpt.mentioned ? `${opts.actorName || 'Jemand'} hat dich erwähnt` : label,
+          ticketUrl,
+        });
+        await sendGraphMail({ to: rcpt.email, toName: rcpt.name, subject, html })
+          .catch(() => { /* Mail darf den Hauptfluss nie brechen */ });
+      }
+    } catch (e) {
+      console.warn('[task-notify] E-Mail-Versand fehlgeschlagen:', (e as Error).message);
+    }
   }
 }


### PR DESCRIPTION
## Was ist neu (TASK-00080)

### Ticket-Vollansicht
- **/admin/aufgaben/[id]** — jedes Ticket in einer eigenen Vollseite, zweispaltig wie in einem Ticketsystem: links Beschreibung + kompletter Verlauf (Notizen/Mails) mit Composer, rechts Meta (Status, Projekt, Priorität, Fälligkeit), Subtasks, Dateien und Zeitbuchungen
- Die **Sidebar bleibt als Vorschau**: Maximize-Icon im Drawer-Kopf und die Ticket-Nummer auf jeder Board-Karte öffnen die Vollansicht
- Technisch: TaskDrawer als gemeinsame Basis (`variant='drawer'|'page'`) — eine Codebasis, keine Duplikate; neuer `GET /api/admin/tasks/[id]`

### E-Mail an Beteiligte
- Bei **neuen Notizen** (Admin **und** ext-API/Claude) und **eingehenden Mail-Antworten** bekommen Assignee, Ersteller und **@Erwähnte** automatisch eine E-Mail — mit Zitat der Nachricht und „Ticket öffnen"-Button zur Vollansicht
- Betreff trägt `[TASK-XXXXX]` → wer auf die Mail antwortet, dessen Antwort landet automatisch wieder am Ticket
- Der Verursacher selbst wird nie benachrichtigt (Ausschluss per Name **und** E-Mail-Adresse — verhindert Selbst-Pings bei Mail-Antworten); Versand ist nie blockierend

## Verifikation
- `tsc --noEmit` ✅, `npm run build` ✅ (Route `/admin/aufgaben/[id]` registriert)
- 5/5 Verhaltenstests der Empfänger-Logik (Ersteller+Assignee, Actor-Ausschluss Name/E-Mail, Mention-Übersteuerung, Mitarbeiter ohne E-Mail → nur Glocke, Dedupe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)