### PR TITLE
feat(admin): einheitlich volle Container-Breite auf allen Admin-Seiten

### DIFF
--- a/src/components/admin/AdminShell.tsx
+++ b/src/components/admin/AdminShell.tsx
@@ -279,7 +279,7 @@ function SidebarContent({ pathname, onNavigate, user }: { pathname: string; onNa
   );
 }
 
-export default function AdminShell({ title, children, wide }: AdminShellProps) {
+export default function AdminShell({ title, children }: AdminShellProps) {
   const pathname = usePathname();
   const [mobileOpen, setMobileOpen] = useState(false);
   const [user, setUser] = useState<{ name: string; src: string } | null>(null);
@@ -322,7 +322,9 @@ export default function AdminShell({ title, children, wide }: AdminShellProps) {
             </div>
           </header>
 
-          <main className={`mx-auto ${wide ? 'max-w-none' : 'max-w-7xl'} px-4 py-6 sm:px-6 lg:px-8`}>{children}</main>
+          {/* Einheitlich volle Content-Breite auf allen Admin-Seiten (TASK-00083);
+              `wide` bleibt als Prop für Abwärtskompatibilität, hat aber keine Wirkung mehr. */}
+          <main className="mx-auto max-w-none px-4 py-6 sm:px-6 lg:px-8">{children}</main>
         </div>
       </div>
   );


### PR DESCRIPTION
## Was ist neu (TASK-00083)
Bislang nutzte nur das Aufgaben-Board die volle Breite (`wide`-Prop), alle anderen Admin-Seiten (Zeit-Rapporte, CRM, Buchungen, Events, …) liefen im schmalen `max-w-7xl`-Container mit viel ungenutztem Rand.

Jetzt zentral in **AdminShell** gelöst: `max-w-none` für **alle** Seiten — einheitlich, ein Einzeiler, kein Seiten-für-Seiten-Nachziehen. Die `wide`-Prop bleibt als No-Op erhalten (bestehende Aufrufe brechen nicht).

## Verifikation
`tsc --noEmit` ✅, `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)