### PR TITLE
feat(aufgaben): Projekte-Verwaltung — anlegen, archivieren, reaktivieren

### DIFF
--- a/src/app/admin/aufgaben/page.tsx
+++ b/src/app/admin/aufgaben/page.tsx
@@ -5,10 +5,11 @@ import AdminShell from '@/components/admin/AdminShell';
 import {
   PageHeader, Card, SectionCard, Button, Field, TextInput, SelectInput, TextArea, Badge, Spinner, COLORS,
 } from '@/components/admin/ui';
-import { Plus, Trash2, ChevronRight, ChevronLeft, ListTodo, GripVertical } from 'lucide-react';
+import { Plus, Trash2, ChevronRight, ChevronLeft, ListTodo, GripVertical, FolderKanban } from 'lucide-react';
 import Link from 'next/link';
 import { DndContext, useDraggable, useDroppable, PointerSensor, useSensor, useSensors, type DragEndEvent } from '@dnd-kit/core';
 import TaskDrawer from '@/components/admin/TaskDrawer';
+import ProjectManagerDialog from '@/components/admin/ProjectManagerDialog';
 
 type TaskStatus = 'offen' | 'in_arbeit' | 'warten_requester' | 'warten_dritte' | 'erledigt';
 
@@ -28,7 +29,7 @@ interface StaffTask {
   project_name?: string | null;
 }
 
-interface ProjectLite { id: string; name: string }
+interface ProjectLite { id: string; name: string; status?: 'aktiv' | 'archiviert' }
 
 function ticketNo(n: number | null): string {
   return n && n > 0 ? `TASK-${String(n).padStart(5, '0')}` : '';
@@ -196,6 +197,7 @@ export default function AufgabenPage() {
   const [form, setForm] = useState({ title: '', description: '', assignee_id: '', due_date: '', priority: 'normal', project_id: '' });
   const [saving, setSaving] = useState(false);
   const [selected, setSelected] = useState<StaffTask | null>(null);
+  const [showProjects, setShowProjects] = useState(false);
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
 
@@ -214,7 +216,7 @@ export default function AufgabenPage() {
 
   const loadProjects = useCallback(async () => {
     const r = await fetch('/api/admin/projects').then((x) => x.json()).catch(() => null);
-    if (r?.success) setProjects(r.data.map((p: ProjectLite) => ({ id: p.id, name: p.name })));
+    if (r?.success) setProjects(r.data.map((p: ProjectLite) => ({ id: p.id, name: p.name, status: p.status })));
   }, []);
 
   useEffect(() => {
@@ -337,12 +339,15 @@ export default function AufgabenPage() {
             <SelectInput value={filterProject} onChange={(e) => setFilterProject(e.target.value)} className="w-52">
               <option value="">Alle Projekte</option>
               <option value="none">Ohne Projekt</option>
-              {projects.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
+              {projects.map((p) => <option key={p.id} value={p.id}>{p.name}{p.status === 'archiviert' ? ' (archiviert)' : ''}</option>)}
             </SelectInput>
             <SelectInput value={filterAssignee} onChange={(e) => setFilterAssignee(e.target.value)} className="w-48">
               <option value="">Alle Mitarbeiter</option>
               {employees.map((e) => <option key={e.id} value={e.id}>{e.name}</option>)}
             </SelectInput>
+            <Button variant="secondary" onClick={() => setShowProjects(true)}>
+              <FolderKanban className="h-4 w-4" /> Projekte
+            </Button>
           </div>
         }
       />
@@ -379,7 +384,9 @@ export default function AufgabenPage() {
               }}
             >
               <option value="">Kein Projekt</option>
-              {projects.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
+              {projects.filter((p) => p.status !== 'archiviert' || p.id === form.project_id).map((p) => (
+                <option key={p.id} value={p.id}>{p.name}{p.status === 'archiviert' ? ' (archiviert)' : ''}</option>
+              ))}
               <option value="__new__">＋ Neues Projekt…</option>
             </SelectInput>
           </Field>
@@ -447,6 +454,11 @@ export default function AufgabenPage() {
         </DndContext>
       )}
       {selected && <TaskDrawer task={selected} onClose={() => setSelected(null)} onChanged={load} />}
+      <ProjectManagerDialog
+        open={showProjects}
+        onClose={() => setShowProjects(false)}
+        onChanged={() => { loadProjects(); load(); }}
+      />
     </AdminShell>
   );
 }

--- a/src/app/admin/rapporte/page.tsx
+++ b/src/app/admin/rapporte/page.tsx
@@ -26,7 +26,7 @@ interface TimeEntry {
   report_status: 'entwurf' | 'final' | null;
 }
 
-interface ProjectLite { id: string; name: string }
+interface ProjectLite { id: string; name: string; status?: 'aktiv' | 'archiviert' }
 
 interface Stats { open_count: number; open_minutes: number; reported_count: number; reported_minutes: number }
 
@@ -137,7 +137,7 @@ export default function RapportePage() {
       if (r.success) setEmployees(r.data.map((e: EmployeeLite) => ({ id: e.id, name: e.name })));
     }).catch(() => {});
     fetch('/api/admin/projects').then((r) => r.json()).then((r) => {
-      if (r.success) setProjects(r.data.map((p: ProjectLite) => ({ id: p.id, name: p.name })));
+      if (r.success) setProjects(r.data.map((p: ProjectLite) => ({ id: p.id, name: p.name, status: p.status })));
     }).catch(() => {});
   }, []);
 
