### PR TITLE
feat(rapporte): Zeiteinträge batch-weise Mitarbeitern zuweisen + löschen

### DIFF
--- a/src/app/admin/rapporte/page.tsx
+++ b/src/app/admin/rapporte/page.tsx
@@ -6,7 +6,7 @@ import {
   PageHeader, Card, SectionCard, Button, Field, TextInput, SelectInput, Badge, Spinner, StatCard, COLORS,
 } from '@/components/admin/ui';
 import {
-  FileClock, Hourglass, CheckCircle2, FileText, Trash2, Plus, RotateCcw, Lock, X, Pencil, Check,
+  FileClock, Hourglass, CheckCircle2, FileText, Trash2, Plus, RotateCcw, Lock, X, Pencil, Check, Users,
 } from 'lucide-react';
 
 interface TimeEntry {
@@ -104,6 +104,10 @@ export default function RapportePage() {
   // Stammdaten-Editor am Rapport-Entwurf (Titel/Stundensatz/Währung)
   const [meta, setMeta] = useState<{ title: string; rate: string; currency: string } | null>(null);
   const [savingMeta, setSavingMeta] = useState(false);
+
+  // Batch-Aktionen auf der Checkbox-Auswahl (Mitarbeiter zuweisen / löschen)
+  const [batchEmp, setBatchEmp] = useState('');
+  const [batchBusy, setBatchBusy] = useState(false);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -309,6 +313,55 @@ export default function RapportePage() {
     </span>
   );
 
+  const batchAssign = async () => {
+    if (!selEntries.length) return;
+    setBatchBusy(true);
+    setErr('');
+    try {
+      const results = await Promise.all(selEntries.map((e) =>
+        fetch(`/api/admin/time-entries/${e.id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ employee_id: batchEmp || null }),
+        }).then((x) => x.json()).catch(() => ({ success: false }))
+      ));
+      const failed = results.filter((r) => !r.success).length;
+      if (failed) setErr(`${failed} von ${selEntries.length} Einträgen konnten nicht zugewiesen werden`);
+      setSel(new Set());
+      await load();
+    } finally {
+      setBatchBusy(false);
+    }
+  };
+
+  const batchDelete = async () => {
+    if (!selEntries.length) return;
+    if (!confirm(`${selEntries.length} ${selEntries.length === 1 ? 'Zeiteintrag' : 'Zeiteinträge'} (${fmtMin(selMinutes)}) unwiderruflich löschen?`)) return;
+    setBatchBusy(true);
+    setErr('');
+    try {
+      const results = await Promise.all(selEntries.map((e) =>
+        fetch(`/api/admin/time-entries/${e.id}`, { method: 'DELETE' })
+          .then((x) => x.json()).catch(() => ({ success: false }))
+      ));
+      const failed = results.filter((r) => !r.success).length;
+      if (failed) setErr(`${failed} von ${selEntries.length} Einträgen konnten nicht gelöscht werden`);
+      setSel(new Set());
+      await load();
+    } finally {
+      setBatchBusy(false);
+    }
+  };
+
+  const delEntry = async (e: TimeEntry) => {
+    if (!confirm(`Zeiteintrag vom ${fmtDate(e.work_date)} (${fmtMin(e.minutes)}) löschen?`)) return;
+    setErr('');
+    const r = await fetch(`/api/admin/time-entries/${e.id}`, { method: 'DELETE' }).then((x) => x.json());
+    if (!r.success) { setErr(r.error || 'Fehler beim Löschen'); return; }
+    setSel((prev) => { const next = new Set(prev); next.delete(e.id); return next; });
+    await load();
+  };
+
   const reportAmount = (r: Report): string => {
     if (r.hourly_rate == null || r.total_minutes == null) return '–';
     return `${fmtMoney((r.total_minutes / 60) * r.hourly_rate)} ${r.currency}`;
@@ -439,9 +492,14 @@ export default function RapportePage() {
                         )}
                         <td className="py-2 pl-2 text-right whitespace-nowrap">
                           {isEdit ? editActions : (
-                            <Button size="sm" variant="ghost" onClick={(ev) => { ev.stopPropagation(); startEdit(e); }} aria-label="Bearbeiten">
-                              <Pencil className="h-3.5 w-3.5" />
-                            </Button>
+                            <span className="inline-flex items-center gap-1">
+                              <Button size="sm" variant="ghost" onClick={(ev) => { ev.stopPropagation(); startEdit(e); }} aria-label="Bearbeiten">
+                                <Pencil className="h-3.5 w-3.5" />
+                              </Button>
+                              <Button size="sm" variant="ghost" onClick={(ev) => { ev.stopPropagation(); delEntry(e); }} aria-label="Löschen">
+                                <Trash2 className="h-3.5 w-3.5" />
+                              </Button>
+                            </span>
                           )}
                         </td>
                       </tr>
@@ -458,6 +516,22 @@ export default function RapportePage() {
                   ? `${sel.size} ${sel.size === 1 ? 'Eintrag' : 'Einträge'} · ${fmtMin(selMinutes)} ausgewählt`
                   : 'Einträge auswählen, um einen Rapport zu erstellen'}
               </div>
+              {sel.size > 0 && (
+                <div className="mb-3 flex flex-wrap items-end gap-3 border-b pb-3" style={{ borderColor: COLORS.stroke }}>
+                  <Field label="Mitarbeiter für Auswahl setzen">
+                    <SelectInput value={batchEmp} onChange={(e) => setBatchEmp(e.target.value)} className="w-48">
+                      <option value="">Extern (API)</option>
+                      {employees.map((e) => <option key={e.id} value={e.id}>{e.name}</option>)}
+                    </SelectInput>
+                  </Field>
+                  <Button size="sm" variant="secondary" onClick={batchAssign} disabled={batchBusy}>
+                    {batchBusy ? <Spinner className="h-4 w-4" /> : <Users className="h-4 w-4" />} Zuweisen
+                  </Button>
+                  <Button size="sm" variant="ghost" onClick={batchDelete} disabled={batchBusy}>
+                    <Trash2 className="h-4 w-4" /> Auswahl löschen
+                  </Button>
+                </div>
+              )}
               <div className="flex flex-wrap items-end gap-3">
                 <Field label="Titel (optional)">
                   <TextInput value={title} onChange={(e) => setTitle(e.target.value)} placeholder="z. B. Entwicklung Juni 2026" className="w-64" />

--- a/src/app/api/admin/time-entries/[id]/route.ts
+++ b/src/app/api/admin/time-entries/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { updateTaskTime } from '@/lib/staffStore';
+import { updateTaskTime, deleteTaskTime } from '@/lib/staffStore';
 
 /**
  * PATCH /api/admin/time-entries/[id] { minutes?, note?, work_date?, employee_id? }
@@ -18,4 +18,12 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
   if (!result) return NextResponse.json({ success: false, error: 'Zeiteintrag nicht gefunden' }, { status: 404 });
   if ('error' in result) return NextResponse.json({ success: false, error: result.error }, { status: 400 });
   return NextResponse.json({ success: true, data: result });
+}
+
+/** DELETE — nur offene (nicht rapportierte) Einträge; rapportierte sind gesperrt. */
+export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const ok = await deleteTaskTime(id);
+  if (!ok) return NextResponse.json({ success: false, error: 'Eintrag nicht gefunden oder bereits rapportiert' }, { status: 400 });
+  return NextResponse.json({ success: true });
 }


### PR DESCRIPTION
## Was ist neu (TASK-00082)
In der **Offene-Zeiten-Tabelle** auf /admin/rapporte:

- **Einzeln löschen:** Papierkorb-Icon pro Zeile (mit Confirm inkl. Datum/Dauer)
- **Batch:** Sobald Einträge per Checkbox ausgewählt sind, erscheint eine Aktionsleiste — **Mitarbeiter für die ganze Auswahl setzen** (Dropdown inkl. `Extern (API)`) und **Auswahl löschen** (Confirm mit Anzahl + Gesamtzeit)
- Fehlgeschlagene Einzeloperationen werden gezählt und gemeldet; Auswahl wird danach geleert und die Liste neu geladen

## Technik
Neuer `DELETE /api/admin/time-entries/[id]` — nutzt den bestehenden `deleteTaskTime`-Guard, **rapportierte Einträge bleiben gesperrt** (400 mit klarer Meldung). Batch-Zuweisung über den vorhandenen PATCH-Endpoint.

## Verifikation
`tsc --noEmit` ✅, `npm run build` ✅; Lösch-Guard bereits durch die bestehenden Offline-SQL-Tests abgedeckt (DELETE auf rapportiertem Eintrag → 0 changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)