### PR TITLE
feat(auto-reply): Link-Buttons am Mail-Ende + Bild-Anhänge

### DIFF
--- a/src/app/admin/events/page.tsx
+++ b/src/app/admin/events/page.tsx
@@ -16,7 +16,8 @@ import {
   ArrowDown,
   Mail,
   Paperclip,
-  Upload
+  Upload,
+  Link2
 } from 'lucide-react';
 import AdminShell from '@/components/admin/AdminShell';
 import AdminImageField from '@/components/admin/AdminImageField';
@@ -117,8 +118,10 @@ interface EventFormState {
   auto_reply_enabled: boolean;
   auto_reply_subject: string;
   auto_reply_message: string;
-  /** Mehrere PDF-Anhänge (Legacy-Einzelfelder auto_reply_pdf/auto_reply_pdf_name werden beim Laden hierher normalisiert). */
+  /** Mehrere Anhänge (PDF/Bilder; Legacy-Einzelfelder auto_reply_pdf/auto_reply_pdf_name werden beim Laden hierher normalisiert). */
   auto_reply_pdfs: Array<{ file: string; name: string; size?: number }>;
+  /** Link-Buttons am Ende der Auto-Antwort. */
+  auto_reply_links: Array<{ label: string; url: string }>;
 }
 
 const DEFAULT_MODULE_ORDER = ['leistungen', 'about', 'duell', 'spielorte', 'spielplan', 'wissenswertes', 'stadionplan', 'lageplan', 'ticket_categories', 'packages', 'faq', 'related'];
@@ -211,7 +214,8 @@ const emptyForm: EventFormState = {
   auto_reply_enabled: false,
   auto_reply_subject: '',
   auto_reply_message: '',
-  auto_reply_pdfs: []
+  auto_reply_pdfs: [],
+  auto_reply_links: []
 };
 
 function normalizeEventFormState(event?: Partial<EventFormState> | null): EventFormState {
@@ -292,7 +296,10 @@ function normalizeEventFormState(event?: Partial<EventFormState> | null): EventF
     auto_reply_enabled: (event as Partial<EventFormState> | null | undefined)?.auto_reply_enabled ?? false,
     auto_reply_subject: (event as Partial<EventFormState> | null | undefined)?.auto_reply_subject ?? '',
     auto_reply_message: (event as Partial<EventFormState> | null | undefined)?.auto_reply_message ?? '',
-    auto_reply_pdfs: normalizeAutoReplyPdfs(event)
+    auto_reply_pdfs: normalizeAutoReplyPdfs(event),
+    auto_reply_links: Array.isArray((event as Partial<EventFormState> | null | undefined)?.auto_reply_links)
+      ? ((event as Partial<EventFormState>).auto_reply_links as Array<{ label?: string; url?: string }>).map((l) => ({ label: l?.label || '', url: l?.url || '' }))
+      : []
   };
 }
 
@@ -410,7 +417,7 @@ export default function AdminEventsPage() {
         }));
       }
     } catch (e) {
-      alert('PDF-Upload fehlgeschlagen: ' + (e as Error).message);
+      alert('Upload fehlgeschlagen: ' + (e as Error).message);
     } finally {
       setPdfUploading(false);
     }
