### PR TITLE
feat(auto-reply): WYSIWYG-Editor (Fett/Listen/Links) + Vollbild-Modus

### DIFF
--- a/src/app/admin/events/page.tsx
+++ b/src/app/admin/events/page.tsx
@@ -22,6 +22,7 @@ import {
 import AdminShell from '@/components/admin/AdminShell';
 import AdminImageField from '@/components/admin/AdminImageField';
 import PinMapEditor from '@/components/admin/PinMapEditor';
+import SimpleRichEditor, { type SimpleRichEditorHandle } from '@/components/admin/SimpleRichEditor';
 import {
   COLORS,
   SectionCard,
@@ -388,16 +389,12 @@ export default function AdminEventsPage() {
   const [searchTerm, setSearchTerm] = useState('');
   const [pdfUploading, setPdfUploading] = useState(false);
   const autoReplyPdfInputRef = useRef<HTMLInputElement>(null);
+  const autoReplyEditorRef = useRef<SimpleRichEditorHandle | null>(null);
 
   function insertAutoReplyToken(token: string) {
-    const el = document.getElementById('ev-f-autoreply-msg') as HTMLTextAreaElement | null;
-    const cur = form.auto_reply_message || '';
-    if (!el) { updateField('auto_reply_message', cur + token); return; }
-    const start = el.selectionStart ?? cur.length;
-    const end = el.selectionEnd ?? cur.length;
-    const next = cur.slice(0, start) + token + cur.slice(end);
-    updateField('auto_reply_message', next);
-    requestAnimationFrame(() => { el.focus(); const p = start + token.length; el.setSelectionRange(p, p); });
+    // WYSIWYG-Editor: an der Cursor-Position einfügen; Fallback: anhängen.
+    if (autoReplyEditorRef.current) { autoReplyEditorRef.current.insertText(token); return; }
+    updateField('auto_reply_message', (form.auto_reply_message || '') + token);
   }
 
   async function handleAutoReplyPdfUpload(files: File[]) {
@@ -1085,15 +1082,18 @@ export default function AdminEventsPage() {
                             </button>
                           ))}
                         </div>
-                        <TextAreaField
-                          id="ev-f-autoreply-msg"
+                        <Field
                           label="Nachricht"
-                          value={form.auto_reply_message}
-                          onChange={(event) => updateField('auto_reply_message', event.target.value)}
-                          rows={8}
-                          placeholder={'Vielen Dank für Ihre unverbindliche Anfrage …\n\nIm Anhang finden Sie unsere aktuellen Angebote.\n\nGerne melden wir uns persönlich bei Ihnen.'}
-                          hint="Die Nachricht wird 1:1 im Faltin-Rahmen (Logo/Footer) versendet. Platzhalter: {{grussformel}} = tageszeit-abhängig „Guten Morgen/Tag/Abend“ · {{anrede}} = „Herr“/„Frau“ · {{vorname}} · {{nachname}}. Beispiel: „Guten Tag {{anrede}} {{nachname}}“ → „Guten Tag Herr Müller“. Fehlt die Anrede, fällt die Zeile automatisch sauber auf „Guten Tag“ zurück (ohne Name)."
-                        />
+                          hint="Die Nachricht wird 1:1 im Faltin-Rahmen (Logo/Footer) versendet — Formatierungen (fett, kursiv, Listen, Links) werden übernommen; Vollbild über das Symbol rechts in der Leiste. Platzhalter: {{grussformel}} = tageszeit-abhängig „Guten Morgen/Tag/Abend“ · {{anrede}} = „Herr“/„Frau“ · {{vorname}} · {{nachname}}. Beispiel: „Guten Tag {{anrede}} {{nachname}}“ → „Guten Tag Herr Müller“. Fehlt die Anrede, fällt die Zeile automatisch sauber auf „Guten Tag“ zurück (ohne Name)."
+                        >
+                          <SimpleRichEditor
+                            value={form.auto_reply_message}
+                            onChange={(html) => updateField('auto_reply_message', html)}
+                            editorRef={autoReplyEditorRef}
+                            minHeight={200}
+                            placeholder="Vielen Dank für Ihre unverbindliche Anfrage … Im Anhang finden Sie unsere aktuellen Angebote."
+                          />
+                        </Field>
                       </div>
 
                       <div className="rounded-xl border px-3 py-3" style={{ borderColor: COLORS.stroke }}>

--- a/src/components/admin/SimpleRichEditor.tsx
+++ b/src/components/admin/SimpleRichEditor.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+/**
+ * SimpleRichEditor — bewusst schlanker WYSIWYG-Editor für E-Mail-Texte
+ * (Auto-Antwort): Fett, Kursiv, Unterstrichen, Listen, Links im Fließtext,
+ * plus Vollbild-Modus zum bequemen Bearbeiten (ESC verlässt ihn).
+ *
+ * - Speichert HTML (String) über onChange; Klartext-Bestände (Legacy) werden
+ *   beim Laden zu HTML konvertiert (Zeilenumbrüche → <br>).
+ * - Einfügen aus der Zwischenablage immer als Klartext (kein Word-HTML-Müll).
+ * - Serverseitig wird das HTML zusätzlich sanitisiert (emailTemplates).
+ */
+import { useEffect, useRef, useState } from 'react';
+import { Bold, Italic, Underline, List, ListOrdered, Link2, Unlink, Maximize2, Minimize2 } from 'lucide-react';
+import { COLORS } from './ui';
+
+export interface SimpleRichEditorHandle {
+  /** Text (z.B. einen {{platzhalter}}) an der aktuellen Cursor-Position einfügen. */
+  insertText: (text: string) => void;
+}
+
+function escapePlain(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/** Klartext (Legacy-Bestand) → HTML für den Editor; HTML bleibt unangetastet. */
+function toEditorHtml(value: string): string {
+  if (!value) return '';
+  if (/<[a-z][^>]*>/i.test(value)) return value;
+  return value.split('\n').map(escapePlain).join('<br>');
+}
+
+/** Leere Editor-Reste ('<br>', leere Divs) als leeren Wert behandeln. */
+function normalizeEmpty(html: string): string {
+  const stripped = html.replace(/<br\s*\/?>/gi, '').replace(/<\/?(div|p|span)[^>]*>/gi, '').replace(/&nbsp;/gi, ' ').trim();
+  return stripped ? html : '';
+}
+
+export default function SimpleRichEditor({
+  value,
+  onChange,
+  placeholder,
+  minHeight = 180,
+  editorRef,
+}: {
+  value: string;
+  onChange: (html: string) => void;
+  placeholder?: string;
+  minHeight?: number;
+  editorRef?: React.MutableRefObject<SimpleRichEditorHandle | null>;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const lastHtml = useRef<string>('');
+  const savedRange = useRef<Range | null>(null);
+  const [full, setFull] = useState(false);
+
+  // Externen Wert nur übernehmen, wenn er nicht vom eigenen Tippen stammt
+  // (sonst springt der Cursor bei jedem Anschlag an den Anfang).
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const html = toEditorHtml(value || '');
+    if (html !== lastHtml.current && html !== el.innerHTML) {
+      el.innerHTML = html;
+      lastHtml.current = html;
+    }
+  }, [value]);
+
+  const emit = () => {
+    const el = ref.current;
+    if (!el) return;
+    const html = normalizeEmpty(el.innerHTML);
+    lastHtml.current = el.innerHTML;
+    onChange(html);
+  };
+
+  const saveSel = () => {
+    const s = window.getSelection();
+    if (s && s.rangeCount > 0 && ref.current && ref.current.contains(s.anchorNode)) {
+      savedRange.current = s.getRangeAt(0).cloneRange();
+    }
+  };
+  const restoreSel = () => {
+    const r = savedRange.current;
+    if (!r) return;
+    const s = window.getSelection();
+    s?.removeAllRanges();
+    s?.addRange(r);
+  };
+
+  const exec = (cmd: string, arg?: string) => {
+    ref.current?.focus();
+    restoreSel();
+    document.execCommand(cmd, false, arg);
+    saveSel();
+    emit();
+  };
+
+  const setLink = () => {
+    ref.current?.focus();
+    restoreSel();
+    const url = window.prompt('Link-Ziel (https://… oder mailto:…):', 'https://');
+    if (!url || !/^(https?:\/\/|mailto:)/i.test(url.trim())) return;
+    document.execCommand('createLink', false, url.trim());
+    saveSel();
+    emit();
+  };
+
+  useEffect(() => {
+    if (!editorRef) return;
+    editorRef.current = {
+      insertText: (text: string) => {
+        ref.current?.focus();
+        restoreSel();
+        document.execCommand('insertText', false, text);
+        saveSel();
+        emit();
+      },
+    };
+    return () => { editorRef.current = null; };
+  });
+
+  // ESC verlässt den Vollbild-Modus
+  useEffect(() => {
+    if (!full) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setFull(false); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [full]);
+
+  const ToolBtn = ({ title, onAction, children }: { title: string; onAction: () => void; children: React.ReactNode }) => (
+    <button
+      type="button"
+      title={title}
+      // preventDefault auf mousedown: sonst verliert der Editor die Auswahl vor dem Klick
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={onAction}
+      className="rounded-md p-1.5 transition hover:bg-gray-100"
+      style={{ color: COLORS.navy }}
+    >
+      {children}
+    </button>
+  );
+
+  return (
+    <div className={full ? 'fixed inset-0 z-[100] flex flex-col bg-black/30 p-3 sm:p-8' : ''} onClick={full ? () => setFull(false) : undefined}>
+      <div
+        className={`flex w-full flex-col rounded-lg border bg-white ${full ? 'h-full shadow-2xl' : ''}`}
+        style={{ borderColor: COLORS.stroke }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex flex-wrap items-center gap-0.5 rounded-t-lg border-b px-1.5 py-1" style={{ borderColor: COLORS.stroke, background: '#fafbfc' }}>
+          <ToolBtn title="Fett (auf Auswahl)" onAction={() => exec('bold')}><Bold className="h-4 w-4" /></ToolBtn>
+          <ToolBtn title="Kursiv" onAction={() => exec('italic')}><Italic className="h-4 w-4" /></ToolBtn>
+          <ToolBtn title="Unterstrichen" onAction={() => exec('underline')}><Underline className="h-4 w-4" /></ToolBtn>
+          <span className="mx-1 h-5 w-px" style={{ background: COLORS.stroke }} />
+          <ToolBtn title="Aufzählung" onAction={() => exec('insertUnorderedList')}><List className="h-4 w-4" /></ToolBtn>
+          <ToolBtn title="Nummerierte Liste" onAction={() => exec('insertOrderedList')}><ListOrdered className="h-4 w-4" /></ToolBtn>
+          <span className="mx-1 h-5 w-px" style={{ background: COLORS.stroke }} />
+          <ToolBtn title="Link auf Auswahl setzen" onAction={setLink}><Link2 className="h-4 w-4" /></ToolBtn>
+          <ToolBtn title="Link entfernen" onAction={() => exec('unlink')}><Unlink className="h-4 w-4" /></ToolBtn>
+          <span className="ml-auto" />
+          <ToolBtn title={full ? 'Vollbild verlassen (ESC)' : 'Vollbild zum Bearbeiten'} onAction={() => setFull((f) => !f)}>
+            {full ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
+          </ToolBtn>
+        </div>
+        <div
+          ref={ref}
+          contentEditable
+          suppressContentEditableWarning
+          onInput={emit}
+          onKeyUp={saveSel}
+          onMouseUp={saveSel}
+          onBlur={saveSel}
+          onPaste={(e) => {
+            e.preventDefault();
+            const t = e.clipboardData.getData('text/plain');
+            document.execCommand('insertText', false, t);
+          }}
+          data-placeholder={placeholder || ''}
+          className="ftre-editor w-full flex-1 overflow-y-auto rounded-b-lg px-3 py-2 text-sm focus:outline-none"
+          style={{ minHeight: full ? undefined : minHeight, color: COLORS.navy, lineHeight: 1.6 }}
+        />
+      </div>
+      {/* Placeholder-Anzeige + sichtbare Links im Editor */}
+      <style>{`
+        .ftre-editor:empty:before { content: attr(data-placeholder); color: #9ca3af; pointer-events: none; }
+        .ftre-editor a { color: #d9531e; text-decoration: underline; }
+        .ftre-editor ul { list-style: disc; padding-left: 1.4em; }
+        .ftre-editor ol { list-style: decimal; padding-left: 1.4em; }
+      `}</style>
+    </div>
+  );
+}

--- a/src/lib/emailTemplates.ts
+++ b/src/lib/emailTemplates.ts
@@ -297,8 +297,40 @@ export function autoReplySubjectDefault(eventName?: string, requestNumber?: stri
   return `Ihre unverbindliche Anfrage${ev}${tag}`;
 }
 
+/** Erlaubte Tags für Admin-gepflegtes Auto-Antwort-HTML (WYSIWYG-Editor). */
+const AUTO_REPLY_ALLOWED_TAGS = new Set(['p', 'br', 'b', 'strong', 'i', 'em', 'u', 'ul', 'ol', 'li', 'a', 'div', 'span']);
+
+/**
+ * Sanitisiert HTML aus dem Auto-Antwort-Editor für den Mail-Versand:
+ * Tag-Whitelist, alle Attribute werden verworfen (bei <a> bleibt ein
+ * geprüftes http(s)/mailto-href mit Marken-Styling), script/style/iframe
+ * fliegen komplett raus. Defense-in-depth — Eingaben kommen nur von Admins.
+ */
+export function sanitizeAutoReplyHtml(html: string): string {
+  let out = String(html || '')
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/<(script|style|iframe|object|embed|form)[\s\S]*?<\/\1\s*>/gi, '')
+    .replace(/<(script|style|iframe|object|embed|form)[^>]*\/?>/gi, '');
+  out = out.replace(/<\s*(\/?)\s*([a-zA-Z0-9]+)((?:[^>"']|"[^"]*"|'[^']*')*)>/g, (_m, slash, tag, attrs) => {
+    const t = String(tag).toLowerCase();
+    if (!AUTO_REPLY_ALLOWED_TAGS.has(t)) return '';
+    if (slash) return `</${t}>`;
+    if (t === 'a') {
+      const hrefM = /href\s*=\s*(?:"([^"]*)"|'([^']*)')/i.exec(attrs || '');
+      const href = ((hrefM?.[1] ?? hrefM?.[2]) || '').trim();
+      if (/^(https?:\/\/|mailto:)/i.test(href)) {
+        return `<a href="${href.replace(/"/g, '&quot;')}" style="color:#d9531e;font-weight:600;">`;
+      }
+      return '<a>';
+    }
+    if (t === 'br') return '<br>';
+    return `<${t}>`;
+  });
+  return out;
+}
+
 export interface AutoReplyInput extends RecipientInfo {
-  /** Frei definierbarer Nachrichtentext (Plaintext mit Zeilenumbrüchen, Platzhalter erlaubt). */
+  /** Frei definierbarer Nachrichtentext: Plaintext ODER (ab TASK-00087) HTML aus dem WYSIWYG-Editor. */
   message: string;
   eventName?: string;
   requestNumber?: string;
@@ -315,16 +347,22 @@ export interface AutoReplyInput extends RecipientInfo {
  */
 export function autoReplyHtml(input: AutoReplyInput): string {
   const r: RecipientInfo = { salutation: input.salutation, firstName: input.firstName, lastName: input.lastName };
-  const rendered = renderRecipientTokens(escapeHtml(input.message || ''), r);
+  // HTML-Nachricht (WYSIWYG-Editor) → sanitisieren; Klartext (Legacy) → escapen.
+  const isHtml = /<[a-z][^>]*>/i.test(input.message || '');
+  const rendered = isHtml
+    ? renderRecipientTokens(sanitizeAutoReplyHtml(input.message || ''), r)
+    : renderRecipientTokens(escapeHtml(input.message || ''), r);
+  // Für Begrüßungs-Erkennung und Preheader den reinen Text betrachten.
+  const renderedText = isHtml ? rendered.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim() : rendered;
 
   // Eigene Begrüßung erkennen (erste nicht-leere Zeile)
-  const firstLine = rendered.replace(/^\s+/, '').slice(0, 40).toLowerCase();
+  const firstLine = renderedText.replace(/^\s+/, '').slice(0, 40).toLowerCase();
   const hasOwnGreeting = /^(sehr geehrt|hallo|guten (tag|morgen|mittag|abend)|liebe|moin|servus|hi[\s,]|hey[\s,])/.test(firstLine);
   const greetingHtml = hasOwnGreeting
     ? ''
     : `<p style="margin:0 0 16px;font-size:15px;line-height:1.7;color:#374151;">${neutralGreeting(r)}</p>`;
 
-  const bodyHtml = rendered.replace(/\n/g, '<br>');
+  const bodyHtml = isHtml ? rendered : rendered.replace(/\n/g, '<br>');
 
   // Link-Buttons am Mail-Ende (vom Admin je Event gepflegt) — gebrandet,
   // nur valide http(s)-/mailto-Ziele mit Beschriftung werden gerendert.
@@ -350,8 +388,8 @@ export function autoReplyHtml(input: AutoReplyInput): string {
 
   // Preheader (Inbox-Vorschau) aus dem BEREITS gerenderten Text bilden – sonst
   // erscheinen die {{…}}-Platzhalter unersetzt in der Gmail-/Client-Vorschau.
-  // rendered ist HTML-escaped → für den Preheader zurück-entschärfen (layout() escaped erneut).
-  const preheader = rendered
+  // renderedText ist HTML-escaped bzw. tag-befreit → zurück-entschärfen (layout() escaped erneut).
+  const preheader = renderedText
     .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')


### PR DESCRIPTION
## Was ist neu (TASK-00087)
**Einfacher WYSIWYG-Editor** für die Auto-Antwort-Nachricht (Events-Admin), statt roher Textarea:
- **Fett, Kursiv, Unterstrichen, Auf-/Nummerierungslisten, Links im Fließtext** (nur `http(s)`/`mailto`)
- **Vollbild-Modus** über das Symbol rechts in der Toolbar (ESC oder Klick daneben schließt)
- Einfügen aus der Zwischenablage immer als Klartext (kein Word-HTML-Müll), `{{platzhalter}}`-Buttons fügen weiter an der Cursor-Position ein

**Sicherheit & Kompatibilität**
- Serverseitiger Sanitizer `sanitizeAutoReplyHtml`: Tag-Whitelist, alle Attribute gestrippt, `<a>` nur mit geprüftem Ziel + Marken-Styling, `script/style/iframe` komplett entfernt — **8/8 Angriffs-/Normalfall-Tests grün** (XSS-Handler, `javascript:`-Links, img/table, Platzhalter bleiben)
- Bestehende **Klartext-Nachrichten rendern unverändert** (HTML wird nur erkannt, wenn Tags vorhanden sind); Begrüßungs-Automatik und Inbox-Preheader arbeiten auf dem tag-befreiten Text

Teil 2 von 2 (nach #71 / TASK-00086).

## Verifikation
`tsc --noEmit` ✅, `npm run build` ✅, Sanitizer-Harness 8/8 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)