### PR TITLE
fix(security): Session-Auth für offene API-Routen (Bookings/Invoices/Expenses/Settings)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,19 @@ Laufzeit-Lesen Content: `src/lib/contentStore.ts` (`findPackagesByEvent` etc.).
 - **SSO-Redirect-URI** `https://next.faltintravel.com/api/auth/microsoft/callback` muss bei der aktiven App registriert sein (sonst `AADSTS500113`). Basis-URL kommt aus `settings.mail.login_base_url` bzw. Request-Host.
 - **Lokaler Admin-Login:** User `localadmin`, PW `LOCAL_ADMIN_PASSWORD` (Default `faltin-localadmin-2026`).
 
+## API-Auth (Routen außerhalb von /api/admin) — WICHTIG
+- Die Middleware schützt NUR `/admin/*` + `/api/admin/*`. Sensible Routen außerhalb
+  (z.B. `/api/bookings` GET, `/api/invoices*`, `/api/expenses*`, `/api/settings`,
+  `/api/bookings/[id]/messages|reply`) prüfen selbst per `requireAdminSession()` aus
+  `src/lib/apiGuard.ts` (401 ohne Session). **Neue Routen außerhalb `/api/admin`:
+  Guard einbauen**, außer bewusst öffentlich (POST `/api/bookings` = Buchungsformular/
+  WordPress-CORS; Content-Routen events/series/faqs/package*; `/api/health`;
+  Portal/Tippspiel/`/api/ext` haben eigene Auth).
+- Interne Loopback-Calls (Portal → Rechnungs-PDF) authentifizieren sich mit
+  `internalApiKey()` (Header `x-internal-key`, aus `AUTH_SECRET` abgeleitet).
+- Cron-Endpoints `/api/inbound/poll` + `/api/status/scan`: Secret ODER Admin-Session,
+  fail-closed (Mail-Polling läuft ohnehin in-process via `instrumentation.ts`).
+
 ## KI-Redaktion
 - Config: `settings.json.ai` (anthropic_api_key, model; Default `claude-sonnet-4-6`).
 - `src/lib/aiAssist.ts` (Anthropic Messages API, multimodal), `src/lib/urlFetch.ts` (HTML→Text).

--- a/src/app/api/bookings/[id]/messages/route.ts
+++ b/src/app/api/bookings/[id]/messages/route.ts
@@ -1,11 +1,14 @@
 import { NextResponse } from 'next/server';
 import { listMessages } from '@/lib/bookingStore';
 import { listAttachmentsForBooking } from '@/lib/documentStore';