@@ -576,6 +583,12 @@ export default function AdminEventsPage() {
       auto_reply_subject: form.auto_reply_subject.trim() || null,
       auto_reply_message: form.auto_reply_message.trim() || null,
       auto_reply_pdfs: form.auto_reply_pdfs.length > 0 ? form.auto_reply_pdfs : null,
+      auto_reply_links: (() => {
+        const cleaned = form.auto_reply_links
+          .map((l) => ({ label: l.label.trim(), url: l.url.trim() }))
+          .filter((l) => l.label && l.url);
+        return cleaned.length > 0 ? cleaned : null;
+      })(),
       // Abwärtskompatibilität: erster Anhang zusätzlich in den Legacy-Einzelfeldern
       auto_reply_pdf: form.auto_reply_pdfs[0]?.file || null,
       auto_reply_pdf_name: form.auto_reply_pdfs[0]?.name || null
@@ -1085,7 +1098,7 @@ export default function AdminEventsPage() {
 
                       <div className="rounded-xl border px-3 py-3" style={{ borderColor: COLORS.stroke }}>
                         <div className="flex items-center gap-2 text-sm font-semibold" style={{ color: COLORS.navy }}>
-                          <Paperclip className="h-4 w-4" /> PDF-Anhänge (optional, mehrere möglich, max. 3,5 MB pro Datei)
+                          <Paperclip className="h-4 w-4" /> Anhänge — PDF &amp; Bilder (optional, mehrere möglich, max. 3,5 MB pro Datei)
                         </div>
                         {form.auto_reply_pdfs.length > 0 ? (
                           <div className="mt-2 grid gap-2">
@@ -1109,12 +1122,12 @@ export default function AdminEventsPage() {
                             ))}
                           </div>
                         ) : (
-                          <div className="mt-2 text-xs" style={{ color: COLORS.textMuted }}>Noch keine PDFs hinterlegt.</div>
+                          <div className="mt-2 text-xs" style={{ color: COLORS.textMuted }}>Noch keine Anhänge hinterlegt.</div>
                         )}
                         <input
                           ref={autoReplyPdfInputRef}
                           type="file"
-                          accept="application/pdf,.pdf"
+                          accept="application/pdf,.pdf,image/jpeg,.jpg,.jpeg,image/png,.png,image/webp,.webp"
                           multiple
                           disabled={pdfUploading}
                           className="hidden"
@@ -1132,7 +1145,7 @@ export default function AdminEventsPage() {
                             disabled={pdfUploading}
                           >
                             <Upload className="h-4 w-4" />
-                            PDFs hinzufügen
+                            Dateien hinzufügen
                           </Button>
                           <span className="min-w-0 text-sm" style={{ color: COLORS.textMuted }}>
                             {form.auto_reply_pdfs.length > 0
@@ -1140,7 +1153,59 @@ export default function AdminEventsPage() {
                               : 'Keine Datei ausgewählt'}
                           </span>
                         </div>
-                        {pdfUploading && <div className="mt-2 text-xs" style={{ color: COLORS.accent }}>PDFs werden hochgeladen …</div>}
+                        {pdfUploading && <div className="mt-2 text-xs" style={{ color: COLORS.accent }}>Dateien werden hochgeladen …</div>}
+                      </div>
+
+                      {/* Link-Buttons am Mail-Ende (TASK-00086) */}
+                      <div className="rounded-xl border px-3 py-3" style={{ borderColor: COLORS.stroke }}>
+                        <div className="flex items-center gap-2 text-sm font-semibold" style={{ color: COLORS.navy }}>
+                          <Link2 className="h-4 w-4" /> Link-Buttons am Mail-Ende (optional)
+                        </div>
+                        <div className="mt-1 text-xs" style={{ color: COLORS.textMuted }}>
+                          Erscheinen in der Auto-Antwort als orange Buttons — z.&nbsp;B. „Weiter zur Buchung“ oder „Unsere Angebote ansehen“. Nur http(s)- und mailto-Links werden versendet.
+                        </div>
+                        {form.auto_reply_links.map((link, idx) => (
+                          <div key={idx} className="mt-2 flex flex-wrap items-center gap-2">
+                            <input
+                              value={link.label}
+                              onChange={(e) => setForm((prev) => ({
+                                ...prev,
+                                auto_reply_links: prev.auto_reply_links.map((l, i) => (i === idx ? { ...l, label: e.target.value } : l)),
+                              }))}
+                              placeholder="Button-Text (z. B. Weiter zur Buchung)"
+                              className="w-64 rounded-lg border px-3 py-1.5 text-sm focus:outline-none"
+                              style={{ borderColor: COLORS.stroke }}
+                            />
+                            <input
+                              value={link.url}
+                              onChange={(e) => setForm((prev) => ({
+                                ...prev,
+                                auto_reply_links: prev.auto_reply_links.map((l, i) => (i === idx ? { ...l, url: e.target.value } : l)),
+                              }))}
+                              placeholder="https://…"
+                              className="min-w-[220px] flex-1 rounded-lg border px-3 py-1.5 text-sm focus:outline-none"
+                              style={{ borderColor: COLORS.stroke }}
+                            />
+                            <button
+                              type="button"
+                              className="shrink-0 text-xs font-semibold underline"
+                              style={{ color: COLORS.danger }}
+                              onClick={() => setForm((prev) => ({ ...prev, auto_reply_links: prev.auto_reply_links.filter((_, i) => i !== idx) }))}
+                            >
+                              Entfernen
+                            </button>
+                          </div>
+                        ))}
+                        <div className="mt-3">
+                          <Button
+                            type="button"
+                            variant="secondary"
+                            onClick={() => setForm((prev) => ({ ...prev, auto_reply_links: [...prev.auto_reply_links, { label: '', url: '' }] }))}
+                          >
+                            <Plus className="h-4 w-4" />
+                            Link hinzufügen
+                          </Button>
+                        </div>
                       </div>
                     </>
                   )}