@@ -453,7 +453,7 @@ export default function RapportePage() {
             <SelectInput value={project} onChange={(e) => setProject(e.target.value)} className="w-52">
               <option value="">Alle</option>
               <option value="none">Ohne Projekt</option>
-              {projects.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
+              {projects.map((p) => <option key={p.id} value={p.id}>{p.name}{p.status === 'archiviert' ? ' (archiviert)' : ''}</option>)}
             </SelectInput>
           </Field>
           {(from || to || employee || project) && (
@@ -492,7 +492,7 @@ export default function RapportePage() {
                   <Field label="Projekt (gilt fürs ganze Ticket)">
                     <SelectInput value={batchProject} onChange={(e) => setBatchProject(e.target.value)} className="w-52">
                       <option value="">Ohne Projekt</option>
-                      {projects.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
+                      {projects.filter((p) => p.status !== 'archiviert').map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
                     </SelectInput>
                   </Field>
                   <Button size="sm" variant="secondary" onClick={batchSetProject} disabled={batchBusy}>

--- a/src/components/admin/ProjectManagerDialog.tsx
+++ b/src/components/admin/ProjectManagerDialog.tsx
@@ -1,0 +1,198 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Archive, ArchiveRestore, FolderKanban, Plus, X } from 'lucide-react';
+import { Button, Field, TextInput, Badge, Spinner, COLORS } from './ui';
+
+interface ProjectSummary {
+  id: string;
+  name: string;
+  description: string;
+  status: 'aktiv' | 'archiviert';
+  task_count: number;
+  total_minutes: number;
+}
+
+function fmtMin(min: number): string {
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  return `${h}:${String(m).padStart(2, '0')} h`;
+}
+
+/**
+ * Projekte verwalten: anlegen, archivieren, reaktivieren.
+ * Archivierte Projekte verschwinden aus den Zuordnungs-Dropdowns,
+ * bleiben aber an bestehenden Tickets/Zeiten und im Filter sichtbar.
+ */
+export default function ProjectManagerDialog({
+  open, onClose, onChanged,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onChanged?: () => void;
+}) {
+  const [projects, setProjects] = useState<ProjectSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [form, setForm] = useState({ name: '', description: '' });
+  const [saving, setSaving] = useState(false);
+  const [busyId, setBusyId] = useState('');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const r = await fetch('/api/admin/projects').then((x) => x.json());
+      if (r.success) setProjects(r.data);
+      else setError(r.error || 'Projekte konnten nicht geladen werden');
+    } catch {
+      setError('Projekte konnten nicht geladen werden');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    setError('');
+    load();
+  }, [open, load]);
+
+  const create = async () => {
+    if (!form.name.trim()) return;
+    setSaving(true);
+    setError('');
+    try {
+      const r = await fetch('/api/admin/projects', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: form.name, description: form.description }),
+      }).then((x) => x.json());
+      if (!r.success) { setError(r.error || 'Projekt konnte nicht angelegt werden'); return; }
+      setForm({ name: '', description: '' });
+      await load();
+      onChanged?.();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const setStatus = async (p: ProjectSummary, status: 'aktiv' | 'archiviert') => {
+    setBusyId(p.id);
+    setError('');
+    try {
+      const r = await fetch(`/api/admin/projects/${p.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status }),
+      }).then((x) => x.json());
+      if (!r.success) { setError(r.error || 'Projekt konnte nicht aktualisiert werden'); return; }
+      await load();
+      onChanged?.();
+    } finally {
+      setBusyId('');
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[80] flex items-center justify-center bg-slate-950/60 p-4 backdrop-blur-sm" onClick={onClose}>
+      <div
+        className="flex max-h-[85vh] w-full max-w-2xl flex-col overflow-hidden rounded-3xl bg-white shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b px-5 py-4" style={{ borderColor: COLORS.stroke }}>
+          <div className="flex items-center gap-2">
+            <FolderKanban className="h-5 w-5" style={{ color: COLORS.accent }} />
+            <div>
+              <div className="text-sm font-bold" style={{ color: COLORS.navy }}>Projekte verwalten</div>
+              <div className="text-xs" style={{ color: COLORS.textMuted }}>
+                Tickets und Zeiten werden im Rapport nach Projekt gruppiert.
+              </div>
+            </div>
+          </div>
+          <button onClick={onClose} className="rounded-full p-2 transition hover:bg-gray-100" title="Schließen">
+            <X className="h-5 w-5" style={{ color: COLORS.textMuted }} />
+          </button>
+        </div>
+
+        {/* Neues Projekt */}
+        <div className="border-b px-5 py-4" style={{ borderColor: COLORS.stroke }}>
+          <div className="flex flex-wrap items-end gap-2">
+            <Field label="Neues Projekt" className="min-w-40 flex-1">
+              <TextInput
+                value={form.name}
+                onChange={(e) => setForm({ ...form, name: e.target.value })}
+                onKeyDown={(e) => { if (e.key === 'Enter') create(); }}
+                placeholder="Projektname"
+              />
+            </Field>
+            <Field label="Beschreibung (optional)" className="min-w-40 flex-1">
+              <TextInput
+                value={form.description}
+                onChange={(e) => setForm({ ...form, description: e.target.value })}
+                onKeyDown={(e) => { if (e.key === 'Enter') create(); }}
+                placeholder="Kurzbeschreibung"
+              />
+            </Field>
+            <Button variant="accent" onClick={create} disabled={saving || !form.name.trim()}>
+              {saving ? <Spinner className="h-4 w-4" /> : <Plus className="h-4 w-4" />} Anlegen
+            </Button>
+          </div>
+          {error && <p className="mt-2 text-xs font-medium" style={{ color: COLORS.danger }}>{error}</p>}
+        </div>
+
+        {/* Projektliste */}
+        <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+          {loading ? (
+            <div className="flex justify-center py-8"><Spinner /></div>
+          ) : projects.length === 0 ? (
+            <p className="py-6 text-center text-sm" style={{ color: COLORS.textMuted }}>
+              Noch keine Projekte — oben das erste anlegen.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {projects.map((p) => (
+                <div
+                  key={p.id}
+                  className="flex flex-wrap items-center justify-between gap-2 rounded-xl border px-3 py-2.5"
+                  style={{ borderColor: COLORS.stroke, opacity: p.status === 'archiviert' ? 0.6 : 1 }}
+                >
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="font-semibold" style={{ color: COLORS.navy }}>🗂 {p.name}</span>
+                      {p.status === 'archiviert' && <Badge tone="muted">archiviert</Badge>}
+                    </div>
+                    {p.description && (
+                      <p className="mt-0.5 text-xs" style={{ color: COLORS.textMuted }}>{p.description}</p>
+                    )}
+                    <p className="mt-0.5 text-xs" style={{ color: COLORS.textMuted }}>
+                      {p.task_count} {p.task_count === 1 ? 'Ticket' : 'Tickets'} · {fmtMin(p.total_minutes)}
+                    </p>
+                  </div>
+                  {p.status === 'aktiv' ? (
+                    <Button
+                      size="sm" variant="ghost" disabled={busyId === p.id}
+                      onClick={() => setStatus(p, 'archiviert')}
+                      title="Archivieren — verschwindet aus den Zuordnungs-Dropdowns, Tickets/Zeiten bleiben erhalten"
+                    >
+                      {busyId === p.id ? <Spinner className="h-3.5 w-3.5" /> : <Archive className="h-3.5 w-3.5" />} Archivieren
+                    </Button>
+                  ) : (
+                    <Button
+                      size="sm" variant="secondary" disabled={busyId === p.id}
+                      onClick={() => setStatus(p, 'aktiv')}
+                      title="Reaktivieren — wieder in den Zuordnungs-Dropdowns verfügbar"
+                    >
+                      {busyId === p.id ? <Spinner className="h-3.5 w-3.5" /> : <ArchiveRestore className="h-3.5 w-3.5" />} Reaktivieren
+                    </Button>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/TaskDrawer.tsx
+++ b/src/components/admin/TaskDrawer.tsx
@@ -22,7 +22,7 @@ interface Task {
   project_id?: string | null;
 }
 
-interface ProjectLite { id: string; name: string }
+interface ProjectLite { id: string; name: string; status?: 'aktiv' | 'archiviert' }
 interface Subtask { id: string; title: string; done: number }
 interface Att { id: string; filename: string; mime: string; size: number }
 interface TimeEntry { id: string; minutes: number; note: string; work_date?: string; report_id?: string | null; report_number?: number | null }
@@ -111,7 +111,7 @@ export default function TaskDrawer({ task, onClose, onChanged, variant = 'drawer
   useEffect(() => {
     setProjectId(task.project_id || '');
     fetch('/api/admin/projects').then((r) => r.json()).then((r) => {
-      if (r.success) setProjects(r.data.map((p: ProjectLite) => ({ id: p.id, name: p.name })));
+      if (r.success) setProjects(r.data.map((p: ProjectLite) => ({ id: p.id, name: p.name, status: p.status })));
     }).catch(() => {});
   }, [task.id, task.project_id]);
 
@@ -264,7 +264,9 @@ export default function TaskDrawer({ task, onClose, onChanged, variant = 'drawer
             title="Projekt zuordnen"
           >
             <option value="">🗂 Kein Projekt</option>
-            {projects.map((p) => <option key={p.id} value={p.id}>🗂 {p.name}</option>)}
+            {projects.filter((p) => p.status !== 'archiviert' || p.id === projectId).map((p) => (
+              <option key={p.id} value={p.id}>🗂 {p.name}{p.status === 'archiviert' ? ' (archiviert)' : ''}</option>
+            ))}
           </select>
           <Badge tone={PRIO_TONE[task.priority]}>{task.priority}</Badge>
           {task.due_date && <span className="text-xs" style={{ color: COLORS.textMuted }}>📅 {task.due_date}</span>}

--- a/src/lib/staffStore.ts
+++ b/src/lib/staffStore.ts
@@ -626,7 +626,7 @@ export async function listProjects(): Promise<ProjectSummary[]> {
     LEFT JOIN staff_tasks s ON s.project_id = p.id
     LEFT JOIN task_time t ON t.task_id = s.id
     GROUP BY p.id
-    ORDER BY lower(p.name)
+    ORDER BY CASE WHEN p.status = 'archiviert' THEN 1 ELSE 0 END, lower(p.name)
   `);
 }
 


### PR DESCRIPTION
## Zusammenfassung

Im Aufgaben-Board gab es bisher keine Projekt-Verwaltung: Anlegen ging nur über ein rohes `window.prompt` im Projekt-Dropdown, Archivieren gar nicht — obwohl das Backend (Status `aktiv/archiviert`, `PATCH /api/admin/projects/[id]`) seit dem Projekte-Feature vollständig existiert und ungenutzt war.

Ticket: TASK-00094

## Änderungen

- **Neu: `ProjectManagerDialog`** — Dialog „Projekte verwalten" auf `/admin/aufgaben` (Button im Header): Projektliste mit Ticket-/Zeitsummen, Anlegen mit optionaler Beschreibung, Archivieren/Reaktivieren pro Projekt
- **Zuordnungs-Dropdowns** (Neue Aufgabe, TaskDrawer, Rapport-Batch): archivierte Projekte ausgeblendet — hängt ein Ticket bereits an einem archivierten Projekt, bleibt dieses sichtbar und ausgewählt (Suffix „(archiviert)")
- **Filter-Dropdowns** (Aufgaben, Rapporte): archivierte Projekte bleiben wählbar, mit Suffix „(archiviert)"
- **`listProjects`**: archivierte Projekte sortieren ans Listenende

Keine Schema-/API-Änderungen — reine UI, nutzt bestehende Endpoints.

## Verifikation (lokaler Dev-Server, durchgeklickt)

- Projekt anlegen mit Beschreibung → erscheint sofort in Liste und Dropdowns ✓
- Archivieren → Badge „archiviert", Button wechselt auf „Reaktivieren", fliegt aus „Neue Aufgabe"-Dropdown, bleibt im Filter mit Suffix ✓
- Reaktivieren → wieder überall verfügbar ✓
- Edge-Case: Ticket an Projekt → Projekt archiviert → TaskDrawer zeigt es weiter als ausgewählte Option „(archiviert)", andere archivierte bleiben ausgeblendet ✓
- `npx tsc --noEmit` grün, keine Browser-Console-Fehler ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)