### PR TITLE
fix(settings): totes Klartext-Admin-Passwort-Feld entfernen

### DIFF
--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -298,15 +298,6 @@ export default function SettingsPage() {
               rows={3}
             />
           </SectionCard>
-          <SectionCard title="Admin">
-            <InputField
-              label="Admin-Passwort"
-              value={settings.site.admin_password}
-              onChange={e => update('site', 'admin_password', e.target.value)}
-              type="password"
-              hint="Passwort für den Admin-Bereich — nach Änderung neu einloggen"
-            />
-          </SectionCard>
         </div>
       )}
 

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getSettings, saveSettings } from '@/lib/settingsStore';
 import { requireAdminSession } from '@/lib/apiGuard';
 
-// Settings enthalten Secrets (admin_password, Graph client_secret, API-Keys)
+// Settings enthalten Secrets (Graph client_secret, API-Keys)
 // und werden nur vom Admin-Panel gelesen/geschrieben → Session-Pflicht.
 export async function GET() {
   const denied = await requireAdminSession();

--- a/src/lib/settingsStore.ts
+++ b/src/lib/settingsStore.ts
@@ -73,8 +73,6 @@ export interface SiteSettings {
   site_description: string;
   /** OG image path in /public */
   og_image: string;
-  /** Admin password (plain – in production use a hashed approach) */
-  admin_password: string;
 }
 
 export interface AiSettings {
@@ -177,7 +175,6 @@ const DEFAULT_SETTINGS: AllSettings = {
     site_description:
       'Offizielle Super Bowl LXI 2027 Packages inkl. Tickets, Hotel & VIP-Hospitality.',
     og_image: '/Super-Bowl-LXI-Tickets-Packages.webp',
-    admin_password: 'faltin-admin-2025',
   },
   mail: {
     tenant_id: '',
@@ -211,6 +208,18 @@ function ensureDataDir() {
   }
 }
 
+/**
+ * site.admin_password ist deprecated (seit 2026-07): der Admin-Login läuft über
+ * Microsoft SSO bzw. localadmin (src/lib/auth.ts), das Feld schützt nichts mehr.
+ * Ältere settings.json-Dateien (und alte Clients im PATCH-Body) dürfen es noch
+ * enthalten — hier wird es beim Lesen/Schreiben still entfernt.
+ */
+function stripLegacySiteFields(site: SiteSettings): SiteSettings {
+  const cleaned = { ...site } as SiteSettings & { admin_password?: unknown };
+  delete cleaned.admin_password;
+  return cleaned;
+}
+
 export function getSettings(): AllSettings {
   try {
     ensureDataDir();
@@ -225,7 +234,7 @@ export function getSettings(): AllSettings {
       bank: { ...DEFAULT_SETTINGS.bank, ...parsed.bank },
       invoice: { ...DEFAULT_SETTINGS.invoice, ...parsed.invoice },
       event: { ...DEFAULT_SETTINGS.event, ...parsed.event },
-      site: { ...DEFAULT_SETTINGS.site, ...parsed.site },
+      site: stripLegacySiteFields({ ...DEFAULT_SETTINGS.site, ...parsed.site }),
       mail: { ...DEFAULT_SETTINGS.mail, ...parsed.mail },
       ai: { ...DEFAULT_SETTINGS.ai, ...parsed.ai },
       github: { ...DEFAULT_SETTINGS.github, ...parsed.github },
@@ -244,7 +253,7 @@ export function saveSettings(updates: Partial<AllSettings>): AllSettings {
     bank: { ...current.bank, ...(updates.bank || {}) },
     invoice: { ...current.invoice, ...(updates.invoice || {}) },
     event: { ...current.event, ...(updates.event || {}) },
-    site: { ...current.site, ...(updates.site || {}) },
+    site: stripLegacySiteFields({ ...current.site, ...(updates.site || {}) }),
     mail: { ...current.mail, ...(updates.mail || {}) },
     ai: { ...current.ai, ...(updates.ai || {}) },
     github: { ...current.github, ...(updates.github || {}) },


### PR DESCRIPTION
## Was
`settings.json.site.admin_password` (Default `faltin-admin-2025`) wird von keiner Auth-Logik mehr genutzt — der Admin-Login läuft über Microsoft SSO bzw. `localadmin`/`LOCAL_ADMIN_PASSWORD` (`src/lib/auth.ts`). Das Eingabefeld unter /admin/einstellungen → Tab Website suggerierte ein Klartext-Passwort, das nichts schützt.

## Änderungen
- **Settings-UI:** SectionCard „Admin" mit dem Passwort-Feld entfernt (`src/app/admin/settings/page.tsx`)
- **settingsStore:** `admin_password` aus `SiteSettings`-Interface und `DEFAULT_SETTINGS` entfernt
- **Abwärtskompatibilität:** `stripLegacySiteFields()` entfernt das Legacy-Feld still beim Lesen (`getSettings`) und Schreiben (`saveSettings`) — bestehende `settings.json`-Dateien brechen nicht und werden beim nächsten Speichern bereinigt
- Kommentar in `/api/settings`-Route angepasst (admin_password ist kein enthaltenes Secret mehr)

## Verifikation
- `npx tsc --noEmit` ✅, `npm run build` ✅
- Smoke-Test: alte `settings.json` mit `admin_password` lädt fehlerfrei; Feld ist im geladenen Objekt nicht mehr enthalten und nach dem nächsten `saveSettings` auch nicht mehr auf Disk; übrige Werte bleiben erhalten

Ticket: TASK-00092

🤖 Generated with [Claude Code](https://claude.com/claude-code)