--- a/src/app/api/bookings/route.ts
+++ b/src/app/api/bookings/route.ts
@@ -9,7 +9,7 @@ import {
   autoReplyHtml, autoReplySubjectDefault, subjectTag,
 } from '@/lib/emailTemplates';
 import { linkBookingToCustomer, normalizeSalutation } from '@/lib/customerStore';
-import { readAutoReplyPdfBase64 } from '@/lib/autoReplyStore';
+import { readAutoReplyPdfBase64, autoReplyContentType } from '@/lib/autoReplyStore';
 
 /**
  * CORS: erlaubt das Anfrage-Formular auf WordPress ([faltin_anfrage]).
@@ -132,7 +132,11 @@ export async function POST(request: Request) {
           subject = (event!.auto_reply_subject || '').trim() || autoReplySubjectDefault(eventName, requestNumber);
           // RQ-Tag fürs Threading anhängen, falls nicht bereits im Custom-Betreff enthalten.
           if (!/RQ-\d/i.test(subject)) subject = `${subject} ${subjectTag(requestNumber)}`;
-          html = autoReplyHtml({ message: event!.auto_reply_message || '', firstName, lastName, salutation, eventName, requestNumber, consent });
+          html = autoReplyHtml({
+            message: event!.auto_reply_message || '',
+            firstName, lastName, salutation, eventName, requestNumber, consent,
+            links: Array.isArray(event!.auto_reply_links) ? event!.auto_reply_links : [],
+          });
 
           // Anhänge: neue Mehrfach-Liste (auto_reply_pdfs) hat Vorrang, sonst Legacy-Einzelfeld.
           const pdfList = Array.isArray(event!.auto_reply_pdfs) && event!.auto_reply_pdfs.length > 0
@@ -146,11 +150,11 @@ export async function POST(request: Request) {
             if (pdf) {
               (attachments ||= []).push({
                 name: pdfMeta.name || 'Angebot.pdf',
-                contentType: 'application/pdf',
+                contentType: autoReplyContentType(pdfMeta.file),
                 contentBytes: pdf.base64,
               });
             } else {
-              console.warn('[AutoReply] PDF nicht gefunden:', pdfMeta.file);
+              console.warn('[AutoReply] Anhang nicht gefunden:', pdfMeta.file);
             }
           }
           pdfCount = attachments?.length ?? 0;

--- a/src/lib/autoReplyStore.ts
+++ b/src/lib/autoReplyStore.ts
@@ -16,8 +16,23 @@ import path from 'path';
 
 const DATA_DIR = path.join(process.cwd(), 'data', 'uploads', 'auto-reply');
 
-/** Max. Größe pro PDF-Anhang (3,5 MB). Große Mails gehen via Graph Draft + Upload-Session raus. */
+/** Max. Größe pro Anhang (3,5 MB). Große Mails gehen via Graph Draft + Upload-Session raus. */
 export const MAX_AUTO_REPLY_PDF_BYTES = Math.floor(3.5 * 1024 * 1024);
