### PR TITLE
Buchungsmaske: Passnummer/Geburtsdatum raus, Danke-Seite, CRM-Reisende-Fix (TASK-00088)

### DIFF
--- a/src/app/admin/crm/page.tsx
+++ b/src/app/admin/crm/page.tsx
@@ -94,15 +94,17 @@ const COLUMNS: { id: CrmStatus; label: string; color: string; bg: string }[] = [
 /* ─── Helpers ────────────────────────────────────────────────────────── */
 
 function getLeadName(lead: Lead): string {
-  if (!lead.travelers) return lead.email;
+  // Erster Reisender MIT Namen (Altbuchungen mit „Ich bin auch Reisender" haben ein leeres travelers[0])
   try {
     const travelers = typeof lead.travelers === 'string' ? JSON.parse(lead.travelers) : lead.travelers;
-    if (!Array.isArray(travelers) || travelers.length === 0) return lead.email;
-    const t = travelers[0];
-    const first = t?.firstName || t?.first_name || '';
-    const last = t?.lastName || t?.last_name || '';
-    return [first, last].filter(Boolean).join(' ') || lead.email;
-  } catch { return lead.email; }
+    if (Array.isArray(travelers)) {
+      for (const t of travelers) {
+        const name = [t?.firstName || t?.first_name, t?.lastName || t?.last_name].filter(Boolean).join(' ');
+        if (name) return name;
+      }
+    }
+  } catch { /* Fallbacks unten */ }
+  return (lead as { customer_name?: string }).customer_name || lead.email;
 }
 
 function formatDate(str?: string) {
@@ -736,7 +738,8 @@ function DetailDrawer({
                 let travelers: Array<{ salutation?: string; firstName?: string; lastName?: string; birthDate?: string; passportNumber?: string }> = [];
                 try {
                   const t = typeof lead.travelers === 'string' ? JSON.parse(lead.travelers) : lead.travelers;
-                  if (Array.isArray(t)) travelers = t;
+                  // Leere Einträge ausblenden (Altbuchungen: „Ich bin auch Reisender" ließ travelers[0] leer)
+                  if (Array.isArray(t)) travelers = t.filter((x) => x && (x.firstName || x.lastName || x.salutation));
                 } catch { /* ignore */ }
                 if (!travelers.length) return null;
                 return (

--- a/src/app/booking/danke/page.tsx
+++ b/src/app/booking/danke/page.tsx
@@ -1,0 +1,81 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { CheckCircle2, Phone, Mail, Clock, ArrowRight } from 'lucide-react';
+
+export const metadata: Metadata = {
+  title: 'Vielen Dank für Ihre Buchungsanfrage | Faltin Travel',
+  robots: { index: false },
+};
+
+/**
+ * Bestätigungsseite nach Absenden der verbindlichen Buchungsanfrage.
+ * Ziel der Weiterleitung aus BookingForm (?rq=RQ-12345).
+ */
+export default async function BookingDankePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ rq?: string }>;
+}) {
+  const { rq } = await searchParams;
+
+  return (
+    <div className='min-h-screen bg-gray-50 flex items-center justify-center px-4 py-16'>
+      <div className='w-full max-w-2xl'>
+        <div className='bg-white rounded-2xl shadow-sm border border-gray-200 p-8 sm:p-12 text-center'>
+          <CheckCircle2 className='mx-auto h-16 w-16' style={{ color: '#16a34a' }} />
+          <h1 className='mt-6 text-3xl font-bold text-gray-900'>Vielen Dank für Ihre Buchungsanfrage!</h1>
+          <p className='mt-3 text-gray-600'>
+            Ihre Anfrage ist bei uns eingegangen und wird persönlich geprüft.
+          </p>
+
+          {rq && (
+            <div className='mt-6 inline-flex items-center gap-2 rounded-xl px-5 py-3' style={{ background: '#f0f5fa', border: '1px solid #d5e2ef' }}>
+              <span className='text-sm text-gray-600'>Ihre Anfragenummer:</span>
+              <span className='font-mono text-lg font-bold' style={{ color: '#184a7b' }}>{rq}</span>
+            </div>
+          )}
+
+          <div className='mt-10 text-left'>
+            <h2 className='text-sm font-semibold uppercase tracking-wider text-gray-500 mb-4'>Wie geht es weiter?</h2>
+            <ol className='space-y-4'>
+              {[
+                'Wir prüfen Verfügbarkeit von Tickets, Hotel und Leistungen für Ihren Wunschtermin.',
+                'Sie erhalten von uns per E-Mail eine persönliche Bestätigung bzw. Ihr verbindliches Angebot.',
+                'Ihr persönlicher Ansprechpartner meldet sich in der Regel innerhalb eines Werktages bei Ihnen.',
+              ].map((step, i) => (
+                <li key={i} className='flex items-start gap-3'>
+                  <span className='flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-sm font-bold text-white' style={{ background: '#184a7b' }}>{i + 1}</span>
+                  <span className='text-gray-700 pt-0.5'>{step}</span>
+                </li>
+              ))}
+            </ol>
+          </div>
+
+          <div className='mt-10 rounded-xl p-6 text-left' style={{ background: '#f8fafc', border: '1px solid #e5e7eb' }}>
+            <p className='font-semibold text-gray-900 mb-3'>Fragen zu Ihrer Anfrage? Wir sind direkt für Sie da:</p>
+            <div className='grid gap-3 sm:grid-cols-3 text-sm text-gray-700'>
+              <a href='tel:+41447002277' className='flex items-center gap-2 hover:underline'>
+                <Phone className='h-4 w-4 shrink-0' style={{ color: '#f14624' }} /> +41 44 700 22 77
+              </a>
+              <a href='mailto:info@faltintravel.com' className='flex items-center gap-2 hover:underline'>
+                <Mail className='h-4 w-4 shrink-0' style={{ color: '#f14624' }} /> info@faltintravel.com
+              </a>
+              <span className='flex items-center gap-2'>
+                <Clock className='h-4 w-4 shrink-0' style={{ color: '#f14624' }} /> Mo–Fr, 08:00–18:00 Uhr
+              </span>
+            </div>
+            {rq && <p className='mt-3 text-xs text-gray-500'>Bitte geben Sie bei Rückfragen Ihre Anfragenummer {rq} an.</p>}
+          </div>
+
+          <Link
+            href='/'
+            className='mt-10 inline-flex items-center gap-2 rounded-xl px-6 py-3 font-semibold text-white transition hover:opacity-90'
+            style={{ background: '#184a7b' }}
+          >
+            Zur Startseite <ArrowRight className='h-4 w-4' />
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/BookingForm.tsx
+++ b/src/components/BookingForm.tsx
@@ -12,7 +12,7 @@ interface Traveler {
   salutation: string;
   firstName: string;
   lastName: string;
-  birthDate: string;
+  birthDate?: string;
   passportNumber?: string;
 }
 
@@ -27,7 +27,6 @@ interface BookingFormData {
   mainBookerSalutation: string;
   mainBookerFirstName: string;
   mainBookerLastName: string;
-  mainBookerBirthDate: string;
   street: string;
   zip: string;
   city: string;
@@ -179,7 +178,7 @@ export default function BookingForm() {
       doubleRooms: 0,
       singleRooms: 1,
       numberOfPersons: 1,
-      travelers: Array(1).fill({ salutation: '', firstName: '', lastName: '', birthDate: '', passportNumber: '' })
+      travelers: Array(1).fill({ salutation: '', firstName: '', lastName: '' })
     }
   });
 
@@ -269,7 +268,7 @@ export default function BookingForm() {
         setValue('numberOfPersons', persons);
         setValue('doubleRooms', 0);
         setValue('singleRooms', persons);
-        setValue('travelers', Array(persons).fill({ salutation: '', firstName: '', lastName: '', birthDate: '', passportNumber: '' }));
+        setValue('travelers', Array(persons).fill({ salutation: '', firstName: '', lastName: '' }));
         setNumberOfPersons(persons);
         setSelectedPreset('0');
       } else if (roomParam === 'double') {
@@ -280,7 +279,7 @@ export default function BookingForm() {
         const singleRooms = persons % 2;
         setValue('doubleRooms', doubleRooms);
         setValue('singleRooms', singleRooms);
-        setValue('travelers', Array(persons).fill({ salutation: '', firstName: '', lastName: '', birthDate: '', passportNumber: '' }));
+        setValue('travelers', Array(persons).fill({ salutation: '', firstName: '', lastName: '' }));
         setNumberOfPersons(persons);
         setSelectedPreset('0');
       } else if (personsParam) {
@@ -290,7 +289,7 @@ export default function BookingForm() {
         const singleRooms = persons % 2;
         setValue('doubleRooms', doubleRooms);
         setValue('singleRooms', singleRooms);
-        setValue('travelers', Array(persons).fill({ salutation: '', firstName: '', lastName: '', birthDate: '', passportNumber: '' }));
+        setValue('travelers', Array(persons).fill({ salutation: '', firstName: '', lastName: '' }));
         setNumberOfPersons(persons);
         setSelectedPreset('0');
       }
@@ -394,7 +393,18 @@ export default function BookingForm() {
     }
 
     setIsSubmitting(true);
-    
+
+    // „Ich bin auch Reisender": Daten des Hauptanmelders als ersten Reisenden übernehmen
+    // (das Formular blendet travelers[0] dann aus – ohne Übernahme bliebe der Eintrag leer).
+    const submittedTravelers = [...data.travelers];
+    if (mainBookerIsTraveler) {
+      submittedTravelers[0] = {
+        salutation: data.mainBookerSalutation,
+        firstName: data.mainBookerFirstName,
+        lastName: data.mainBookerLastName,
+      };
+    }
+
     try {
       const response = await fetch('/api/bookings', {
         method: 'POST',
@@ -410,7 +420,7 @@ export default function BookingForm() {
           numberOfPersons: data.numberOfPersons,
           doubleRooms: data.doubleRooms,
           singleRooms: data.singleRooms,
-          travelers: data.travelers,
+          travelers: submittedTravelers,
           salutation: data.mainBookerSalutation,
           firstName: data.mainBookerFirstName,
           lastName: data.mainBookerLastName,
@@ -430,9 +440,9 @@ export default function BookingForm() {
       const result = await response.json();
 
       if (result.success) {
-        alert('✅ Vielen Dank für Ihre Buchungsanfrage! Wir werden uns in Kürze bei Ihnen melden.');
-        // Optionally redirect to thank you page
-        // window.location.href = '/danke';
+        const rq = result.requestNumber ? `?rq=${encodeURIComponent(result.requestNumber)}` : '';
+        window.location.href = `/booking/danke${rq}`;
+        return;
       } else {
         alert('❌ Fehler beim Absenden: ' + result.error);
       }
@@ -745,11 +755,6 @@ export default function BookingForm() {
 
                     <div className='grid md:grid-cols-2 gap-4'>
                       <div>
-                        <label className='block text-sm font-semibold text-gray-700 mb-2'>Geburtsdatum *</label>
-                        <input type='date' {...register('mainBookerBirthDate', { required: true })} className='w-full min-w-0 max-w-full appearance-none px-4 py-3 border border-gray-300 rounded-lg bg-white' />
-                        {errors.mainBookerBirthDate && <span className='text-red-500 text-sm'>Pflichtfeld</span>}
-                      </div>
-                      <div>
                         <label className='block text-sm font-semibold text-gray-700 mb-2'>E-Mail *</label>
                         <div className='relative'>
                           <Mail className='absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5' />
@@ -932,16 +937,6 @@ export default function BookingForm() {
                       <div>
                         <label className='block text-sm font-semibold text-gray-700 mb-2'>Nachname *</label>
                         <input type='text' {...register(`travelers.${index}.lastName`, { required: true })} className='w-full px-4 py-3 border border-gray-300 rounded-lg bg-white' placeholder='Wie im Reisepass' />
-                      </div>
-                    </div>
-                    <div className='grid md:grid-cols-2 gap-4'>
-                      <div>
-                        <label className='block text-sm font-semibold text-gray-700 mb-2'>Geburtsdatum *</label>
-                        <input type='date' {...register(`travelers.${index}.birthDate`, { required: true })} className='w-full min-w-0 max-w-full appearance-none px-4 py-3 border border-gray-300 rounded-lg bg-white' />
-                      </div>
-                      <div>
-                        <label className='block text-sm font-semibold text-gray-700 mb-2'>Passnummer (optional)</label>
-                        <input type='text' {...register(`travelers.${index}.passportNumber`)} className='w-full px-4 py-3 border border-gray-300 rounded-lg bg-white' placeholder='Falls vorhanden' />
                       </div>
                     </div>
                   </div>

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -40,7 +40,7 @@ export interface Traveler {
   salutation: string;
   firstName: string;
   lastName: string;
-  birthDate: string;
+  birthDate?: string;
   passportNumber?: string;
 }
 


### PR DESCRIPTION
## Ticket
TASK-00088 – Super Bowl Buchungsseite anpassen (Stefan) — betrifft die zentrale Buchungsmaske aller Events.

## Änderungen (alle 4 Punkte)
1. **Passnummer raus:** Das Feld erschien nur bei weiteren Reisenden — entfernt.
2. **Geburtsdatum raus:** Beim Hauptanmelder UND bei den Reisenden entfernt (das Hauptanmelder-Geburtsdatum wurde ohnehin nie an die API gesendet). Alte Buchungen mit Geburtsdatum bleiben im CRM lesbar.
3. **Weiterleitung:** Nach erfolgreicher verbindlicher Buchungsanfrage kein Browser-`alert()` mehr, sondern Redirect auf die neue Danke-Seite `/booking/danke?rq=RQ-xxxxx` — mit Anfragenummer, „Wie geht es weiter?"-Schritten und Kontaktblock.
4. **CRM-Darstellung (Stefan vs. Natalie):** Root Cause gefunden — die Checkbox „Ich bin auch Reisender" versprach die Datenübernahme, hat sie aber nie gemacht: `travelers[0]` blieb leer → je nach Buchung fehlte der Name im CRM. Jetzt werden die Hauptanmelder-Daten beim Absenden wirklich übernommen; zusätzlich blendet das CRM leere Alt-Einträge aus und fällt beim Lead-Namen auf den ersten benannten Reisenden bzw. den Kunden zurück. (Es war also datenabhängig, nicht userabhängig.)

## Verifikation
End-zu-End im Browser: Formular ohne Geburtsdatum/Passnummer ausgefüllt, „Ich bin auch Reisender" angehakt, abgesendet → Redirect auf `/booking/danke?rq=RQ-10001`, gespeicherte Buchung enthält `travelers[0]` mit den Hauptanmelder-Daten. `tsc` ✅ · `build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)