### PR TITLE
fix(db): SQLite-Init crasht auf Alt-DBs ohne task_time.report_id (TASK-00095)

### DIFF
--- a/scripts/check-old-db-init.mts
+++ b/scripts/check-old-db-init.mts
@@ -1,0 +1,26 @@
+// Lädt database.ts (Modul-Load ruft initDatabase()) gegen die präparierte Alt-DB
+// und prüft, dass Migration + Index + alle Folge-Tabellen da sind.
+import { db as sqlite } from '../src/lib/database';
+
+const cols = sqlite.prepare(`PRAGMA table_info(task_time)`).all() as Array<{ name: string }>;
+const hasReportId = cols.some((c) => c.name === 'report_id');
+const hasWorkDate = cols.some((c) => c.name === 'work_date');
+const idx = sqlite
+  .prepare(`SELECT name FROM sqlite_master WHERE type='index' AND name='idx_task_time_report'`)
+  .get();
+const laterTables = ['time_reports', 'projects', 'task_messages', 'api_keys', 'admin_notifications', 'tippspiel_users'];
+const missing = laterTables.filter(
+  (t) => !sqlite.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`).get(t)
+);
+const oldRow = sqlite.prepare(`SELECT note FROM task_time WHERE id='t1'`).get() as { note: string } | undefined;
+
+console.log('report_id-Spalte:', hasReportId ? 'OK' : 'FEHLT');
+console.log('work_date-Spalte:', hasWorkDate ? 'OK' : 'FEHLT');
+console.log('idx_task_time_report:', idx ? 'OK' : 'FEHLT');
+console.log('Folge-Tabellen:', missing.length ? `FEHLEN: ${missing.join(', ')}` : 'OK');
+console.log('Alt-Daten erhalten:', oldRow?.note === 'alt-eintrag' ? 'OK' : 'FEHLT');
+
+if (!hasReportId || !hasWorkDate || !idx || missing.length || oldRow?.note !== 'alt-eintrag') {
+  process.exit(1);
+}
+console.log('ALLES OK');

--- a/scripts/make-old-db.cjs
+++ b/scripts/make-old-db.cjs
@@ -1,0 +1,28 @@
+// Präpariert data/bookings.db als "Alt-DB": task_time OHNE work_date/report_id
+// (Stand vor den Rapport-Migrationen). initDatabase() muss darauf sauber laufen.
+const Database = require('better-sqlite3');
+const fs = require('fs');
+const path = require('path');
+
+const dataDir = path.join(process.cwd(), 'data');
+fs.mkdirSync(dataDir, { recursive: true });
+const dbPath = path.join(dataDir, 'bookings.db');
+for (const f of [dbPath, dbPath + '-wal', dbPath + '-shm']) {
+  if (fs.existsSync(f)) fs.unlinkSync(f);
+}
+
+const db = new Database(dbPath);
+db.exec(`
+  CREATE TABLE task_time (
+    id TEXT PRIMARY KEY,
+    task_id TEXT NOT NULL,
+    employee_id TEXT,
+    minutes INTEGER NOT NULL DEFAULT 0,
+    note TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE INDEX idx_task_time_task ON task_time(task_id);
+  INSERT INTO task_time (id, task_id, minutes, note) VALUES ('t1', 'task-1', 30, 'alt-eintrag');
+`);
+db.close();
+console.log('Alt-DB angelegt:', dbPath);

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -316,7 +316,6 @@ export function initDatabase() {
       created_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
     CREATE INDEX IF NOT EXISTS idx_task_time_task ON task_time(task_id);
-    CREATE INDEX IF NOT EXISTS idx_task_time_report ON task_time(report_id);
 
     CREATE TABLE IF NOT EXISTS time_reports (
       id TEXT PRIMARY KEY,
@@ -503,6 +502,10 @@ export function initDatabase() {
   const ttcols = sqlite.prepare(`PRAGMA table_info(task_time)`).all() as Array<{ name: string }>;
   if (ttcols.length && !ttcols.some((c) => c.name === 'work_date')) addColumn('task_time', "work_date TEXT NOT NULL DEFAULT ''");
   if (ttcols.length && !ttcols.some((c) => c.name === 'report_id')) addColumn('task_time', 'report_id TEXT');
+  // Indizes auf nachträglich migrierte Spalten gehören HIERHER, nicht in den großen
+  // exec oben: dort würde CREATE INDEX auf Alt-DBs ohne die Spalte werfen, bevor
+  // addColumn sie nachziehen kann — und alle Statements danach liefen nie.
+  sqlite.exec(`CREATE INDEX IF NOT EXISTS idx_task_time_report ON task_time(report_id)`);
   const stcols2 = sqlite.prepare(`PRAGMA table_info(staff_tasks)`).all() as Array<{ name: string }>;
   if (stcols2.length && !stcols2.some((c) => c.name === 'project_id')) addColumn('staff_tasks', 'project_id TEXT');
   // Backfill: bestehende Tasks ohne Nummer fortlaufend ab 10 nummerieren (nach Erstellzeit).


### PR DESCRIPTION
## Problem
`initDatabase()` (src/lib/database.ts) legt das komplette Schema in einem großen `sqlite.exec` an — inklusive `CREATE INDEX IF NOT EXISTS idx_task_time_report ON task_time(report_id)`. Die `addColumn`-Migration, die `report_id` auf Bestands-DBs nachzieht, läuft aber erst NACH dem exec.

Auf einer älteren SQLite-Datei (task_time ohne `report_id`) wirft der exec daher `SqliteError: no such column: report_id`, bevor die Migration greifen kann:
- `initDatabase()` schlägt beim Modul-Load fehl → **alle API-Routen geben 500** (lokal reproduziert am 2026-07-09, u. a. `/api/admin/notifications`).
- Alle im exec **nachfolgenden** `CREATE TABLE` (time_reports, projects, task_messages, api_keys, admin_notifications, tippspiel_*) laufen nie.

Prod (Postgres) ist nicht betroffen — aber der SQLite-Fallback ist laut CLAUDE.md das Rollback-Szenario und würde auf alten Volumes crashen.

## Fix
Den Index aus dem großen exec herausgelöst; er wird jetzt direkt nach den `task_time`-addColumn-Migrationen angelegt. Kommentar an der Stelle warnt davor, künftige Indizes auf nachträglich migrierte Spalten wieder in den großen exec zu setzen.

## Verifikation
Testskripte im PR (`scripts/make-old-db.cjs` präpariert eine Alt-DB ohne `report_id`/`work_date`, `scripts/check-old-db-init.mts` lädt `database.ts` und prüft das Ergebnis):
- **Alter Code + Alt-DB:** Crash reproduziert (`no such column: report_id`) ✔
- **Fix + Alt-DB:** Spalten migriert, Index angelegt, alle Folge-Tabellen vorhanden, Bestandsdaten erhalten ✔
- **Frische DB:** Schema inkl. Index vollständig ✔
- **Idempotenz:** zweiter `initDatabase()`-Lauf auf migrierter DB ohne Fehler ✔
- `npx tsc --noEmit` sauber ✔

Ticket: TASK-00095

🤖 Generated with [Claude Code](https://claude.com/claude-code)