### PR TITLE
feat(release-notes): Changelog-Mail an alle nach jedem Deploy (TASK-00096)

### DIFF
--- a/src/app/admin/mail/page.tsx
+++ b/src/app/admin/mail/page.tsx
@@ -8,7 +8,7 @@ import {
 import { buildEntraSetupScript } from '@/lib/entraSetupScript';
 import {
   Mail, Send, RefreshCw, CheckCircle2, XCircle, Server, Inbox, ListChecks, KeyRound,
-  Save, Terminal, Copy, Download, ShieldCheck, Sun,
+  Save, Terminal, Copy, Download, ShieldCheck, Sun, Rocket,
 } from 'lucide-react';
 
 interface MailStatus {
@@ -45,6 +45,7 @@ export default function MailAdminPage() {
     inbound_poll_secret: '', brevo_api_key: '', login_base_url: '', notify_to: '',
     ticket_auto_create: false, ticket_auto_create_domains: 'faltintravel.com',
     daily_briefing_enabled: true, daily_briefing_hour: '7',
+    release_notes_enabled: true,
   });
 
   const [testTo, setTestTo] = useState('');
@@ -52,6 +53,8 @@ export default function MailAdminPage() {
   const [polling, setPolling] = useState(false);
   const [briefingStatus, setBriefingStatus] = useState<{ last_sent_date: string | null; last_result: { sent: number; skippedEmpty: number; errors: number } | null } | null>(null);
   const [sendingBriefing, setSendingBriefing] = useState(false);
+  const [releaseStatus, setReleaseStatus] = useState<{ githubConfigured: boolean; last_run_at: string | null; last_result: { sent: number; prs: number[] } | null } | null>(null);
+  const [sendingRelease, setSendingRelease] = useState(false);
   const [toast, setToast] = useState<{ ok: boolean; msg: string } | null>(null);
 
   // Script generator
@@ -62,13 +65,15 @@ export default function MailAdminPage() {
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      const [s, c, b] = await Promise.all([
+      const [s, c, b, rn] = await Promise.all([
         fetch('/api/admin/mail/status').then((r) => r.json()),
         fetch('/api/admin/mail/config').then((r) => r.json()),
         fetch('/api/admin/briefing').then((r) => r.json()).catch(() => null),
+        fetch('/api/admin/release-notes').then((r) => r.json()).catch(() => null),
       ]);
       if (s.success) setStatus(s.data);
       if (b?.success) setBriefingStatus(b.data);
+      if (rn?.success) setReleaseStatus(rn.data);
       if (c.success) {
         setCfg(c.data);
         setForm((f) => ({
@@ -84,6 +89,7 @@ export default function MailAdminPage() {
           ticket_auto_create_domains: c.data.ticket_auto_create_domains ?? 'faltintravel.com',
           daily_briefing_enabled: c.data.daily_briefing_enabled !== false,
           daily_briefing_hour: String(c.data.daily_briefing_hour ?? 7),
+          release_notes_enabled: c.data.release_notes_enabled !== false,
           client_secret: '',
           brevo_api_key: '',
         }));
@@ -145,6 +151,21 @@ export default function MailAdminPage() {
       } else flash(false, data.error || 'Briefing fehlgeschlagen.');
     } catch { flash(false, 'Verbindungsfehler.'); }
     finally { setSendingBriefing(false); }
+  };
+
+  const runReleaseNotes = async () => {
+    setSendingRelease(true);
+    try {
+      const res = await fetch('/api/admin/release-notes', { method: 'POST' });
+      const data = await res.json();
+      if (data.success) {
+        flash(true, data.data.prs.length
+          ? `Release-Mail verschickt: ${data.data.sent} Empfänger, PRs #${data.data.prs.join(', #')}.`
+          : `Keine neuen Merges seit dem letzten Lauf — nichts zu verschicken.`);
+        await load();
+      } else flash(false, data.error || 'Release-Mail fehlgeschlagen.');
+    } catch { flash(false, 'Verbindungsfehler.'); }
+    finally { setSendingRelease(false); }
   };
 
   const runPoll = async () => {
@@ -291,6 +312,17 @@ export default function MailAdminPage() {
                   />
                 </div>
               </div>
+              <div className="rounded-xl border border-gray-200 p-4">
+                <Toggle
+                  checked={form.release_notes_enabled}
+                  onChange={(v) => set('release_notes_enabled', v)}
+                  label="Release-Mail nach jedem Deploy"
+                />
+                <p className="mt-1.5 text-xs" style={{ color: '#9ca3af' }}>
+                  Nach jedem Deploy geht ein Entwickler-Changelog an alle Mitarbeitenden: neue Funktionen,
+                  Bugfixes & Co. mit PR-Link und TASK-Nummern (Quelle: gemergte GitHub-PRs).
+                </p>
+              </div>
               <InputField
                 label="Brevo API-Key (Listen)"
                 type="password"
@@ -360,6 +392,24 @@ export default function MailAdminPage() {
             </p>
             <Button variant="primary" onClick={runBriefing} disabled={sendingBriefing || !status?.graphConfigured}>
               {sendingBriefing ? <Spinner className="h-4 w-4 border-white" /> : <Send className="h-4 w-4" />} Jetzt an alle senden
+            </Button>
+          </SectionCard>
+
+          {/* Release-Mails */}
+          <SectionCard title="Release-Mails" description="Changelog nach jedem Deploy ans Team" icon={<Rocket className="h-5 w-5" />}>
+            <p className="mb-4 text-sm" style={{ color: COLORS.textMuted }}>
+              {releaseStatus?.last_result?.prs?.length
+                ? <>Zuletzt angekündigt: PR&nbsp;#{releaseStatus.last_result.prs.join(', #')} ({releaseStatus.last_result.sent} Mails).</>
+                : 'Noch keine Release-Mail verschickt.'}
+              {' '}Der Button prüft auf neue Merges und verschickt sofort.
+              {releaseStatus && !releaseStatus.githubConfigured && (
+                <span className="block mt-2 font-semibold" style={{ color: COLORS.danger }}>
+                  Kein GitHub-Token konfiguriert — Quelle für die Changelog-Daten fehlt.
+                </span>
+              )}
+            </p>
+            <Button variant="primary" onClick={runReleaseNotes} disabled={sendingRelease || !status?.graphConfigured || !releaseStatus?.githubConfigured}>
+              {sendingRelease ? <Spinner className="h-4 w-4 border-white" /> : <Rocket className="h-4 w-4" />} Jetzt prüfen &amp; senden
             </Button>
           </SectionCard>
         </div>

--- a/src/app/api/admin/mail/config/route.ts
+++ b/src/app/api/admin/mail/config/route.ts
@@ -18,6 +18,7 @@ export async function GET() {
       ticket_auto_create_domains: m.ticket_auto_create_domains ?? 'faltintravel.com',
       daily_briefing_enabled: m.daily_briefing_enabled !== false,
       daily_briefing_hour: m.daily_briefing_hour ?? 7,
+      release_notes_enabled: m.release_notes_enabled !== false,
       has_client_secret: !!(m.client_secret || process.env.GRAPH_CLIENT_SECRET),
       has_brevo: !!(m.brevo_api_key || process.env.BREVO_API_KEY),
       env_fallback: {
@@ -41,6 +42,7 @@ export async function POST(request: Request) {
     }
     if ('ticket_auto_create' in body) updates.ticket_auto_create = !!body.ticket_auto_create;
     if ('daily_briefing_enabled' in body) updates.daily_briefing_enabled = !!body.daily_briefing_enabled;
+    if ('release_notes_enabled' in body) updates.release_notes_enabled = !!body.release_notes_enabled;
     if ('daily_briefing_hour' in body) {
       const h = Number(body.daily_briefing_hour);
       if (Number.isFinite(h)) updates.daily_briefing_hour = Math.min(23, Math.max(0, Math.round(h)));

--- a/src/app/api/admin/release-notes/route.ts
+++ b/src/app/api/admin/release-notes/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { getSessionEmployee } from '@/lib/serverSession';
+import { runReleaseNotes, releaseNotesStatus } from '@/lib/releaseNotes';
+
+/** GET → Status der Release-Notes-Mail (Toggle, GitHub-Zugang, letzter Lauf). */
+export async function GET() {
+  const ctx = await getSessionEmployee();
+  if (!ctx) return NextResponse.json({ success: false, error: 'Nicht angemeldet' }, { status: 401 });
+  return NextResponse.json({ success: true, data: releaseNotesStatus() });
+}
+
+/**
+ * POST → sofort prüfen & verschicken (manueller Test). Ohne neue Merges seit
+ * dem letzten Lauf geht keine Mail raus (reason im Ergebnis).
+ */
+export async function POST() {
+  const ctx = await getSessionEmployee();
+  if (!ctx) return NextResponse.json({ success: false, error: 'Nicht angemeldet' }, { status: 401 });
+  try {
+    const result = await runReleaseNotes({ force: true });
+    if (!result.configured) {
+      return NextResponse.json({ success: false, error: result.reason || 'Nicht konfiguriert.' }, { status: 409 });
+    }
+    return NextResponse.json({ success: true, data: result });
+  } catch (error) {
+    return NextResponse.json({ success: false, error: (error as Error).message }, { status: 500 });
+  }
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -5,14 +5,17 @@
  *   – Inbound-Mail-Polling (alle 120 s), kein externer Cron auf /api/inbound/poll nötig
  *   – Tägliches Team-Briefing (Check alle 5 min; Versand einmal pro Tag ab der
  *     konfigurierten Stunde, dedupliziert über data/briefing-state.json)
+ *   – Release-Notes-Mail (einmalig ~90 s nach Start = nach jedem Deploy;
+ *     kündigt seit dem letzten Lauf gemergte PRs an, ohne neue Merges keine Mail)
  * Läuft nur im Node.js-Runtime-Prozess; Fehler werden geloggt, crashen aber
- * niemals den Server. Beide Jobs beenden sich sofort billig, wenn Microsoft
+ * niemals den Server. Alle Jobs beenden sich sofort billig, wenn Microsoft
  * Graph nicht konfiguriert bzw. das Feature deaktiviert ist.
  * ─────────────────────────────────────────────────────────────────────────────
  */
 
 const POLL_INTERVAL_MS = 120_000;
 const BRIEFING_CHECK_MS = 300_000;
+const RELEASE_NOTES_DELAY_MS = 90_000;
 const GLOBAL_KEY = Symbol.for('faltin.inboundPollTimer');
 
 export async function register() {
@@ -58,4 +61,23 @@ export async function register() {
   (briefingTimer as unknown as { unref?: () => void }).unref?.();
 
   console.log(`[daily-briefing] Scheduler aktiv (Check alle ${BRIEFING_CHECK_MS / 1000}s).`);
+
+  // Release-Notes einmalig nach dem Start (= nach jedem Deploy, der Container
+  // startet neu). Verzögert, damit der Server erst sauber hochgefahren ist.
+  const releaseTimer = setTimeout(async () => {
+    try {
+      const { runReleaseNotes } = await import('./lib/releaseNotes');
+      const result = await runReleaseNotes();
+      if (result.sent > 0 || result.errors > 0 || result.prs.length > 0) {
+        console.log(`[release-notes] sent=${result.sent} errors=${result.errors} prs=${result.prs.join(',')}`);
+      } else if (result.reason) {
+        console.log(`[release-notes] Übersprungen: ${result.reason}`);
+      }
+    } catch (err) {
+      console.error('[release-notes] Lauf fehlgeschlagen:', err);
+    }
+  }, RELEASE_NOTES_DELAY_MS);
+  (releaseTimer as unknown as { unref?: () => void }).unref?.();
+
+  console.log(`[release-notes] Check ${RELEASE_NOTES_DELAY_MS / 1000}s nach Start geplant.`);
 }

--- a/src/lib/emailTemplates.ts
+++ b/src/lib/emailTemplates.ts
@@ -698,3 +698,91 @@ export function dailyBriefingEmailHtml(input: DailyBriefingInput): string {
 
   return layout(inner, `Dein Tages-Briefing: ${input.myOpenTasks.length + (input.myOpenMore || 0)} offene Aufgaben, ${input.newInquiries.length} neue Anfragen.`);
 }
+
+/* ── Release-Notes-Mail nach Deploy (TASK-00096) ───────────────────────────── */
+
+export interface ReleaseNoteItem {
+  type: 'feature' | 'bugfix' | 'performance' | 'security' | 'refactor' | 'chore' | 'other';
+  /** Titel ohne Conventional-Commit-Präfix, z.B. "Tägliches Team-Briefing per Mail" */
+  title: string;
+  prNumber: number;
+  prUrl: string;
+  /** Referenzierte Tickets, z.B. ["TASK-00091"] */
+  taskNos: string[];
+  /** Kurzfassung aus dem PR-Body (bereits Markdown-bereinigt). */
+  summary?: string;
+  author?: string;
+}
+
+export interface ReleaseNotesInput {
+  /** z.B. "09.07.2026, 10:45" */
+  dateLabel: string;
+  /** z.B. "next.faltintravel.com" */
+  siteHost: string;
+  items: ReleaseNoteItem[];
+  /** Anzahl nicht gezeigter älterer Merges (Kappung). */
+  omittedCount?: number;
+  repoUrl: string;
+}
+
+const RELEASE_TYPE_META: Record<ReleaseNoteItem['type'], { label: string; bg: string; fg: string }> = {
+  feature:     { label: 'FEATURE',     bg: '#fff1ea', fg: '#d9531e' },
+  bugfix:      { label: 'BUGFIX',      bg: '#f0fdf4', fg: '#16a34a' },
+  performance: { label: 'PERFORMANCE', bg: '#f5f3ff', fg: '#7c3aed' },
+  security:    { label: 'SECURITY',    bg: '#fef2f2', fg: '#dc2626' },
+  refactor:    { label: 'REFACTOR',    bg: '#eff6ff', fg: '#2563eb' },
+  chore:       { label: 'WARTUNG',     bg: '#f5f7fa', fg: '#6b7280' },
+  other:       { label: 'ÄNDERUNG',    bg: '#f5f7fa', fg: '#6b7280' },
+};
+
+function releaseItemHtml(item: ReleaseNoteItem): string {
+  const meta = RELEASE_TYPE_META[item.type] || RELEASE_TYPE_META.other;
+  const metaLine = [
+    `<a href="${item.prUrl}" style="color:#6b7280;text-decoration:none;">PR&nbsp;#${item.prNumber}</a>`,
+    ...item.taskNos.map((t) => `<span style="font-family:monospace;color:${ACCENT};font-weight:700;">${escapeHtml(t)}</span>`),
+    item.author ? `von ${escapeHtml(item.author)}` : '',
+  ].filter(Boolean).join(' &nbsp;·&nbsp; ');
+  return `<tr><td style="padding:14px 16px;border:1px solid #e5e8ed;border-radius:12px;">
+    <span style="display:inline-block;background:${meta.bg};color:${meta.fg};font-size:10px;font-weight:800;letter-spacing:1px;padding:3px 10px;border-radius:999px;">${meta.label}</span>
+    <p style="margin:8px 0 0;font-size:15px;font-weight:700;color:${NAVY};line-height:1.5;">${escapeHtml(item.title)}</p>
+    ${item.summary ? `<p style="margin:6px 0 0;font-size:13px;line-height:1.6;color:#4b5563;">${escapeHtml(item.summary)}</p>` : ''}
+    <p style="margin:8px 0 0;font-size:12px;color:#6b7280;">${metaLine}</p>
+  </td></tr><tr><td style="height:10px;line-height:10px;font-size:10px;">&nbsp;</td></tr>`;
+}
+
+/**
+ * Release-Changelog nach einem Deploy — Entwickler-Stil mit Typ-Badges,
+ * PR-Links, Ticket-Nummern und Kurzbeschreibung je Änderung.
+ */
+export function releaseNotesEmailHtml(input: ReleaseNotesInput): string {
+  const features = input.items.filter((i) => i.type === 'feature').length;
+  const fixes = input.items.filter((i) => i.type === 'bugfix').length;
+  const rest = input.items.length - features - fixes;
+  const statChip = (n: number, label: string, color: string) =>
+    n ? `<span style="display:inline-block;margin:0 8px 6px 0;background:#f5f7fa;border:1px solid #e5e8ed;border-radius:999px;padding:5px 14px;font-size:12px;font-weight:700;color:${color};">${n} ${label}</span>` : '';
+
+  const inner = `
+    <p style="margin:0 0 4px;font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:1px;color:#9ca3af;">Release · ${escapeHtml(input.siteHost)} · ${escapeHtml(input.dateLabel)}</p>
+    <h1 style="margin:6px 0 0;font-size:24px;font-weight:800;color:${NAVY};">🚀 Frisch deployed!</h1>
+    <p style="margin:10px 0 0;font-size:15px;line-height:1.7;color:#374151;">
+      Soeben ist ein neues Release live gegangen — das steckt drin:
+    </p>
+    <p style="margin:14px 0 0;">
+      ${statChip(features, features === 1 ? 'neue Funktion' : 'neue Funktionen', '#d9531e')}
+      ${statChip(fixes, fixes === 1 ? 'Bugfix' : 'Bugfixes', '#16a34a')}
+      ${statChip(rest, rest === 1 ? 'weitere Änderung' : 'weitere Änderungen', '#6b7280')}
+    </p>
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-top:16px;">
+      ${input.items.map(releaseItemHtml).join('')}
+    </table>
+    ${input.omittedCount ? `<p style="margin:4px 0 0;font-size:12px;color:#9ca3af;">… und ${input.omittedCount} ältere Änderung${input.omittedCount === 1 ? '' : 'en'} (siehe GitHub).</p>` : ''}
+    <p style="margin:24px 0 0;">
+      <a href="${input.repoUrl}/pulls?q=is%3Apr+is%3Amerged" style="display:inline-block;background:${NAVY};color:#ffffff;text-decoration:none;font-weight:700;font-size:14px;padding:11px 22px;border-radius:10px;">Alle Änderungen auf GitHub</a>
+    </p>
+    <p style="margin:22px 0 0;font-size:11px;line-height:1.6;color:#9ca3af;">
+      Automatische Release-Mail nach jedem Deploy — konfigurierbar unter Admin → E-Mail / Microsoft 365.
+    </p>`;
+
+  const preheader = input.items.map((i) => i.title).join(' · ').slice(0, 120);
+  return layout(inner, preheader);
+}

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -1,0 +1,249 @@
+/**
+ * releaseNotes.ts (TASK-00096)
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Release-Notes-Mail nach jedem Deploy: Beim Produktions-Start (= nach jedem
+ * Deploy, da der Container neu startet) werden die seit dem letzten Lauf nach
+ * main gemergten Pull Requests über die GitHub-API geholt und als
+ * Entwickler-Changelog an alle aktiven Mitarbeitenden gemailt — mit Typ-Badge
+ * (Feature/Bugfix/…), PR-Link, referenzierten TASK-Nummern und Kurzfassung.
+ *
+ * Gesteuert über settings.mail.release_notes_enabled; GitHub-Zugang kommt aus
+ * den bestehenden GitHub-Settings (settings.github.token, Auto-Fix-Bot).
+ * Watermark (merged_at) liegt in data/release-notes-state.json.
+ * Manueller Test: POST /api/admin/release-notes.
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+import fs from 'fs';
+import path from 'path';
+import { getSettings } from './settingsStore';
+import { getGithubConfig } from './autoFix';
+import { listEmployees } from './staffStore';
+import { releaseNotesEmailHtml, type ReleaseNoteItem } from './emailTemplates';
+
+const STATE_PATH = path.join(process.cwd(), 'data', 'release-notes-state.json');
+/** Erster Lauf ohne State: nur PRs der letzten 2 h ankündigen (kein Historien-Spam). */
+const FIRST_RUN_WINDOW_MS = 2 * 3600 * 1000;
+const MAX_ITEMS = 10;
+
+export interface ReleaseNotesResult {
+  /** false = Feature aus, Graph oder GitHub-Token fehlt. */
+  configured: boolean;
+  sent: number;
+  errors: number;
+  /** Angekündigte PR-Nummern. */
+  prs: number[];
+  reason?: string;
+}
+
+interface ReleaseState {
+  /** ISO-Zeitpunkt des neuesten bereits angekündigten Merges. */
+  last_merged_at?: string;
+  last_run_at?: string;
+  last_result?: Omit<ReleaseNotesResult, 'reason'>;
+}
+
+interface GithubPull {
+  number: number;
+  title: string;
+  body: string | null;
+  html_url: string;
+  merged_at: string | null;
+  user?: { login?: string } | null;
+}
+
+function readState(): ReleaseState {
+  try {
+    return JSON.parse(fs.readFileSync(STATE_PATH, 'utf-8')) as ReleaseState;
+  } catch {
+    return {};
+  }
+}
+
+function writeState(state: ReleaseState): void {
+  try {
+    fs.mkdirSync(path.dirname(STATE_PATH), { recursive: true });
+    fs.writeFileSync(STATE_PATH, JSON.stringify(state, null, 2), 'utf-8');
+  } catch (e) {
+    console.warn('[release-notes] State konnte nicht geschrieben werden:', (e as Error).message);
+  }
+}
+
+/** Typ aus Conventional-Commit-Präfix der PR-Titel ("feat(x): …" → feat). */
+export function classifyPrType(title: string): ReleaseNoteItem['type'] {
+  const m = /^\s*(feat|fix|chore|refactor|docs|perf|security|ci|build|test)\b/i.exec(title);
+  const t = (m?.[1] || '').toLowerCase();
+  if (t === 'feat') return 'feature';
+  if (t === 'fix') return 'bugfix';
+  if (t === 'perf') return 'performance';
+  if (t === 'security') return 'security';
+  if (t === 'refactor') return 'refactor';
+  if (t) return 'chore';
+  return 'other';
+}
+
+/** PR-Titel ohne Conventional-Commit-Präfix und ohne Ticket-Klammer am Ende. */
+export function cleanPrTitle(title: string): string {
+  return title
+    .replace(/^\s*(feat|fix|chore|refactor|docs|perf|security|ci|build|test)(\([^)]*\))?\s*[:!]\s*/i, '')
+    .replace(/\s*\(TASK-\d{3,}\)\s*$/i, '')
+    .trim();
+}
+
+/** Alle referenzierten TASK-Nummern (Titel + Body), dedupliziert. */
+export function extractTaskNos(...texts: Array<string | null | undefined>): string[] {
+  const found = new Set<string>();
+  for (const t of texts) {
+    for (const m of (t || '').matchAll(/TASK-\d{3,}/gi)) found.add(m[0].toUpperCase());
+  }
+  return [...found];
+}
+
+/**
+ * Kurzfassung aus dem PR-Body: erster Aufzählungspunkt bzw. erster Absatz,
+ * Markdown grob entschärft (Links → Text, Code-Backticks/Fettung entfernt).
+ */
+export function summarizeBody(body: string | null | undefined): string {
+  const text = (body || '')
+    .replace(/\r/g, '')
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/[`*_]/g, '');
+  const lines = text.split('\n').map((l) => l.trim());
+  const firstBullet = lines.find((l) => /^[-•]\s+\S/.test(l));
+  const firstPara = lines.find((l) => l && !l.startsWith('#') && !/^🤖/.test(l));
+  const raw = (firstBullet || firstPara || '').replace(/^[-•]\s+/, '');
+  return raw.length > 220 ? raw.slice(0, 217).trimEnd() + '…' : raw;
+}
+
+async function fetchMergedPulls(sinceIso: string): Promise<GithubPull[] | null> {
+  const cfg = getGithubConfig();
+  if (!cfg.configured) return null;
+  const res = await fetch(
+    `https://api.github.com/repos/${cfg.owner}/${cfg.repo}/pulls?state=closed&base=${encodeURIComponent(cfg.base)}&sort=updated&direction=desc&per_page=30`,
+    {
+      headers: {
+        Authorization: `Bearer ${cfg.token}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'User-Agent': 'ft-release-notes',
+      },
+    }
+  );
+  if (!res.ok) {
+    console.warn('[release-notes] GitHub-API-Fehler:', res.status);
+    return null;
+  }
+  const pulls = (await res.json()) as GithubPull[];
+  return pulls
+    .filter((p) => p.merged_at && p.merged_at > sinceIso)
+    .sort((a, b) => (a.merged_at! < b.merged_at! ? -1 : 1));
+}
+
+let running = false;
+
+/**
+ * Kündigt neu gemergte PRs per Mail an. Läuft einmal pro Container-Start
+ * (instrumentation.ts) — ohne neue Merges wird keine Mail verschickt.
+ */
+export async function runReleaseNotes(opts: { force?: boolean } = {}): Promise<ReleaseNotesResult> {
+  const done = (over: Partial<ReleaseNotesResult>): ReleaseNotesResult =>
+    ({ configured: true, sent: 0, errors: 0, prs: [], ...over });
+
+  if (running) return done({ reason: 'Läuft bereits.' });
+  const m = getSettings().mail;
+  if (m.release_notes_enabled === false && !opts.force) return done({ configured: false, reason: 'Feature deaktiviert.' });
+
+  const { isGraphConfigured, sendGraphMail } = await import('./graphMailer');
+  if (!isGraphConfigured()) return done({ configured: false, reason: 'Microsoft Graph nicht konfiguriert.' });
+  if (!getGithubConfig().configured) return done({ configured: false, reason: 'Kein GitHub-Token konfiguriert (Admin → Status/Auto-Fix).' });
+
+  running = true;
+  try {
+    const state = readState();
+    const since = state.last_merged_at || new Date(Date.now() - FIRST_RUN_WINDOW_MS).toISOString();
+    const pulls = await fetchMergedPulls(since);
+    if (pulls === null) return done({ configured: false, reason: 'GitHub-API nicht erreichbar.' });
+    if (!pulls.length) {
+      writeState({ ...state, last_run_at: new Date().toISOString() });
+      return done({ reason: 'Keine neuen Merges.' });
+    }
+
+    const shown = pulls.slice(-MAX_ITEMS);
+    const items: ReleaseNoteItem[] = shown.map((p) => ({
+      type: classifyPrType(p.title),
+      title: cleanPrTitle(p.title),
+      prNumber: p.number,
+      prUrl: p.html_url,
+      taskNos: extractTaskNos(p.title, p.body),
+      summary: summarizeBody(p.body),
+      author: p.user?.login || undefined,
+    }));
+
+    const cfg = getGithubConfig();
+    const base = (m.login_base_url || 'https://next.faltintravel.com').replace(/\/+$/, '');
+    const dateLabel = new Intl.DateTimeFormat('de-CH', {
+      timeZone: 'Europe/Zurich', day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit',
+    }).format(new Date());
+    const html = releaseNotesEmailHtml({
+      dateLabel,
+      siteHost: base.replace(/^https?:\/\//, ''),
+      items,
+      omittedCount: pulls.length - shown.length,
+      repoUrl: `https://github.com/${cfg.owner}/${cfg.repo}`,
+    });
+
+    const features = items.filter((i) => i.type === 'feature').length;
+    const fixes = items.filter((i) => i.type === 'bugfix').length;
+    const parts = [
+      features ? `${features} neue Funktion${features === 1 ? '' : 'en'}` : '',
+      fixes ? `${fixes} Bugfix${fixes === 1 ? '' : 'es'}` : '',
+      items.length - features - fixes ? `${items.length - features - fixes} weitere Änderung${items.length - features - fixes === 1 ? '' : 'en'}` : '',
+    ].filter(Boolean).join(' · ');
+    const subject = `🚀 Release ${dateLabel} — ${parts || `${items.length} Änderungen`}`;
+
+    // Watermark VOR dem Versand setzen: ein Fehler mitten im Loop darf beim
+    // nächsten Start keine Doppel-Mails an bereits Beliefert erzeugen.
+    const newest = pulls[pulls.length - 1].merged_at!;
+    writeState({ last_merged_at: newest, last_run_at: new Date().toISOString() });
+
+    const result = done({ prs: shown.map((p) => p.number) });
+    const recipients = (await listEmployees(false)).filter((e) => (e.email || '').trim());
+    for (const emp of recipients) {
+      const send = await sendGraphMail({ to: emp.email, toName: emp.name, subject, html })
+        .catch((e) => ({ success: false, error: (e as Error).message }));
+      if (send.success) result.sent++;
+      else {
+        result.errors++;
+        console.warn('[release-notes] Versand fehlgeschlagen an', emp.email, (send as { error?: string }).error);
+      }
+    }
+
+    writeState({
+      last_merged_at: newest,
+      last_run_at: new Date().toISOString(),
+      last_result: { configured: true, sent: result.sent, errors: result.errors, prs: result.prs },
+    });
+    return result;
+  } finally {
+    running = false;
+  }
+}
+
+/** Status für die Admin-UI. */
+export function releaseNotesStatus(): {
+  enabled: boolean;
+  githubConfigured: boolean;
+  last_merged_at: string | null;
+  last_run_at: string | null;
+  last_result: ReleaseState['last_result'] | null;
+} {
+  const m = getSettings().mail;
+  const state = readState();
+  return {
+    enabled: m.release_notes_enabled !== false,
+    githubConfigured: getGithubConfig().configured,
+    last_merged_at: state.last_merged_at || null,
+    last_run_at: state.last_run_at || null,
+    last_result: state.last_result || null,
+  };
+}

--- a/src/lib/settingsStore.ts
+++ b/src/lib/settingsStore.ts
@@ -127,6 +127,8 @@ export interface MailSettings {
   daily_briefing_enabled?: boolean;
   /** Stunde (0–23, Europe/Zurich), ab der das Tages-Briefing verschickt wird */
   daily_briefing_hour?: number;
+  /** Release-Notes-Mail an alle nach jedem Deploy (gemergte PRs via GitHub-API) */
+  release_notes_enabled?: boolean;
 }
 
 const DEFAULT_SETTINGS: AllSettings = {
@@ -194,6 +196,7 @@ const DEFAULT_SETTINGS: AllSettings = {
     ticket_auto_create_domains: 'faltintravel.com',
     daily_briefing_enabled: true,
     daily_briefing_hour: 7,
+    release_notes_enabled: true,
   },
   ai: {
     anthropic_api_key: '',


### PR DESCRIPTION
## Zusammenfassung
Setzt **TASK-00096** um: Nach jedem Deploy geht automatisch eine Release-Mail im Entwickler-Stil an alle aktiven Mitarbeitenden — „🚀 Frisch deployed!" mit allem, was seit dem letzten Release gemergt wurde.

**Inhalt je Änderung:**
- Typ-Badge aus dem Conventional-Commit-Präfix des PR-Titels: FEATURE (orange), BUGFIX (grün), PERFORMANCE, SECURITY, REFACTOR, WARTUNG
- bereinigter Titel (ohne `feat(x):`-Präfix), Kurzfassung aus dem PR-Body (Markdown bereinigt)
- PR-Link, referenzierte **TASK-Nummern** (aus Titel + Body extrahiert), Autor
- Statistik-Chips („2 neue Funktionen · 1 Bugfix") + Button zu allen Änderungen auf GitHub

**Mechanik:**
- Quelle: gemergte PRs auf `main` via GitHub-API — nutzt den vorhandenen Token aus den GitHub-Settings (Auto-Fix-Bot)
- Auslösung: einmalig ~90 s nach Produktions-Start (jeder Deploy startet den Container neu); ohne neue Merges keine Mail
- `merged_at`-Watermark in `data/release-notes-state.json`, wird **vor** dem Versand gesetzt (keine Doppel-Mails); Erstlauf kündigt nur die letzten 2 h an (kein Historien-Spam); Kappung auf 10 Einträge mit „… und N ältere"
- Settings: `mail.release_notes_enabled` (Default **an**), Toggle + Karte „Release-Mails" mit „Jetzt prüfen & senden" unter **/admin/mail** (`POST /api/admin/release-notes`, session-gated)

**Hinweis:** Direkt nach dem Deploy dieses PRs verschickt der Erstlauf eine Launch-Mail mit den heutigen Merges (2-h-Fenster) — das Feature kündigt sich damit selbst an. 🚀

## Verifikation
- `npx tsc --noEmit` grün
- tsx-Tests: Typ-Klassifizierung, Titel-Bereinigung, TASK-Extraktion (dedupliziert, case-insensitive), Body-Kurzfassung (Markdown-Strip, 220-Zeichen-Kappung), Template (Badges, Chips, Kappungshinweis, XSS-Escaping)
- Dev-Server: `GET /api/admin/release-notes` → Status; `POST` ohne Graph → sauberer 409; Admin-UI (Toggle, Karte, Token-Warnung ohne GitHub-Token) im Browser geprüft

Ticket: TASK-00096

🤖 Generated with [Claude Code](https://claude.com/claude-code)