+import { requireAdminSession } from '@/lib/apiGuard';
 
 export async function GET(
   _request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const denied = await requireAdminSession();
+  if (denied) return denied;
   try {
     const { id } = await params;
     const messages = await listMessages(id);

--- a/src/app/api/bookings/[id]/reply/route.ts
+++ b/src/app/api/bookings/[id]/reply/route.ts
@@ -4,11 +4,14 @@ import { getEventBySlug } from '@/lib/eventData';
 import { sendGraphMail, isGraphConfigured, getMailbox, getFromName, type MailAttachment } from '@/lib/graphMailer';
 import { replyEmailHtml, replySubject } from '@/lib/emailTemplates';
 import { addMessageAttachment, MAX_FILE_BYTES } from '@/lib/documentStore';
+import { requireAdminSession } from '@/lib/apiGuard';
 
 export async function POST(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const denied = await requireAdminSession();
+  if (denied) return denied;
   try {
     const { id } = await params;
 

--- a/src/app/api/bookings/[id]/route.ts
+++ b/src/app/api/bookings/[id]/route.ts
@@ -1,10 +1,13 @@
 import { NextResponse } from 'next/server';
 import { updateBooking } from '@/lib/bookingStore';
+import { requireAdminSession } from '@/lib/apiGuard';
 
 export async function PATCH(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const denied = await requireAdminSession();
+  if (denied) return denied;
   try {
     const { id } = await params;
     const body = await request.json();

--- a/src/app/api/bookings/route.ts
+++ b/src/app/api/bookings/route.ts
@@ -10,6 +10,7 @@ import {
 } from '@/lib/emailTemplates';
 import { linkBookingToCustomer, normalizeSalutation } from '@/lib/customerStore';
 import { readAutoReplyPdfBase64, autoReplyContentType } from '@/lib/autoReplyStore';
+import { requireAdminSession } from '@/lib/apiGuard';
 
 /**
  * CORS: erlaubt das Anfrage-Formular auf WordPress ([faltin_anfrage]).
@@ -232,7 +233,11 @@ export async function POST(request: Request) {
   }
 }
 
+// Nur für das Admin-Panel: komplette Lead-Liste inkl. PII → Session-Pflicht.
+// (POST bleibt bewusst öffentlich – Buchungsformular + WordPress posten hierher.)
 export async function GET() {
+  const denied = await requireAdminSession();
+  if (denied) return denied;
   try {
     const bookings = await listBookings();
     return NextResponse.json({ success: true, data: bookings });

--- a/src/app/api/expenses/[id]/route.ts
+++ b/src/app/api/expenses/[id]/route.ts
@@ -1,10 +1,13 @@
 import { NextResponse } from 'next/server';
 import { getExpense, updateExpenseRecord, deleteExpenseRecord } from '@/lib/expenseStore';
+import { requireAdminSession } from '@/lib/apiGuard';
 
 export async function PATCH(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const denied = await requireAdminSession();
+  if (denied) return denied;
   try {
     const { id } = await params;
     const body = await request.json();
@@ -42,6 +45,8 @@ export async function DELETE(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const denied = await requireAdminSession();
+  if (denied) return denied;
   try {
     const { id } = await params;
     const existing = await getExpense(id);

--- a/src/app/api/expenses/route.ts
+++ b/src/app/api/expenses/route.ts
@@ -1,8 +1,11 @@
 import { NextResponse } from 'next/server';
 import { createExpenseRecord, listExpenses } from '@/lib/expenseStore';
+import { requireAdminSession } from '@/lib/apiGuard';
 
 // Get all expenses (optionally filtered by event or booking)
 export async function GET(request: Request) {
+  const denied = await requireAdminSession();
+  if (denied) return denied;
   try {
     const { searchParams } = new URL(request.url);
     const eventSlug = searchParams.get('eventSlug');
@@ -21,6 +24,8 @@ export async function GET(request: Request) {
 
 // Create expense
 export async function POST(request: Request) {
+  const denied = await requireAdminSession();
+  if (denied) return denied;
   try {
     const body = await request.json();
 

--- a/src/app/api/inbound/poll/route.ts
+++ b/src/app/api/inbound/poll/route.ts
@@ -1,21 +1,23 @@
 import { NextResponse } from 'next/server';
 import { runInboundPoll } from '@/lib/inboundPoll';
 import { getSettings } from '@/lib/settingsStore';
+import { requireAdminSession } from '@/lib/apiGuard';
 
 /**
  * Inbound-Polling (Cron-Endpoint).
  * Aufruf: GET/POST /api/inbound/poll?secret=<INBOUND_POLL_SECRET>
- * Schutz: wenn INBOUND_POLL_SECRET gesetzt ist, muss es übergeben werden.
+ * Schutz: gültiges Secret ODER Admin-Session. Ohne konfiguriertes Secret ist
+ * der Endpoint NICHT offen (fail-closed) – der interne Scheduler
+ * (instrumentation.ts) ruft runInboundPoll() direkt auf und braucht ihn nicht.
  */
 async function handle(request: Request) {
   const secret = getSettings().mail.inbound_poll_secret || process.env.INBOUND_POLL_SECRET;
-  if (secret) {
-    const url = new URL(request.url);
-    const provided =
-      url.searchParams.get('secret') || request.headers.get('x-poll-secret') || '';
-    if (provided !== secret) {
-      return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
-    }
+  const url = new URL(request.url);
+  const provided =
+    url.searchParams.get('secret') || request.headers.get('x-poll-secret') || '';
+  if (!secret || provided !== secret) {
+    const denied = await requireAdminSession();
+    if (denied) return denied;
   }
 
   const result = await runInboundPoll();

--- a/src/app/api/invoices/[id]/pdf/route.ts
+++ b/src/app/api/invoices/[id]/pdf/route.ts
@@ -7,11 +7,17 @@ import { jsPDF } from 'jspdf';
 import fs from 'fs';
 import path from 'path';
 import QRCode from 'qrcode';
+import { requireAdminSession, isInternalRequest } from '@/lib/apiGuard';
 
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  // Admin-Session ODER interner Loopback-Aufruf (Portal-PDF mit eigenem Owner-Check).
+  if (!isInternalRequest(request)) {
+    const denied = await requireAdminSession();
+    if (denied) return denied;
+  }
   try {
     const { id } = await params;
     

--- a/src/app/api/invoices/[id]/route.ts
+++ b/src/app/api/invoices/[id]/route.ts
@@ -1,10 +1,13 @@
 import { NextResponse } from 'next/server';
 import { updateInvoiceStatus, recordPayment, getInvoiceById, getInvoiceItems } from '@/lib/invoiceStore';
+import { requireAdminSession } from '@/lib/apiGuard';
 
 export async function PATCH(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const denied = await requireAdminSession();
+  if (denied) return denied;
   try {
     const { id } = await params;
     const body = await request.json();
@@ -98,6 +101,8 @@ export async function DELETE(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const denied = await requireAdminSession();
+  if (denied) return denied;
   try {
     const { id } = await params;
     

--- a/src/app/api/invoices/prefill/route.ts
+++ b/src/app/api/invoices/prefill/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getBooking } from '@/lib/bookingStore';
 import { getCustomer } from '@/lib/customerStore';
 import { findEventBySlug, findPackagesByEvent, getPackages, getEvents, type ContentPackageRecord } from '@/lib/contentStore';
+import { requireAdminSession } from '@/lib/apiGuard';
 
 /**
  * Rechnungs-Vorbefüllung aus einer Buchungsanfrage: lädt Buchung + Package +
@@ -14,6 +15,8 @@ import { findEventBySlug, findPackagesByEvent, getPackages, getEvents, type Cont
 interface PrefillItem { description: string; quantity: number; unit_price: number }
 
 export async function GET(request: Request) {
+  const denied = await requireAdminSession();
+  if (denied) return denied;
   const { searchParams } = new URL(request.url);
   const bookingId = searchParams.get('bookingId') || '';
   if (!bookingId) {

--- a/src/app/api/invoices/route.ts
+++ b/src/app/api/invoices/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { createInvoiceRecord, listInvoices, getInvoiceItems } from '@/lib/invoiceStore';
 import { getBooking, createBooking } from '@/lib/bookingStore';
+import { requireAdminSession } from '@/lib/apiGuard';
 
 interface ManualCustomer {
   firstName?: string;
@@ -12,6 +13,8 @@ interface ManualCustomer {
 
 // Create invoice (für bestehenden Lead ODER individuelle/manuelle Buchung)
 export async function POST(request: Request) {
+  const denied = await requireAdminSession();
+  if (denied) return denied;
   try {
     const body = await request.json();
     const { bookingId, items, dueInDays, notes } = body;
@@ -82,6 +85,8 @@ export async function POST(request: Request) {
 
 // Get all invoices or by booking ID
 export async function GET(request: Request) {
+  const denied = await requireAdminSession();
+  if (denied) return denied;
   try {
     const { searchParams } = new URL(request.url);
     const bookingId = searchParams.get('bookingId');

--- a/src/app/api/portal/invoices/[id]/pdf/route.ts
+++ b/src/app/api/portal/invoices/[id]/pdf/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getPortalSession } from '@/lib/portalSession';
 import { getInvoiceById } from '@/lib/invoiceStore';
 import { getBooking } from '@/lib/bookingStore';
+import { internalApiKey, INTERNAL_KEY_HEADER } from '@/lib/apiGuard';
 
 /** GET /api/portal/invoices/[id]/pdf - Rechnung-PDF (nur Eigentuemer). */
 export async function GET(req: Request, { params }: { params: Promise<{ id: string }> }) {
@@ -19,7 +20,9 @@ export async function GET(req: Request, { params }: { params: Promise<{ id: stri
   // PDF-Erzeugung an die bestehende Route delegieren – intern über Loopback
   // (hinter dem Reverse-Proxy ist req.url die interne Adresse; Loopback ist robust).
   const internal = `http://127.0.0.1:${process.env.PORT || '3000'}`;
-  const r = await fetch(`${internal}/api/invoices/${encodeURIComponent(id)}/pdf`);
+  const r = await fetch(`${internal}/api/invoices/${encodeURIComponent(id)}/pdf`, {
+    headers: { [INTERNAL_KEY_HEADER]: internalApiKey() },
+  });
   if (!r.ok) return NextResponse.json({ success: false, error: 'PDF-Erzeugung fehlgeschlagen' }, { status: 502 });
   const buf = Buffer.from(await r.arrayBuffer());
   return new NextResponse(buf, {

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,7 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSettings, saveSettings } from '@/lib/settingsStore';
+import { requireAdminSession } from '@/lib/apiGuard';
 
+// Settings enthalten Secrets (admin_password, Graph client_secret, API-Keys)
+// und werden nur vom Admin-Panel gelesen/geschrieben → Session-Pflicht.
 export async function GET() {
+  const denied = await requireAdminSession();
+  if (denied) return denied;
   try {
     const settings = getSettings();
     return NextResponse.json({ success: true, data: settings });
@@ -14,6 +19,8 @@ export async function GET() {
 }
 
 export async function PATCH(request: NextRequest) {
+  const denied = await requireAdminSession();
+  if (denied) return denied;
   try {
     const body = await request.json();
     const updated = saveSettings(body);

--- a/src/app/api/status/scan/route.ts
+++ b/src/app/api/status/scan/route.ts
@@ -1,23 +1,24 @@
 import { NextResponse } from 'next/server';
 import { runScan } from '@/lib/statusCheck';
 import { getSettings } from '@/lib/settingsStore';
+import { requireAdminSession } from '@/lib/apiGuard';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 60;
 
 /**
- * Cron-Endpoint für den täglichen System-Scan (außerhalb von /api/admin, also ohne Login).
+ * Cron-Endpoint für den täglichen System-Scan (außerhalb von /api/admin).
  * Aufruf: GET/POST /api/status/scan?secret=<INBOUND_POLL_SECRET>
- * Schutz: identisch zum Inbound-Poll – wenn ein Secret gesetzt ist, muss es übergeben werden.
+ * Schutz: identisch zum Inbound-Poll – gültiges Secret ODER Admin-Session,
+ * ohne konfiguriertes Secret fail-closed.
  */
 async function handle(request: Request) {
   const secret = getSettings().mail.inbound_poll_secret || process.env.INBOUND_POLL_SECRET;
-  if (secret) {
-    const url = new URL(request.url);
-    const provided = url.searchParams.get('secret') || request.headers.get('x-poll-secret') || '';
-    if (provided !== secret) {
-      return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
-    }
+  const url = new URL(request.url);
+  const provided = url.searchParams.get('secret') || request.headers.get('x-poll-secret') || '';
+  if (!secret || provided !== secret) {
+    const denied = await requireAdminSession();
+    if (denied) return denied;
   }
   try {
     const report = await runScan(true);

--- a/src/lib/apiGuard.ts
+++ b/src/lib/apiGuard.ts
@@ -1,0 +1,42 @@
+/**
+ * apiGuard.ts – Session-Guard für sensible API-Routen AUSSERHALB von /api/admin.
+ *
+ * Die Middleware (src/middleware.ts) schützt nur /admin/* und /api/admin/*.
+ * Routen wie /api/bookings (GET), /api/invoices oder /api/settings liegen
+ * außerhalb und müssen selbst prüfen – sonst sind Kundendaten (PII),
+ * Rechnungen und Secrets öffentlich abrufbar.
+ *
+ * Verwendung im Route-Handler (erste Zeile):
+ *   const denied = await requireAdminSession();
+ *   if (denied) return denied;
+ */
+import { createHmac, timingSafeEqual } from 'crypto';
+import { NextResponse } from 'next/server';
+import { getSession } from './serverSession';
+import { authSecret } from './auth';
+
+/** 401-Response, wenn keine gültige Admin-Session vorliegt – sonst null. */
+export async function requireAdminSession(): Promise<NextResponse | null> {
+  if (await getSession()) return null;
+  return NextResponse.json({ success: false, error: 'Nicht angemeldet' }, { status: 401 });
+}
+
+export const INTERNAL_KEY_HEADER = 'x-internal-key';
+
+/**
+ * Schlüssel für interne Server-zu-Server-Loopback-Aufrufe (z.B. Portal →
+ * Rechnungs-PDF). Aus AUTH_SECRET abgeleitet, damit kein zusätzliches
+ * Secret gepflegt werden muss.
+ */
+export function internalApiKey(): string {
+  return createHmac('sha256', authSecret()).update('ft-internal-api').digest('hex');
+}
+
+/** Trägt der Request den gültigen internen Loopback-Schlüssel? */
+export function isInternalRequest(request: Request): boolean {
+  const provided = request.headers.get(INTERNAL_KEY_HEADER) || '';
+  const expected = internalApiKey();
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  return a.length === b.length && timingSafeEqual(a, b);
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -17,9 +17,10 @@ export interface Session {
   exp: number;
 }
 
-function secret(): string {
+export function authSecret(): string {
   return process.env.AUTH_SECRET || 'ft-dev-insecure-secret-bitte-AUTH_SECRET-setzen';
 }
+const secret = authSecret;
 
 function b64url(bytes: Uint8Array): string {
   let s = '';


### PR DESCRIPTION
## Problem (TASK-00089)

`GET /api/bookings` lieferte die **komplette Lead-/Buchungsliste inkl. PII** (Namen, Adressen, E-Mail, Telefon, Altdaten mit Geburtsdaten/Passnummern) **ohne Authentifizierung** — die Middleware schützt nur `/admin/*` + `/api/admin/*`, die Buchungs-Routen prüften selbst nichts. Ein Audit aller `/api/*`-Routen außerhalb von `/api/admin` fand weitere offene Endpoints.

## Fix

Neuer Guard `requireAdminSession()` in `src/lib/apiGuard.ts` (nutzt `getSession()`/`verifySessionToken` wie `getSessionEmployee` in `/api/admin/tasks`) — direkt in den Handlern:

| Route | Methoden | Vorher |
|---|---|---|
| `/api/bookings` | GET | komplette Lead-Liste inkl. PII offen |
| `/api/bookings/[id]` | PATCH | Status/Notizen von jedem änderbar |
| `/api/bookings/[id]/messages` | GET | CRM-Mailverlauf offen |
| `/api/bookings/[id]/reply` | POST | Mailversand im Firmennamen von jedem |
| `/api/invoices` + `[id]` + `[id]/pdf` + `prefill` | GET/POST/PATCH/DELETE | Rechnungen inkl. PII/Bankdaten offen, Zahlungen von jedem verbuchbar |
| `/api/expenses` + `[id]` | GET/POST/PATCH/DELETE | Ausgaben offen/manipulierbar |
| `/api/settings` | GET/PATCH | **admin_password, Graph client_secret, anthropic_api_key** offen lesbar + überschreibbar |
| `/api/inbound/poll`, `/api/status/scan` | GET/POST | fail-open ohne Secret → jetzt Secret ODER Session, fail-closed |

**Bewusst öffentlich bleiben:** `POST /api/bookings` (Buchungsformular auf next.faltintravel.com + WordPress `[faltin_anfrage]`, CORS unverändert), `OPTIONS`, Content-Routen (`/api/events`, `/api/series`, `/api/faqs`, `/api/package*`), `/api/health`. Portal/Tippspiel/`/api/ext` haben eigene Auth (geprüft).

**Portal-Rechnungs-PDF:** `/api/portal/invoices/[id]/pdf` holt das PDF per Loopback von `/api/invoices/[id]/pdf` — dieser interne Call authentifiziert sich jetzt via `x-internal-key` (`internalApiKey()`, HMAC aus `AUTH_SECRET`), Owner-Check bleibt in der Portal-Route.

Die Admin-UIs (CRM, Buchungen, Finanzen, Settings) sind Client-Components mit same-origin Fetch — das Session-Cookie wird automatisch mitgesendet, **keine UI-Änderungen nötig**.

## Verifikation (lokaler Dev-Server)

- Ohne Session: alle o.g. Routen → `401 Nicht angemeldet` ✅
- Mit localadmin-Session: `GET /api/bookings|invoices|expenses|settings` → 200; `PATCH /api/bookings/<unbekannt>` → 404 (Handler erreicht) ✅
- `POST /api/bookings` ohne Auth → 400 Validierung (Handler öffentlich erreichbar), `OPTIONS` → 204, `/api/events` + `/api/health` → 200 ✅
- PDF-Route: gültiger `x-internal-key` → passiert Guard (404 bei unbekannter Rechnung), falscher Key → 401 ✅
- `npx tsc --noEmit` + `npm run build` grün ✅

Ticket: TASK-00089

🤖 Generated with [Claude Code](https://claude.com/claude-code)