### PR TITLE
feat(briefing): Tägliches Team-Briefing per Mail (TASK-00091)

### DIFF
--- a/src/app/admin/mail/page.tsx
+++ b/src/app/admin/mail/page.tsx
@@ -8,7 +8,7 @@ import {
 import { buildEntraSetupScript } from '@/lib/entraSetupScript';
 import {
   Mail, Send, RefreshCw, CheckCircle2, XCircle, Server, Inbox, ListChecks, KeyRound,
-  Save, Terminal, Copy, Download, ShieldCheck,
+  Save, Terminal, Copy, Download, ShieldCheck, Sun,
 } from 'lucide-react';
 
 interface MailStatus {
@@ -27,6 +27,8 @@ interface MailConfig {
   inbound_poll_secret: string;
   ticket_auto_create: boolean;
   ticket_auto_create_domains: string;
+  daily_briefing_enabled: boolean;
+  daily_briefing_hour: number;
   has_client_secret: boolean;
   has_brevo: boolean;
 }
@@ -42,11 +44,14 @@ export default function MailAdminPage() {
     tenant_id: '', client_id: '', client_secret: '', mailbox: '', from_name: '',
     inbound_poll_secret: '', brevo_api_key: '', login_base_url: '', notify_to: '',
     ticket_auto_create: false, ticket_auto_create_domains: 'faltintravel.com',
+    daily_briefing_enabled: true, daily_briefing_hour: '7',
   });
 
   const [testTo, setTestTo] = useState('');
   const [testing, setTesting] = useState(false);
   const [polling, setPolling] = useState(false);
+  const [briefingStatus, setBriefingStatus] = useState<{ last_sent_date: string | null; last_result: { sent: number; skippedEmpty: number; errors: number } | null } | null>(null);
+  const [sendingBriefing, setSendingBriefing] = useState(false);
   const [toast, setToast] = useState<{ ok: boolean; msg: string } | null>(null);
 
   // Script generator
@@ -57,11 +62,13 @@ export default function MailAdminPage() {
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      const [s, c] = await Promise.all([
+      const [s, c, b] = await Promise.all([
         fetch('/api/admin/mail/status').then((r) => r.json()),
         fetch('/api/admin/mail/config').then((r) => r.json()),
+        fetch('/api/admin/briefing').then((r) => r.json()).catch(() => null),
       ]);
       if (s.success) setStatus(s.data);
+      if (b?.success) setBriefingStatus(b.data);
       if (c.success) {
         setCfg(c.data);
         setForm((f) => ({
@@ -75,6 +82,8 @@ export default function MailAdminPage() {
           notify_to: c.data.notify_to || '',
           ticket_auto_create: !!c.data.ticket_auto_create,
           ticket_auto_create_domains: c.data.ticket_auto_create_domains ?? 'faltintravel.com',
+          daily_briefing_enabled: c.data.daily_briefing_enabled !== false,
+          daily_briefing_hour: String(c.data.daily_briefing_hour ?? 7),
           client_secret: '',
           brevo_api_key: '',
         }));
@@ -123,6 +132,19 @@ export default function MailAdminPage() {
       flash(data.success, data.success ? data.message : data.error);
     } catch { flash(false, 'Verbindungsfehler.'); }
     finally { setTesting(false); }
+  };
+
+  const runBriefing = async () => {
+    setSendingBriefing(true);
+    try {
+      const res = await fetch('/api/admin/briefing', { method: 'POST' });
+      const data = await res.json();
+      if (data.success) {
+        flash(true, `Briefing verschickt: ${data.data.sent} Mail(s), ${data.data.skippedEmpty} ohne Inhalt übersprungen${data.data.errors ? `, ${data.data.errors} Fehler` : ''}.`);
+        await load();
+      } else flash(false, data.error || 'Briefing fehlgeschlagen.');
+    } catch { flash(false, 'Verbindungsfehler.'); }
+    finally { setSendingBriefing(false); }
   };
 
   const runPoll = async () => {
@@ -248,6 +270,27 @@ export default function MailAdminPage() {
                   </Field>
                 </div>
               </div>
+              <div className="rounded-xl border border-gray-200 p-4">
+                <Toggle
+                  checked={form.daily_briefing_enabled}
+                  onChange={(v) => set('daily_briefing_enabled', v)}
+                  label="Tägliches Team-Briefing per Mail"
+                />
+                <p className="mt-1.5 text-xs" style={{ color: '#9ca3af' }}>
+                  Jede:r aktive Mitarbeiter:in erhält einmal täglich eine Mail mit offenen/neuen Aufgaben,
+                  neuen Anfragen, liegengebliebenen Anfragen (5+ Tage) und Erledigt-Bilanz.
+                </p>
+                <div className="mt-3 max-w-[200px]">
+                  <InputField
+                    label="Versand ab Stunde (0–23 Uhr)"
+                    type="number"
+                    value={form.daily_briefing_hour}
+                    onChange={(e) => set('daily_briefing_hour', e.target.value)}
+                    placeholder="7"
+                    disabled={!form.daily_briefing_enabled}
+                  />
+                </div>
+              </div>
               <InputField
                 label="Brevo API-Key (Listen)"
                 type="password"
@@ -304,6 +347,19 @@ export default function MailAdminPage() {
             </p>
             <Button variant="primary" onClick={runPoll} disabled={polling || !status?.graphConfigured}>
               {polling ? <Spinner className="h-4 w-4 border-white" /> : <RefreshCw className="h-4 w-4" />} Jetzt abrufen
+            </Button>
+          </SectionCard>
+
+          {/* Tages-Briefing */}
+          <SectionCard title="Tages-Briefing" description="Aufgaben & Anfragen als Morgen-Mail ans Team" icon={<Sun className="h-5 w-5" />}>
+            <p className="mb-4 text-sm" style={{ color: COLORS.textMuted }}>
+              {briefingStatus?.last_sent_date
+                ? <>Zuletzt verschickt am <span className="font-semibold">{briefingStatus.last_sent_date}</span>{briefingStatus.last_result ? ` (${briefingStatus.last_result.sent} Mails)` : ''}.</>
+                : 'Noch nie verschickt.'}
+              {' '}Der Button sendet sofort an alle Mitarbeitenden und zählt als heutiger Versand.
+            </p>
+            <Button variant="primary" onClick={runBriefing} disabled={sendingBriefing || !status?.graphConfigured}>
+              {sendingBriefing ? <Spinner className="h-4 w-4 border-white" /> : <Send className="h-4 w-4" />} Jetzt an alle senden
             </Button>
           </SectionCard>
         </div>

--- a/src/app/api/admin/briefing/route.ts
+++ b/src/app/api/admin/briefing/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { getSessionEmployee } from '@/lib/serverSession';
+import { runDailyBriefing, briefingStatus } from '@/lib/dailyBriefing';
+
+/** GET → Status des Tages-Briefings (Toggle, Stunde, letzter Versand). */
+export async function GET() {
+  const ctx = await getSessionEmployee();
+  if (!ctx) return NextResponse.json({ success: false, error: 'Nicht angemeldet' }, { status: 401 });
+  return NextResponse.json({ success: true, data: briefingStatus() });
+}
+
+/**
+ * POST → Briefing sofort verschicken (manueller Test, unabhängig von Uhrzeit
+ * und Tages-Deduplizierung; zählt danach als heutiger Versand).
+ */
+export async function POST() {
+  const ctx = await getSessionEmployee();
+  if (!ctx) return NextResponse.json({ success: false, error: 'Nicht angemeldet' }, { status: 401 });
+  try {
+    const result = await runDailyBriefing({ force: true });
+    if (!result.configured) {
+      return NextResponse.json({ success: false, error: 'Microsoft Graph ist nicht konfiguriert.' }, { status: 409 });
+    }
+    return NextResponse.json({ success: true, data: result });
+  } catch (error) {
+    return NextResponse.json({ success: false, error: (error as Error).message }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/mail/config/route.ts
+++ b/src/app/api/admin/mail/config/route.ts
@@ -16,6 +16,8 @@ export async function GET() {
       notify_to: m.notify_to || '',
       ticket_auto_create: !!m.ticket_auto_create,
       ticket_auto_create_domains: m.ticket_auto_create_domains ?? 'faltintravel.com',
+      daily_briefing_enabled: m.daily_briefing_enabled !== false,
+      daily_briefing_hour: m.daily_briefing_hour ?? 7,
       has_client_secret: !!(m.client_secret || process.env.GRAPH_CLIENT_SECRET),
       has_brevo: !!(m.brevo_api_key || process.env.BREVO_API_KEY),
       env_fallback: {
@@ -38,6 +40,11 @@ export async function POST(request: Request) {
       if (key in body) updates[key] = String(body[key] ?? '');
     }
     if ('ticket_auto_create' in body) updates.ticket_auto_create = !!body.ticket_auto_create;
+    if ('daily_briefing_enabled' in body) updates.daily_briefing_enabled = !!body.daily_briefing_enabled;
+    if ('daily_briefing_hour' in body) {
+      const h = Number(body.daily_briefing_hour);
+      if (Number.isFinite(h)) updates.daily_briefing_hour = Math.min(23, Math.max(0, Math.round(h)));
+    }
     // Secrets nur setzen, wenn nicht leer (leer = unverändert lassen)
     if (body.client_secret) updates.client_secret = String(body.client_secret);
     if (body.brevo_api_key) updates.brevo_api_key = String(body.brevo_api_key);

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,15 +1,18 @@
 /**
  * instrumentation.ts (Next.js Instrumentation Hook)
  * ─────────────────────────────────────────────────────────────────────────────
- * Startet in Produktion einen internen Scheduler für das Inbound-Mail-Polling
- * (alle 120 s), sodass kein externer Cron-Job auf /api/inbound/poll nötig ist.
+ * Startet in Produktion interne Scheduler:
+ *   – Inbound-Mail-Polling (alle 120 s), kein externer Cron auf /api/inbound/poll nötig
+ *   – Tägliches Team-Briefing (Check alle 5 min; Versand einmal pro Tag ab der
+ *     konfigurierten Stunde, dedupliziert über data/briefing-state.json)
  * Läuft nur im Node.js-Runtime-Prozess; Fehler werden geloggt, crashen aber
- * niemals den Server. runInboundPoll() beendet sich sofort billig, wenn
- * Microsoft Graph nicht konfiguriert ist.
+ * niemals den Server. Beide Jobs beenden sich sofort billig, wenn Microsoft
+ * Graph nicht konfiguriert bzw. das Feature deaktiviert ist.
  * ─────────────────────────────────────────────────────────────────────────────
  */
 
 const POLL_INTERVAL_MS = 120_000;
+const BRIEFING_CHECK_MS = 300_000;
 const GLOBAL_KEY = Symbol.for('faltin.inboundPollTimer');
 
 export async function register() {
@@ -40,4 +43,19 @@ export async function register() {
   (timer as unknown as { unref?: () => void }).unref?.();
 
   console.log(`[inbound-poll] Interner Poll-Scheduler aktiv (alle ${POLL_INTERVAL_MS / 1000}s).`);
+
+  const { runDailyBriefing } = await import('./lib/dailyBriefing');
+  const briefingTimer = setInterval(async () => {
+    try {
+      const result = await runDailyBriefing();
+      if (result.sent > 0 || result.errors > 0) {
+        console.log(`[daily-briefing] sent=${result.sent} skippedEmpty=${result.skippedEmpty} errors=${result.errors}`);
+      }
+    } catch (err) {
+      console.error('[daily-briefing] Lauf fehlgeschlagen:', err);
+    }
+  }, BRIEFING_CHECK_MS);
+  (briefingTimer as unknown as { unref?: () => void }).unref?.();
+
+  console.log(`[daily-briefing] Scheduler aktiv (Check alle ${BRIEFING_CHECK_MS / 1000}s).`);
 }

--- a/src/lib/dailyBriefing.ts
+++ b/src/lib/dailyBriefing.ts
@@ -1,0 +1,308 @@
+/**
+ * dailyBriefing.ts (TASK-00091)
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Tägliches Team-Briefing per Mail an alle aktiven Mitarbeitenden:
+ *   – eigene offene Aufgaben (NEU-Markierung, Fälligkeit/Überfälligkeit)
+ *   – neue Aufgaben im Team (letzte 24 h)
+ *   – neue Anfragen & Anfragen mit Bewegung (letzte 24 h)
+ *   – eigene Anfragen ohne Bewegung seit 5+ Tagen (Erinnerung)
+ *   – Schulterklopfen für Erledigtes (eigene erledigte Aufgaben/Buchungen)
+ *
+ * Gesteuert über settings.mail.daily_briefing_enabled / daily_briefing_hour
+ * (Europe/Zurich). Der Scheduler in instrumentation.ts ruft runDailyBriefing()
+ * alle 5 Minuten auf; der Versandzeitpunkt wird über data/briefing-state.json
+ * dedupliziert (einmal pro Kalendertag). Manueller Test: POST /api/admin/briefing.
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+import fs from 'fs';
+import path from 'path';
+import { listEmployees, listStaffTasks, formatTicketNo, type StaffTask, type Employee } from './staffStore';
+import { getAllBookings } from './database';
+import type { BookingRequest } from './supabase';
+import { getSettings } from './settingsStore';
+import {
+  dailyBriefingEmailHtml,
+  type BriefingTaskItem,
+  type BriefingInquiryItem,
+} from './emailTemplates';
+
+const STATE_PATH = path.join(process.cwd(), 'data', 'briefing-state.json');
+const DAY_MS = 24 * 3600 * 1000;
+const STALE_DAYS = 5;
+const MAX_ITEMS_PER_SECTION = 12;
+
+/** Anfrage-Zeilen aus SELECT b.* enthalten auch nicht im Interface deklarierte Spalten. */
+type BookingRow = BookingRequest & { updated_at?: string | null; assigned_to?: string | null };
+
+export interface BriefingRunResult {
+  /** false = Feature aus oder Graph nicht konfiguriert. */
+  configured: boolean;
+  /** false = heute schon verschickt bzw. Versandstunde noch nicht erreicht. */
+  due: boolean;
+  sent: number;
+  skippedEmpty: number;
+  errors: number;
+  recipients: string[];
+}
+
+interface BriefingState {
+  last_sent_date?: string;
+  last_run_at?: string;
+  last_result?: Omit<BriefingRunResult, 'recipients'>;
+}
+
+function readState(): BriefingState {
+  try {
+    return JSON.parse(fs.readFileSync(STATE_PATH, 'utf-8')) as BriefingState;
+  } catch {
+    return {};
+  }
+}
+
+function writeState(state: BriefingState): void {
+  try {
+    fs.mkdirSync(path.dirname(STATE_PATH), { recursive: true });
+    fs.writeFileSync(STATE_PATH, JSON.stringify(state, null, 2), 'utf-8');
+  } catch (e) {
+    console.warn('[daily-briefing] State konnte nicht geschrieben werden:', (e as Error).message);
+  }
+}
+
+/** Datum (YYYY-MM-DD) und Stunde in Europe/Zurich. */
+function zurichNow(d = new Date()): { date: string; hour: number } {
+  const parts = Object.fromEntries(
+    new Intl.DateTimeFormat('en-CA', {
+      timeZone: 'Europe/Zurich', year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', hourCycle: 'h23',
+    }).formatToParts(d).map((p) => [p.type, p.value])
+  );
+  return { date: `${parts.year}-${parts.month}-${parts.day}`, hour: Number(parts.hour) };
+}
+
+/** Toleranter Timestamp-Parser: ISO ("…T…Z") und SQL ("YYYY-MM-DD HH:MM:SS", UTC). */
+function ts(s?: string | null): number {
+  if (!s) return 0;
+  let v = s.includes('T') ? s : s.replace(' ', 'T');
+  if (!/([zZ]|[+-]\d\d:?\d\d)$/.test(v)) v += 'Z';
+  const n = Date.parse(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+const BOOKING_STATUS_LABEL: Record<string, string> = {
+  new: 'Neu',
+  in_progress: 'In Bearbeitung',
+  booked: 'Gebucht',
+  rejected: 'Abgelehnt',
+};
+
+function bookingTitle(b: BookingRow): string {
+  const who = (b.customer_name || '').trim() || b.email || '';
+  return [b.package_title, who].filter(Boolean).join(' — ') || 'Anfrage';
+}
+
+function formatDueDate(iso: string): string {
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(iso);
+  return m ? `${m[3]}.${m[2]}.${m[1]}` : iso;
+}
+
+/** Rotierende Schulterklopf-Floskel (deterministisch pro Tag). */
+function praisePhrase(dateStr: string): string {
+  const phrases = ['Stark gemacht', 'Sauber abgeräumt', 'Top-Leistung', 'Weiter so', 'Klasse Arbeit'];
+  const seed = Number(dateStr.replace(/-/g, '')) || 0;
+  return phrases[seed % phrases.length];
+}
+
+function plural(n: number, singular: string, pluralWord: string): string {
+  return `${n} ${n === 1 ? singular : pluralWord}`;
+}
+
+function taskItem(t: StaffTask, opts: { sinceMs: number; today: string; base: string; withAssignee?: Map<string, string> }): BriefingTaskItem {
+  const due = (t.due_date || '').slice(0, 10);
+  const overdue = !!due && due < opts.today;
+  return {
+    ticketNo: formatTicketNo(t.ticket_number) || '—',
+    title: t.title,
+    url: `${opts.base}/admin/aufgaben/${t.id}`,
+    priority: t.priority,
+    dueLabel: due ? (overdue ? `überfällig seit ${formatDueDate(due)}` : `fällig ${formatDueDate(due)}`) : undefined,
+    overdue,
+    isNew: ts(t.created_at) >= opts.sinceMs,
+    assigneeName: opts.withAssignee
+      ? (t.assignee_id ? opts.withAssignee.get(t.assignee_id) || 'Unbekannt' : 'Nicht zugewiesen')
+      : undefined,
+  };
+}
+
+function inquiryItem(b: BookingRow, base: string, ageLabel?: string): BriefingInquiryItem {
+  return {
+    requestNumber: b.request_number || '—',
+    title: bookingTitle(b),
+    url: `${base}/admin/crm`,
+    statusLabel: BOOKING_STATUS_LABEL[b.status] || b.status,
+    ageLabel,
+  };
+}
+
+/** Eigene offene Aufgaben sortieren: überfällig → fällig (aufsteigend) → hoch → neueste. */
+function sortOpenTasks(a: StaffTask, b: StaffTask, today: string): number {
+  const dueA = (a.due_date || '').slice(0, 10);
+  const dueB = (b.due_date || '').slice(0, 10);
+  const overA = dueA && dueA < today ? 0 : 1;
+  const overB = dueB && dueB < today ? 0 : 1;
+  if (overA !== overB) return overA - overB;
+  if (dueA !== dueB) return (dueA || '9999') < (dueB || '9999') ? -1 : 1;
+  const prioA = a.priority === 'hoch' ? 0 : 1;
+  const prioB = b.priority === 'hoch' ? 0 : 1;
+  if (prioA !== prioB) return prioA - prioB;
+  return ts(b.created_at) - ts(a.created_at);
+}
+
+let running = false;
+
+/**
+ * Prüft Zeitfenster & Versand-Status und verschickt fällige Briefings.
+ * `force` überspringt Feature-Toggle, Uhrzeit und Tages-Deduplizierung
+ * (zählt aber als heutiger Versand, damit der Scheduler nicht doppelt schickt).
+ */
+export async function runDailyBriefing(opts: { force?: boolean } = {}): Promise<BriefingRunResult> {
+  const empty = (over: Partial<BriefingRunResult>): BriefingRunResult =>
+    ({ configured: true, due: true, sent: 0, skippedEmpty: 0, errors: 0, recipients: [], ...over });
+
+  if (running) return empty({ due: false });
+  const m = getSettings().mail;
+  const enabled = m.daily_briefing_enabled !== false;
+  const sendHour = Math.min(23, Math.max(0, Math.round(Number(m.daily_briefing_hour ?? 7)) || 0));
+
+  const { isGraphConfigured, sendGraphMail } = await import('./graphMailer');
+  if (!isGraphConfigured() || (!enabled && !opts.force)) return empty({ configured: false, due: false });
+
+  const now = zurichNow();
+  const state = readState();
+  if (!opts.force) {
+    if (now.hour < sendHour) return empty({ due: false });
+    if (state.last_sent_date === now.date) return empty({ due: false });
+  }
+
+  running = true;
+  try {
+    // Versand-Marker VOR dem Mail-Loop setzen: ein Fehler mitten im Versand darf
+    // beim nächsten Scheduler-Tick keine Doppel-Mails an bereits Beliefert erzeugen.
+    writeState({ ...state, last_sent_date: now.date, last_run_at: new Date().toISOString() });
+
+    const base = (m.login_base_url || 'https://next.faltintravel.com').replace(/\/+$/, '');
+    const sinceMs = Date.now() - DAY_MS;
+    const staleBeforeMs = Date.now() - STALE_DAYS * DAY_MS;
+
+    const [employees, tasks, bookings] = await Promise.all([
+      listEmployees(false),
+      listStaffTasks(),
+      getAllBookings() as Promise<BookingRow[]>,
+    ]);
+    const nameById = new Map(employees.map((e) => [e.id, e.name]));
+
+    const newTeamTasks = tasks.filter((t) => ts(t.created_at) >= sinceMs);
+    const newInquiries = bookings.filter((b) => ts(b.created_at) >= sinceMs);
+    const movedInquiries = bookings.filter((b) => ts(b.created_at) < sinceMs && ts(b.updated_at) >= sinceMs);
+    const teamDoneCount = tasks.filter((t) => t.status === 'erledigt' && ts(t.updated_at) >= sinceMs).length;
+
+    const dateLabel = new Intl.DateTimeFormat('de-CH', {
+      timeZone: 'Europe/Zurich', weekday: 'long', day: '2-digit', month: '2-digit', year: 'numeric',
+    }).format(new Date());
+
+    const result = empty({});
+    const recipients = employees.filter((e): e is Employee => !!(e.email || '').trim());
+
+    for (const emp of recipients) {
+      try {
+        const myOpenAll = tasks
+          .filter((t) => t.assignee_id === emp.id && t.status !== 'erledigt')
+          .sort((a, b) => sortOpenTasks(a, b, now.date));
+        const myOpen = myOpenAll.slice(0, MAX_ITEMS_PER_SECTION);
+        const othersNew = newTeamTasks
+          .filter((t) => t.assignee_id !== emp.id)
+          .slice(0, MAX_ITEMS_PER_SECTION);
+        const myStale = bookings
+          .filter((b) => b.assigned_to === emp.id
+            && (b.status === 'new' || b.status === 'in_progress')
+            && ts(b.updated_at || b.created_at) <= staleBeforeMs)
+          .slice(0, MAX_ITEMS_PER_SECTION);
+
+        const myDone = tasks.filter((t) => t.assignee_id === emp.id && t.status === 'erledigt' && ts(t.updated_at) >= sinceMs).length;
+        const myBooked = bookings.filter((b) => b.assigned_to === emp.id && b.status === 'booked' && ts(b.updated_at) >= sinceMs).length;
+        const kudos: string[] = [];
+        if (myDone > 0 || myBooked > 0) {
+          const parts: string[] = [];
+          if (myDone > 0) parts.push(plural(myDone, 'Aufgabe erledigt', 'Aufgaben erledigt'));
+          if (myBooked > 0) parts.push(plural(myBooked, 'Anfrage zur Buchung gebracht', 'Anfragen zur Buchung gebracht'));
+          kudos.push(`🎉 ${praisePhrase(now.date)}: In den letzten 24 Stunden hast du ${parts.join(' und ')}.`);
+        }
+        if (teamDoneCount > myDone) {
+          kudos.push(`👏 Das Team hat insgesamt ${plural(teamDoneCount, 'Aufgabe', 'Aufgaben')} erledigt.`);
+        }
+
+        const hasContent = myOpen.length || othersNew.length || newInquiries.length || movedInquiries.length || myStale.length || kudos.length;
+        if (!hasContent) {
+          result.skippedEmpty++;
+          continue;
+        }
+
+        const html = dailyBriefingEmailHtml({
+          recipientFirstName: (emp.name || '').split(' ')[0] || undefined,
+          dateLabel,
+          kudos,
+          myOpenTasks: myOpen.map((t) => taskItem(t, { sinceMs, today: now.date, base })),
+          myOpenMore: Math.max(0, myOpenAll.length - myOpen.length),
+          newTeamTasks: othersNew.map((t) => taskItem(t, { sinceMs, today: now.date, base, withAssignee: nameById })),
+          newInquiries: newInquiries.slice(0, MAX_ITEMS_PER_SECTION).map((b) => inquiryItem(b, base)),
+          movedInquiries: movedInquiries.slice(0, MAX_ITEMS_PER_SECTION).map((b) => inquiryItem(b, base)),
+          staleInquiries: myStale.map((b) => {
+            const days = Math.floor((Date.now() - ts(b.updated_at || b.created_at)) / DAY_MS);
+            return inquiryItem(b, base, `seit ${plural(days, 'Tag', 'Tagen')} ohne Bewegung`);
+          }),
+          boardUrl: `${base}/admin/aufgaben`,
+          crmUrl: `${base}/admin/crm`,
+        });
+
+        const counts = [
+          myOpenAll.length ? plural(myOpenAll.length, 'offene Aufgabe', 'offene Aufgaben') : '',
+          newInquiries.length ? plural(newInquiries.length, 'neue Anfrage', 'neue Anfragen') : '',
+        ].filter(Boolean).join(' · ');
+        const subject = `☀️ Dein Tages-Briefing – ${dateLabel}${counts ? ` (${counts})` : ''}`;
+
+        const send = await sendGraphMail({ to: emp.email, toName: emp.name, subject, html });
+        if (send.success) {
+          result.sent++;
+          result.recipients.push(emp.email);
+        } else {
+          result.errors++;
+          console.warn('[daily-briefing] Versand fehlgeschlagen an', emp.email, send.error);
+        }
+      } catch (e) {
+        result.errors++;
+        console.warn('[daily-briefing] Fehler für', emp.email, (e as Error).message);
+      }
+    }
+
+    writeState({
+      last_sent_date: now.date,
+      last_run_at: new Date().toISOString(),
+      last_result: { configured: true, due: true, sent: result.sent, skippedEmpty: result.skippedEmpty, errors: result.errors },
+    });
+    return result;
+  } finally {
+    running = false;
+  }
+}
+
+/** Status für die Admin-UI. */
+export function briefingStatus(): { enabled: boolean; hour: number; last_sent_date: string | null; last_run_at: string | null; last_result: BriefingState['last_result'] | null } {
+  const m = getSettings().mail;
+  const state = readState();
+  return {
+    enabled: m.daily_briefing_enabled !== false,
+    hour: Math.min(23, Math.max(0, Math.round(Number(m.daily_briefing_hour ?? 7)) || 0)),
+    last_sent_date: state.last_sent_date || null,
+    last_run_at: state.last_run_at || null,
+    last_result: state.last_result || null,
+  };
+}

--- a/src/lib/emailTemplates.ts
+++ b/src/lib/emailTemplates.ts
@@ -548,3 +548,144 @@ export function taskEmailHtml(input: TaskEmailInput): string {
     </p>`;
   return layout(inner, `${input.ticketNo}: ${input.bodyText.slice(0, 100)}`);
 }
+
+/* ── Tägliches Team-Briefing (TASK-00091) ──────────────────────────────────── */
+
+export interface BriefingTaskItem {
+  ticketNo: string;
+  title: string;
+  url: string;
+  /** 'hoch' wird hervorgehoben. */
+  priority?: string;
+  /** z.B. "fällig 09.07." oder "überfällig seit 05.07." */
+  dueLabel?: string;
+  overdue?: boolean;
+  /** In den letzten 24 h erstellt → NEU-Badge. */
+  isNew?: boolean;
+  /** Nur in Team-Listen: wem die Aufgabe zugewiesen ist. */
+  assigneeName?: string;
+}
+
+export interface BriefingInquiryItem {
+  requestNumber: string;
+  title: string;
+  url: string;
+  statusLabel: string;
+  /** z.B. "seit 6 Tagen ohne Bewegung" */
+  ageLabel?: string;
+}
+
+export interface DailyBriefingInput {
+  recipientFirstName?: string;
+  /** z.B. "Mittwoch, 09.07.2026" */
+  dateLabel: string;
+  /** Fertig formulierte Schulterklopf-Zeile(n), leer = keine Kudos-Box. */
+  kudos?: string[];
+  myOpenTasks: BriefingTaskItem[];
+  /** Anzahl weiterer eigener Aufgaben jenseits des Limits. */
+  myOpenMore?: number;
+  newTeamTasks: BriefingTaskItem[];
+  newInquiries: BriefingInquiryItem[];
+  movedInquiries: BriefingInquiryItem[];
+  staleInquiries: BriefingInquiryItem[];
+  boardUrl: string;
+  crmUrl: string;
+}
+
+function briefingSectionHeading(text: string): string {
+  return `<p style="margin:26px 0 10px;font-size:12px;font-weight:700;text-transform:uppercase;letter-spacing:1.2px;color:#9ca3af;">${escapeHtml(text)}</p>`;
+}
+
+function briefingTaskRow(t: BriefingTaskItem): string {
+  const badges: string[] = [];
+  if (t.isNew) badges.push(`<span style="display:inline-block;background:${ACCENT};color:#ffffff;font-size:10px;font-weight:800;padding:2px 8px;border-radius:999px;letter-spacing:0.5px;">NEU</span>`);
+  if ((t.priority || '') === 'hoch') badges.push(`<span style="display:inline-block;background:#fef2f2;color:#dc2626;border:1px solid #fecaca;font-size:10px;font-weight:800;padding:1px 8px;border-radius:999px;letter-spacing:0.5px;">HOCH</span>`);
+  const meta: string[] = [];
+  if (t.dueLabel) meta.push(`<span style="color:${t.overdue ? '#dc2626' : '#6b7280'};font-weight:${t.overdue ? '700' : '400'};">${escapeHtml(t.dueLabel)}</span>`);
+  if (t.assigneeName) meta.push(escapeHtml(t.assigneeName));
+  return `<tr><td style="padding:9px 0;border-bottom:1px solid #f0f2f5;">
+    <a href="${t.url}" style="text-decoration:none;">
+      <span style="font-family:monospace;font-size:12px;font-weight:700;color:${ACCENT};">${escapeHtml(t.ticketNo)}</span>
+      <span style="font-size:14px;font-weight:600;color:${NAVY};"> ${escapeHtml(t.title)}</span>
+    </a>
+    ${badges.length ? ' ' + badges.join(' ') : ''}
+    ${meta.length ? `<div style="margin-top:2px;font-size:12px;color:#6b7280;">${meta.join(' · ')}</div>` : ''}
+  </td></tr>`;
+}
+
+function briefingInquiryRow(q: BriefingInquiryItem): string {
+  return `<tr><td style="padding:9px 0;border-bottom:1px solid #f0f2f5;">
+    <a href="${q.url}" style="text-decoration:none;">
+      <span style="font-family:monospace;font-size:12px;font-weight:700;color:${ACCENT};">${escapeHtml(q.requestNumber)}</span>
+      <span style="font-size:14px;font-weight:600;color:${NAVY};"> ${escapeHtml(q.title)}</span>
+    </a>
+    <div style="margin-top:2px;font-size:12px;color:#6b7280;">${escapeHtml(q.statusLabel)}${q.ageLabel ? ` · <span style="color:#dc2626;font-weight:700;">${escapeHtml(q.ageLabel)}</span>` : ''}</div>
+  </td></tr>`;
+}
+
+function briefingList(rows: string[]): string {
+  return `<table role="presentation" width="100%" cellpadding="0" cellspacing="0">${rows.join('')}</table>`;
+}
+
+/**
+ * Tägliche Briefing-Mail an einen Mitarbeitenden: eigene offene Aufgaben,
+ * neue Team-Aufgaben, Anfragen-Bewegungen, liegengebliebene eigene Anfragen
+ * und eine Schulterklopf-Box für Erledigtes. Leere Sektionen werden weggelassen.
+ */
+export function dailyBriefingEmailHtml(input: DailyBriefingInput): string {
+  const hi = input.recipientFirstName ? `Guten Morgen ${escapeHtml(input.recipientFirstName)}` : 'Guten Morgen';
+
+  const kudosHtml = (input.kudos || []).length
+    ? `<div style="margin:22px 0 0;padding:14px 16px;background:#f0fdf4;border:1px solid #bbf7d0;border-radius:12px;">
+        ${(input.kudos || []).map((k) => `<p style="margin:0;font-size:14px;line-height:1.7;color:#166534;">${escapeHtml(k)}</p>`).join('')}
+      </div>`
+    : '';
+
+  const sections: string[] = [];
+  if (input.myOpenTasks.length) {
+    sections.push(
+      briefingSectionHeading(`Deine offenen Aufgaben (${input.myOpenTasks.length + (input.myOpenMore || 0)})`) +
+      briefingList(input.myOpenTasks.map(briefingTaskRow)) +
+      (input.myOpenMore ? `<p style="margin:8px 0 0;font-size:12px;color:#9ca3af;">… und ${input.myOpenMore} weitere im Board.</p>` : '')
+    );
+  }
+  if (input.newTeamTasks.length) {
+    sections.push(
+      briefingSectionHeading(`Neue Aufgaben im Team (letzte 24 h)`) +
+      briefingList(input.newTeamTasks.map(briefingTaskRow))
+    );
+  }
+  if (input.newInquiries.length) {
+    sections.push(
+      briefingSectionHeading(`Neue Anfragen (letzte 24 h)`) +
+      briefingList(input.newInquiries.map(briefingInquiryRow))
+    );
+  }
+  if (input.movedInquiries.length) {
+    sections.push(
+      briefingSectionHeading(`Anfragen mit Bewegung (letzte 24 h)`) +
+      briefingList(input.movedInquiries.map(briefingInquiryRow))
+    );
+  }
+  if (input.staleInquiries.length) {
+    sections.push(
+      briefingSectionHeading(`⚠️ Deine Anfragen ohne Bewegung seit 5+ Tagen`) +
+      briefingList(input.staleInquiries.map(briefingInquiryRow))
+    );
+  }
+
+  const inner = `
+    <p style="margin:0 0 4px;font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:1px;color:#9ca3af;">Tages-Briefing · ${escapeHtml(input.dateLabel)}</p>
+    <h1 style="margin:6px 0 0;font-size:22px;font-weight:800;color:${NAVY};">${hi}! ☀️</h1>
+    ${kudosHtml}
+    ${sections.join('')}
+    <p style="margin:28px 0 0;">
+      <a href="${input.boardUrl}" style="display:inline-block;margin:0 10px 10px 0;background:${ACCENT};color:#ffffff;text-decoration:none;font-weight:700;font-size:14px;padding:11px 22px;border-radius:10px;">Zum Aufgaben-Board</a>
+      <a href="${input.crmUrl}" style="display:inline-block;margin:0 10px 10px 0;background:${NAVY};color:#ffffff;text-decoration:none;font-weight:700;font-size:14px;padding:11px 22px;border-radius:10px;">Zum CRM</a>
+    </p>
+    <p style="margin:22px 0 0;font-size:11px;line-height:1.6;color:#9ca3af;">
+      Automatisches Tages-Briefing — konfigurierbar unter Admin → E-Mail / Microsoft 365.
+    </p>`;
+
+  return layout(inner, `Dein Tages-Briefing: ${input.myOpenTasks.length + (input.myOpenMore || 0)} offene Aufgaben, ${input.newInquiries.length} neue Anfragen.`);
+}

--- a/src/lib/settingsStore.ts
+++ b/src/lib/settingsStore.ts
@@ -123,6 +123,10 @@ export interface MailSettings {
   ticket_auto_create?: boolean;
   /** Komma-getrennte Absender-Domain-Allowlist für Auto-Create (leer = alle Absender) */
   ticket_auto_create_domains?: string;
+  /** Tägliches Team-Briefing per Mail (Aufgaben & Anfragen je Mitarbeiter:in) */
+  daily_briefing_enabled?: boolean;
+  /** Stunde (0–23, Europe/Zurich), ab der das Tages-Briefing verschickt wird */
+  daily_briefing_hour?: number;
 }
 
 const DEFAULT_SETTINGS: AllSettings = {
@@ -188,6 +192,8 @@ const DEFAULT_SETTINGS: AllSettings = {
     notify_to: '',
     ticket_auto_create: false,
     ticket_auto_create_domains: 'faltintravel.com',
+    daily_briefing_enabled: true,
+    daily_briefing_hour: 7,
   },
   ai: {
     anthropic_api_key: '',


### PR DESCRIPTION
## Zusammenfassung
Setzt **TASK-00091** um: Jede:r aktive Mitarbeiter:in bekommt einmal täglich (Standard: ab **07:00 Europe/Zurich**) eine persönliche Briefing-Mail mit:

- **Deine offenen Aufgaben** — sortiert (überfällig → fällig → hoch-Prio → neueste), NEU-Badge für Aufgaben der letzten 24 h, überfällige rot markiert
- **Neue Aufgaben im Team** (letzte 24 h, mit Zuständigkeit)
- **Neue Anfragen** und **Anfragen mit Bewegung** (letzte 24 h, mit Status)
- **⚠️ Eigene Anfragen ohne Bewegung seit 5+ Tagen** (Erinnerung, wie im Ticket gewünscht)
- **🎉 Schulterklopfen**: eigene erledigte Aufgaben / zur Buchung gebrachte Anfragen (rotierende Lob-Floskel) + 👏 Team-Bilanz

Mitarbeiter ohne Briefing-Inhalt bekommen keine Mail (kein Spam).

## Technik
- `src/lib/dailyBriefing.ts`: Datensammlung über bestehende Stores (`listStaffTasks`, `getAllBookings`, `listEmployees`), Tages-Deduplizierung über `data/briefing-state.json` (Marker wird **vor** dem Versand gesetzt → keine Doppel-Mails bei Fehlern mitten im Lauf), toleranter Timestamp-Parser (SQLite- und ISO-Format)
- Scheduler im bestehenden Instrumentation-Hook (Check alle 5 min, nur Produktion, `unref()`)
- Settings: `mail.daily_briefing_enabled` (Default **an**) + `mail.daily_briefing_hour` (Default 7) — gepflegt unter **/admin/mail** (Toggle + Stundenfeld)
- Neue Karte „Tages-Briefing" unter /admin/mail mit Status (zuletzt verschickt) und **„Jetzt an alle senden"** (`POST /api/admin/briefing`, session-gated; zählt als heutiger Versand)
- Mail-Template `dailyBriefingEmailHtml` im bestehenden Marken-Layout (tabellenbasiert, inline-CSS)

## Verifikation
- `npx tsc --noEmit` grün
- Template-Rendertest (tsx): alle Sektionen, NEU/HOCH-Badges, „+N weitere", XSS-Escaping, leere Sektionen werden weggelassen
- Dev-Server: `GET /api/admin/briefing` → Status-JSON; `POST` ohne Graph-Config → sauberer 409; Admin-UI (Toggle, Stundenfeld, Karte) im Browser geprüft (Screenshot im Ticket-Verlauf)

## Ideen für später (aus dem Ticket „Was kann man sonst noch einbauen?")
- Wochen-Rückblick freitags (erledigte Aufgaben/gebuchte Anfragen der Woche)
- Streaks („5 Tage in Folge alles abgearbeitet") & kleine Abzeichen
- Umsatz-/Pipeline-Zeile (Summe offener Angebote)
- Opt-out je Mitarbeiter:in

Ticket: TASK-00091

🤖 Generated with [Claude Code](https://claude.com/claude-code)