+
+/** Erlaubte Anhangstypen: PDF + gängige Bildformate (TASK-00086). */
+const ALLOWED_TYPES: Record<string, string> = {
+  '.pdf': 'application/pdf',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.webp': 'image/webp',
+};
+
+/** MIME-Type eines gespeicherten Anhangs anhand der Endung (Fallback: PDF-Legacy). */
+export function autoReplyContentType(file: string): string {
+  const ext = path.extname(file || '').toLowerCase();
+  return ALLOWED_TYPES[ext] || 'application/pdf';
+}
 
 export interface AutoReplyPdfMeta {
   /** Gespeicherter Dateiname (im Event-Datensatz hinterlegt) */
@@ -43,26 +58,26 @@ function safeStoredName(file: string): string {
   return path.basename(file || '').replace(/[^a-zA-Z0-9._-]/g, '');
 }
 
-/** Speichert eine hochgeladene PDF und gibt Metadaten zurück. */
+/** Speichert einen hochgeladenen Anhang (PDF oder Bild) und gibt Metadaten zurück. */
 export async function saveAutoReplyPdf(file: File, eventSlug?: string): Promise<AutoReplyPdfMeta> {
   const originalName = file.name || 'dokument.pdf';
   const ext = path.extname(originalName).toLowerCase();
-  if (ext !== '.pdf') {
-    throw new Error('Nur PDF-Dateien sind als Auto-Antwort-Anhang erlaubt.');
+  if (!ALLOWED_TYPES[ext]) {
+    throw new Error('Erlaubt sind PDF-Dateien und Bilder (JPG, PNG, WebP).');
   }
 
   const bytes = Buffer.from(await file.arrayBuffer());
   // Versand großer Anhänge läuft über die Graph Upload-Session (graphMailer.ts),
   // daher gilt nur noch das eigene Limit pro Datei.
   if (bytes.length > MAX_AUTO_REPLY_PDF_BYTES) {
-    throw new Error('PDF ist zu groß (max. 3,5 MB pro Anhang).');
+    throw new Error('Datei ist zu groß (max. 3,5 MB pro Anhang).');
   }
 
   await mkdir(DATA_DIR, { recursive: true });
 
   const slugPart = eventSlug ? `${sanitizeBase(eventSlug)}-` : '';
   const timeStamp = new Date().toISOString().replace(/[:.]/g, '-');
-  const finalName = `${slugPart}${timeStamp}-${sanitizeBase(originalName)}.pdf`;
+  const finalName = `${slugPart}${timeStamp}-${sanitizeBase(originalName)}${ext}`;
   const finalPath = path.join(DATA_DIR, finalName);
   await writeFile(finalPath, bytes);
 

--- a/src/lib/contentStore.ts
+++ b/src/lib/contentStore.ts
@@ -119,8 +119,10 @@ export interface ContentEventRecord {
   auto_reply_message?: string | null;
   auto_reply_pdf?: string | null;
   auto_reply_pdf_name?: string | null;
-  /** Mehrere Auto-Antwort-PDFs (je { file, name, size? }). Hat Vorrang vor den Legacy-Feldern auto_reply_pdf/auto_reply_pdf_name. */
+  /** Mehrere Auto-Antwort-Anhänge (PDF/Bilder, je { file, name, size? }). Hat Vorrang vor den Legacy-Feldern auto_reply_pdf/auto_reply_pdf_name. */
   auto_reply_pdfs?: Array<{ file: string; name: string; size?: number }> | null;
+  /** Link-Buttons am Ende der Auto-Antwort (je { label, url }). */
+  auto_reply_links?: Array<{ label: string; url: string }> | null;
 }
 
 export interface ContentPackageInclude {

--- a/src/lib/emailTemplates.ts
+++ b/src/lib/emailTemplates.ts
@@ -303,6 +303,8 @@ export interface AutoReplyInput extends RecipientInfo {
   eventName?: string;
   requestNumber?: string;
   consent?: boolean;
+  /** Link-Buttons am Mail-Ende (nur http(s)/mailto werden gerendert). */
+  links?: Array<{ label: string; url: string }>;
 }
 
 /**
@@ -324,6 +326,17 @@ export function autoReplyHtml(input: AutoReplyInput): string {
 
   const bodyHtml = rendered.replace(/\n/g, '<br>');
 
+  // Link-Buttons am Mail-Ende (vom Admin je Event gepflegt) — gebrandet,
+  // nur valide http(s)-/mailto-Ziele mit Beschriftung werden gerendert.
+  const validLinks = (input.links || []).filter(
+    (l) => l && (l.label || '').trim() && /^(https?:\/\/|mailto:)/i.test((l.url || '').trim())
+  );
+  const linksHtml = validLinks.length
+    ? `<div style="margin:22px 0 0;">${validLinks.map((l) =>
+        `<a href="${escapeHtml(l.url.trim())}" style="display:inline-block;margin:0 10px 10px 0;background:#d9531e;color:#ffffff;text-decoration:none;font-weight:700;font-size:14px;padding:11px 22px;border-radius:10px;">${escapeHtml(l.label.trim())}</a>`
+      ).join('')}</div>`
+    : '';
+
   // Bewusst minimal: nur (optionale) Anrede + der Admin-Text im Marken-Rahmen.
   // KEINE automatische Anfragenummer-Zeile und KEINE Grußformel – die Nachricht ist
   // vollständig vom Admin gepflegt (vermeidet doppelten/überflüssigen Text).
@@ -331,6 +344,7 @@ export function autoReplyHtml(input: AutoReplyInput): string {
   const inner = `
     ${greetingHtml}
     <div style="font-size:15px;line-height:1.7;color:#374151;">${bodyHtml}</div>
+    ${linksHtml}
     ${portalCtaHtml({ withNote: true })}
     ${consentNoticeHtml(input.consent)}`;
 

--- a/src/lib/eventData.ts
+++ b/src/lib/eventData.ts
@@ -157,8 +157,10 @@ export interface EventRecord {
   auto_reply_pdf?: string | null;
   /** Anzeigename der PDF (wird als Anhang-Name in der Mail genutzt). Legacy-Einzelfeld. */
   auto_reply_pdf_name?: string | null;
-  /** Mehrere Auto-Antwort-PDFs (je { file, name, size? }). Hat Vorrang vor den Legacy-Feldern. */
+  /** Mehrere Auto-Antwort-Anhänge (PDF/Bilder, je { file, name, size? }). Hat Vorrang vor den Legacy-Feldern. */
   auto_reply_pdfs?: Array<{ file: string; name: string; size?: number }> | null;
+  /** Link-Buttons am Ende der Auto-Antwort (je { label, url }). */
+  auto_reply_links?: Array<{ label: string; url: string }> | null;
 }
 
 export interface SeriesRecord {


### PR DESCRIPTION
## Was ist neu (TASK-00086)
**1. Link-Buttons in der Auto-Antwort**
- Im Events-Admin (Auto-Antwort-Bereich) beliebig viele Links mit Button-Beschriftung pflegen — intuitive Zeilen mit `+ Link hinzufügen` / `Entfernen`
- In der Mail erscheinen sie am Ende als **gebrandete orange Buttons**
- Sicherheit: nur `http(s)`- und `mailto:`-Ziele werden versendet (`javascript:` & leere Felder werden verworfen — verifiziert)

**2. Bild-Anhänge**
- Der Anhang-Multi-Upload akzeptiert neben PDF jetzt **JPG, PNG, WebP** (Endungs-Whitelist + MIME-Map, 3,5-MB-Limit pro Datei bleibt)
- Versand mit korrektem `contentType` je Datei; bestehende PDF-Anhänge unverändert (Legacy-Fallback bleibt)

## Verifikation
`tsc --noEmit` ✅, `npm run build` ✅, Link-Filter-Logik per Node-Check verifiziert (javascript:-URL und unvollständige Zeilen fliegen raus)

Teil 1 von 2 — der WYSIWYG-Editor + Vollbild (TASK-00087) folgt als separater PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)