### PR TITLE
feat(briefing): v2 — Unbeantwortete Mails, Pipeline, Countdowns, Wochen-Rückblick, Streaks, Opt-out (TASK-00103)

### DIFF
--- a/src/app/admin/team/page.tsx
+++ b/src/app/admin/team/page.tsx
@@ -19,6 +19,7 @@ interface Employee {
   vacation_days_per_year: number;
   employment_start: string | null;
   notes: string;
+  briefing_opt_out: boolean;
   last_login_at: string | null;
   vacation: { entitlement: number; used: number; pending: number; remaining: number };
 }
@@ -65,6 +66,7 @@ export default function TeamPage() {
           vacation_days_per_year: editing.vacation_days_per_year,
           employment_start: editing.employment_start,
           notes: editing.notes,
+          briefing_opt_out: editing.briefing_opt_out,
         }),
       });
       setEditing(null);
@@ -201,6 +203,14 @@ export default function TeamPage() {
             <Field label="Notizen" className="mt-4">
               <TextInput value={editing.notes} onChange={(ev) => setEditing({ ...editing, notes: ev.target.value })} />
             </Field>
+
+            <div className="mt-4">
+              <Toggle
+                checked={!editing.briefing_opt_out}
+                onChange={(v) => setEditing({ ...editing, briefing_opt_out: !v })}
+                label="Tages-Briefing per Mail erhalten"
+              />
+            </div>
 
             <div className="mt-5 flex items-center justify-between">
               <Toggle checked={editing.active} onChange={(v) => setEditing({ ...editing, active: v })} label="Aktiv" />

--- a/src/app/api/admin/team/[id]/route.ts
+++ b/src/app/api/admin/team/[id]/route.ts
@@ -13,6 +13,7 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
     employment_start: body.employment_start,
     notes: body.notes,
     name: body.name,
+    briefing_opt_out: body.briefing_opt_out,
   });
   if (!updated) return NextResponse.json({ success: false, error: 'Mitarbeiter nicht gefunden' }, { status: 404 });
   return NextResponse.json({ success: true, data: updated });

--- a/src/lib/dailyBriefing.ts
+++ b/src/lib/dailyBriefing.ts
@@ -16,8 +16,12 @@
  */
 import fs from 'fs';
 import path from 'path';
-import { listEmployees, listStaffTasks, formatTicketNo, type StaffTask, type Employee } from './staffStore';
-import { getAllBookings } from './database';
+import {
+  listEmployees, listStaffTasks, formatTicketNo, listUnansweredTaskInbound, listTaskTimeEntries,
+  type StaffTask, type Employee,
+} from './staffStore';
+import { getAllBookings, listUnansweredBookingInbound } from './database';
+import { getEvents } from './contentStore';
 import type { BookingRequest } from './supabase';
 import { getSettings } from './settingsStore';
 import {
@@ -116,6 +120,43 @@ function plural(n: number, singular: string, pluralWord: string): string {
   return `${n} ${n === 1 ? singular : pluralWord}`;
 }
 
+/** YYYY-MM-DD um n Tage verschieben (rein kalendarisch, UTC-Mittag gegen DST-Kanten). */
+function addDays(dateStr: string, n: number): string {
+  const d = new Date(`${dateStr}T12:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + n);
+  return d.toISOString().slice(0, 10);
+}
+
+/** Wochentag 0=So … 6=Sa eines YYYY-MM-DD. */
+function dayOfWeek(dateStr: string): number {
+  return new Date(`${dateStr}T12:00:00Z`).getUTCDay();
+}
+
+function formatEuro(n: number): string {
+  return new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR', minimumFractionDigits: 0 }).format(n);
+}
+
+function formatHours(minutes: number): string {
+  return `${(minutes / 60).toFixed(1).replace('.', ',')} h`;
+}
+
+/**
+ * Streak: zusammenhängende Arbeitstage (Mo–Fr) bis heute/gestern, an denen der
+ * Mitarbeitende Zeiten gebucht hat. Wochenenden unterbrechen den Streak nicht.
+ */
+function bookingStreak(workDates: Set<string>, today: string): number {
+  let day = workDates.has(today) ? today : addDays(today, -1);
+  let streak = 0;
+  for (let i = 0; i < 60; i++) {
+    const dow = dayOfWeek(day);
+    if (dow === 0 || dow === 6) { day = addDays(day, -1); continue; }
+    if (!workDates.has(day)) break;
+    streak++;
+    day = addDays(day, -1);
+  }
+  return streak;
+}
+
 function taskItem(t: StaffTask, opts: { sinceMs: number; today: string; base: string; withAssignee?: Map<string, string> }): BriefingTaskItem {
   const due = (t.due_date || '').slice(0, 10);
   const overdue = !!due && due < opts.today;
@@ -193,10 +234,14 @@ export async function runDailyBriefing(opts: { force?: boolean } = {}): Promise<
     const sinceMs = Date.now() - DAY_MS;
     const staleBeforeMs = Date.now() - STALE_DAYS * DAY_MS;
 
-    const [employees, tasks, bookings] = await Promise.all([
+    const [employees, tasks, bookings, unansweredBookings, unansweredTasks, timeEntries] = await Promise.all([
       listEmployees(false),
       listStaffTasks(),
       getAllBookings() as Promise<BookingRow[]>,
+      listUnansweredBookingInbound().catch(() => []),
+      listUnansweredTaskInbound().catch(() => []),
+      // Zeiten der letzten 30 Tage: Streaks + Wochen-Rückblick aus einem Abruf
+      listTaskTimeEntries({ from: addDays(now.date, -30) }).catch(() => []),
     ]);
     const nameById = new Map(employees.map((e) => [e.id, e.name]));
 
@@ -205,12 +250,74 @@ export async function runDailyBriefing(opts: { force?: boolean } = {}): Promise<
     const movedInquiries = bookings.filter((b) => ts(b.created_at) < sinceMs && ts(b.updated_at) >= sinceMs);
     const teamDoneCount = tasks.filter((t) => t.status === 'erledigt' && ts(t.updated_at) >= sinceMs).length;
 
+    // Pipeline: offene Anfragen nach Status + offenes Volumen (für alle gleich)
+    const openBookings = bookings.filter((b) => b.status === 'new' || b.status === 'in_progress');
+    const pipeline = {
+      newCount: openBookings.filter((b) => b.status === 'new').length,
+      inProgressCount: openBookings.filter((b) => b.status === 'in_progress').length,
+      volumeLabel: formatEuro(openBookings.reduce((s, b) => s + (b.total_price || 0), 0)),
+    };
+
+    // Unbeantwortete Kundenmails (>24 h) aus CRM + Tickets, älteste zuerst
+    const unanswered: BriefingInquiryItem[] = [
+      ...unansweredBookings.map((u) => ({
+        requestNumber: u.request_number || '—',
+        title: [u.package_title, (u.customer_name || '').trim() || u.email].filter(Boolean).join(' — '),
+        url: `${base}/admin/crm`,
+        statusLabel: `${BOOKING_STATUS_LABEL[u.status] || u.status}${u.assigned_to ? ` · ${nameById.get(u.assigned_to) || 'Unbekannt'}` : ' · nicht zugewiesen'}`,
+        lastInMs: ts(u.last_in_at),
+      })),
+      ...unansweredTasks.map((u) => ({
+        requestNumber: formatTicketNo(u.ticket_number) || '—',
+        title: u.title,
+        url: `${base}/admin/aufgaben/${u.task_id}`,
+        statusLabel: u.assignee_id ? `Ticket · ${nameById.get(u.assignee_id) || 'Unbekannt'}` : 'Ticket · nicht zugewiesen',
+        lastInMs: ts(u.last_in_at),
+      })),
+    ]
+      .filter((u) => u.lastInMs > 0 && u.lastInMs <= sinceMs)
+      .sort((a, b) => a.lastInMs - b.lastInMs)
+      .slice(0, MAX_ITEMS_PER_SECTION)
+      .map(({ lastInMs, ...item }) => ({
+        ...item,
+        ageLabel: `seit ${plural(Math.max(1, Math.floor((Date.now() - lastInMs) / DAY_MS)), 'Tag', 'Tagen')} unbeantwortet`,
+      }));
+
+    // Event-Countdowns: nächste 3 Events mit offenen Anfragen je Event
+    const countdowns = getEvents()
+      .filter((e) => (e.start_date || '') >= now.date)
+      .sort((a, b) => ((a.start_date || '') < (b.start_date || '') ? -1 : 1))
+      .slice(0, 3)
+      .map((e) => {
+        const days = Math.round((ts(`${e.start_date}T12:00:00Z`) - ts(`${now.date}T12:00:00Z`)) / DAY_MS);
+        const open = openBookings.filter((b) => b.event_slug && b.event_slug === e.slug).length;
+        return {
+          name: e.name || e.title,
+          daysLabel: days === 0 ? 'heute!' : days === 1 ? 'morgen' : `in ${days} Tagen`,
+          extra: open ? plural(open, 'offene Anfrage', 'offene Anfragen') : undefined,
+        };
+      });
+
+    // Zeiten-Buchungs-Streak je Mitarbeiter:in (Arbeitstage Mo–Fr)
+    const workDatesByEmp = new Map<string, Set<string>>();
+    for (const te of timeEntries) {
+      if (!te.employee_id || !te.work_date) continue;
+      if (!workDatesByEmp.has(te.employee_id)) workDatesByEmp.set(te.employee_id, new Set());
+      workDatesByEmp.get(te.employee_id)!.add(te.work_date.slice(0, 10));
+    }
+
+    // Freitags: Wochen-Rückblick (Mo–heute)
+    const isFriday = dayOfWeek(now.date) === 5;
+    const weekFrom = addDays(now.date, -((dayOfWeek(now.date) + 6) % 7));
+    const weekFromMs = ts(`${weekFrom}T00:00:00Z`);
+    const weekTime = timeEntries.filter((te) => (te.work_date || '').slice(0, 10) >= weekFrom);
+
     const dateLabel = new Intl.DateTimeFormat('de-CH', {
       timeZone: 'Europe/Zurich', weekday: 'long', day: '2-digit', month: '2-digit', year: 'numeric',
     }).format(new Date());
 
     const result = empty({});
-    const recipients = employees.filter((e): e is Employee => !!(e.email || '').trim());
+    const recipients = employees.filter((e): e is Employee => !!(e.email || '').trim() && !e.briefing_opt_out);
 
     for (const emp of recipients) {
       try {
@@ -239,8 +346,32 @@ export async function runDailyBriefing(opts: { force?: boolean } = {}): Promise<
         if (teamDoneCount > myDone) {
           kudos.push(`👏 Das Team hat insgesamt ${plural(teamDoneCount, 'Aufgabe', 'Aufgaben')} erledigt.`);
         }
+        const streak = bookingStreak(workDatesByEmp.get(emp.id) || new Set(), now.date);
+        if (streak >= 2) {
+          kudos.push(`🔥 ${streak} Arbeitstage in Folge Zeiten gebucht — dranbleiben!`);
+        }
 
-        const hasContent = myOpen.length || othersNew.length || newInquiries.length || movedInquiries.length || myStale.length || kudos.length;
+        // Freitags: Wochen-Bilanz (Team gesamt + eigener Zeitanteil)
+        let weekReview: { title: string; lines: string[] } | null = null;
+        if (isFriday) {
+          const doneWeek = tasks.filter((t) => t.status === 'erledigt' && ts(t.updated_at) >= weekFromMs).length;
+          const bookedWeek = bookings.filter((b) => b.status === 'booked' && ts(b.updated_at) >= weekFromMs).length;
+          const newWeek = bookings.filter((b) => ts(b.created_at) >= weekFromMs).length;
+          const totalMin = weekTime.reduce((s, te) => s + (te.minutes || 0), 0);
+          const ownMin = weekTime.filter((te) => te.employee_id === emp.id).reduce((s, te) => s + (te.minutes || 0), 0);
+          const lines = [
+            doneWeek ? `✅ ${plural(doneWeek, 'Aufgabe erledigt', 'Aufgaben erledigt')}` : '',
+            bookedWeek ? `✈️ ${plural(bookedWeek, 'Anfrage zur Buchung gebracht', 'Anfragen zur Buchung gebracht')}` : '',
+            newWeek ? `📥 ${plural(newWeek, 'neue Anfrage eingegangen', 'neue Anfragen eingegangen')}` : '',
+            totalMin ? `⏱️ ${formatHours(totalMin)} Zeiten gebucht${ownMin ? ` (davon du: ${formatHours(ownMin)})` : ''}` : '',
+          ].filter(Boolean);
+          if (lines.length) {
+            weekReview = { title: `Dein Wochen-Rückblick (seit Mo. ${formatDueDate(weekFrom)})`, lines };
+          }
+        }
+
+        const hasContent = myOpen.length || othersNew.length || newInquiries.length || movedInquiries.length
+          || myStale.length || kudos.length || unanswered.length || weekReview;
         if (!hasContent) {
           result.skippedEmpty++;
           continue;
@@ -259,11 +390,16 @@ export async function runDailyBriefing(opts: { force?: boolean } = {}): Promise<
             const days = Math.floor((Date.now() - ts(b.updated_at || b.created_at)) / DAY_MS);
             return inquiryItem(b, base, `seit ${plural(days, 'Tag', 'Tagen')} ohne Bewegung`);
           }),
+          pipeline,
+          unansweredMails: unanswered,
+          countdowns,
+          weekReview,
           boardUrl: `${base}/admin/aufgaben`,
           crmUrl: `${base}/admin/crm`,
         });
 
         const counts = [
+          unanswered.length ? plural(unanswered.length, 'unbeantwortete Mail', 'unbeantwortete Mails') : '',
           myOpenAll.length ? plural(myOpenAll.length, 'offene Aufgabe', 'offene Aufgaben') : '',
           newInquiries.length ? plural(newInquiries.length, 'neue Anfrage', 'neue Anfragen') : '',
         ].filter(Boolean).join(' · ');

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -233,7 +233,8 @@ export function initDatabase() {
       weekly_hours TEXT NOT NULL DEFAULT '[0,8.4,8.4,8.4,8.4,8.4,0]',
       vacation_days_per_year REAL NOT NULL DEFAULT 25,
       employment_start TEXT,
-      notes TEXT NOT NULL DEFAULT ''
+      notes TEXT NOT NULL DEFAULT '',
+      briefing_opt_out INTEGER NOT NULL DEFAULT 0
     );
 
     CREATE TABLE IF NOT EXISTS time_entries (
@@ -462,6 +463,8 @@ export function initDatabase() {
   if (ccols.length && !ccols.some((c) => c.name === 'salutation')) addColumn('customers', "salutation TEXT DEFAULT ''");
   if (ccols.length && !ccols.some((c) => c.name === 'first_name')) addColumn('customers', "first_name TEXT DEFAULT ''");
   if (ccols.length && !ccols.some((c) => c.name === 'last_name')) addColumn('customers', "last_name TEXT DEFAULT ''");
+  const ecols = sqlite.prepare(`PRAGMA table_info(employees)`).all() as Array<{ name: string }>;
+  if (ecols.length && !ecols.some((c) => c.name === 'briefing_opt_out')) addColumn('employees', 'briefing_opt_out INTEGER NOT NULL DEFAULT 0');
 
   // Ticket-System: fortlaufende Ticketnummer + Zeit-Datum (Bestands-DBs nachrüsten)
   const stcols = sqlite.prepare(`PRAGMA table_info(staff_tasks)`).all() as Array<{ name: string }>;
@@ -622,6 +625,40 @@ export async function getMessagesByBooking(bookingId: string): Promise<BookingMe
     [bookingId]
   );
   return rows as BookingMessage[];
+}
+
+export interface UnansweredBookingInbound {
+  booking_id: string;
+  request_number: string | null;
+  package_title: string;
+  status: string;
+  assigned_to: string | null;
+  email: string;
+  customer_name: string | null;
+  /** created_at der neuesten unbeantworteten Kunden-Mail. */
+  last_in_at: string;
+}
+
+/**
+ * Offene Anfragen, bei denen die letzte Kunden-Mail ('in') neuer ist als die
+ * letzte Team-Antwort ('out') — fürs Tages-Briefing. Aggregat-Ausdrücke im
+ * HAVING bewusst wiederholt (Postgres erlaubt keine SELECT-Aliase dort).
+ */
+export async function listUnansweredBookingInbound(): Promise<UnansweredBookingInbound[]> {
+  return dbAll<UnansweredBookingInbound>(`
+    SELECT b.id AS booking_id, b.request_number, b.package_title, b.status, b.assigned_to, b.email,
+           c.name AS customer_name,
+           MAX(CASE WHEN m.direction = 'in' THEN m.created_at END) AS last_in_at
+    FROM booking_requests b
+    JOIN booking_messages m ON m.booking_id = b.id
+    LEFT JOIN customers c ON c.id = b.customer_id
+    WHERE b.status IN ('new', 'in_progress')
+    GROUP BY b.id, b.request_number, b.package_title, b.status, b.assigned_to, b.email, c.name
+    HAVING MAX(CASE WHEN m.direction = 'in' THEN m.created_at END) IS NOT NULL
+       AND (MAX(CASE WHEN m.direction = 'out' THEN m.created_at END) IS NULL
+            OR MAX(CASE WHEN m.direction = 'out' THEN m.created_at END) < MAX(CASE WHEN m.direction = 'in' THEN m.created_at END))
+    ORDER BY MAX(CASE WHEN m.direction = 'in' THEN m.created_at END) ASC
+  `);
 }
 
 export async function findBookingByRequestNumber(requestNumber: string): Promise<BookingRequest | undefined> {

--- a/src/lib/dbq.ts
+++ b/src/lib/dbq.ts
@@ -200,6 +200,8 @@ export async function applyPgSchemaEnhancements(): Promise<void> {
     try { await pool.query(`ALTER TABLE booking_requests ADD COLUMN IF NOT EXISTS event_slug text DEFAULT ''`); } catch { /* ignore */ }
     try { await pool.query(`ALTER TABLE booking_requests ADD COLUMN IF NOT EXISTS package_slug text DEFAULT ''`); } catch { /* ignore */ }
     try { await pool.query(`ALTER TABLE booking_requests ADD COLUMN IF NOT EXISTS travel_period text DEFAULT ''`); } catch { /* ignore */ }
+    // Tages-Briefing: Opt-out pro Mitarbeiter:in (TASK-00103)
+    try { await pool.query(`ALTER TABLE employees ADD COLUMN IF NOT EXISTS briefing_opt_out integer NOT NULL DEFAULT 0`); } catch { /* ignore */ }
     try { await pool.query(`INSERT INTO counters (name, value) SELECT 'booking_number', 1000 WHERE NOT EXISTS (SELECT 1 FROM counters WHERE name = 'booking_number')`); } catch { /* ignore */ }
 
     // Kundenportal-Tabellen (in PG zusätzlich anlegen – Migration introspektiert nur Bestandstabellen).

--- a/src/lib/emailTemplates.ts
+++ b/src/lib/emailTemplates.ts
@@ -597,6 +597,14 @@ export interface DailyBriefingInput {
   newInquiries: BriefingInquiryItem[];
   movedInquiries: BriefingInquiryItem[];
   staleInquiries: BriefingInquiryItem[];
+  /** Pipeline-Zeile: offene Anfragen nach Status + offenes Volumen (TASK-00103). */
+  pipeline?: { newCount: number; inProgressCount: number; volumeLabel: string } | null;
+  /** Unbeantwortete Kunden-Mails (>24 h) aus CRM & Tickets — wichtigste Sektion. */
+  unansweredMails?: BriefingInquiryItem[];
+  /** Countdown-Zeilen zu den nächsten Events. */
+  countdowns?: Array<{ name: string; daysLabel: string; extra?: string }>;
+  /** Freitags: Wochen-Rückblick als Stichpunkte. */
+  weekReview?: { title: string; lines: string[] } | null;
   boardUrl: string;
   crmUrl: string;
 }
@@ -650,7 +658,24 @@ export function dailyBriefingEmailHtml(input: DailyBriefingInput): string {
       </div>`
     : '';
 
+  // Pipeline-Chips direkt unter der Begrüßung: der Geschäftsstand auf einen Blick.
+  const chip = (label: string, color: string) =>
+    `<span style="display:inline-block;margin:0 8px 6px 0;background:#f5f7fa;border:1px solid #e5e8ed;border-radius:999px;padding:5px 14px;font-size:12px;font-weight:700;color:${color};">${escapeHtml(label)}</span>`;
+  const pipelineHtml = input.pipeline
+    ? `<p style="margin:16px 0 0;">
+        ${chip(`${input.pipeline.newCount} neu`, ACCENT)}
+        ${chip(`${input.pipeline.inProgressCount} in Bearbeitung`, NAVY)}
+        ${chip(`${input.pipeline.volumeLabel} offenes Volumen`, '#16a34a')}
+      </p>`
+    : '';
+
   const sections: string[] = [];
+  if ((input.unansweredMails || []).length) {
+    sections.push(
+      briefingSectionHeading(`📬 Unbeantwortete Kundenmails (älter als 24 h)`) +
+      briefingList((input.unansweredMails || []).map(briefingInquiryRow))
+    );
+  }
   if (input.myOpenTasks.length) {
     sections.push(
       briefingSectionHeading(`Deine offenen Aufgaben (${input.myOpenTasks.length + (input.myOpenMore || 0)})`) +
@@ -682,10 +707,29 @@ export function dailyBriefingEmailHtml(input: DailyBriefingInput): string {
       briefingList(input.staleInquiries.map(briefingInquiryRow))
     );
   }
+  if (input.weekReview && input.weekReview.lines.length) {
+    sections.push(
+      briefingSectionHeading(`📊 ${input.weekReview.title}`) +
+      `<table role="presentation" width="100%" cellpadding="0" cellspacing="0"><tr><td style="padding:12px 16px;background:#f5f7fa;border:1px solid #e5e8ed;border-radius:12px;">
+        ${input.weekReview.lines.map((l) => `<p style="margin:0;font-size:14px;line-height:1.9;color:#374151;">${escapeHtml(l)}</p>`).join('')}
+      </td></tr></table>`
+    );
+  }
+  if ((input.countdowns || []).length) {
+    sections.push(
+      briefingSectionHeading(`🗓 Nächste Events`) +
+      briefingList((input.countdowns || []).map((c) => `<tr><td style="padding:7px 0;border-bottom:1px solid #f0f2f5;">
+        <span style="font-size:14px;font-weight:600;color:${NAVY};">${escapeHtml(c.name)}</span>
+        <span style="font-size:13px;font-weight:700;color:${ACCENT};"> — ${escapeHtml(c.daysLabel)}</span>
+        ${c.extra ? `<span style="font-size:12px;color:#6b7280;"> · ${escapeHtml(c.extra)}</span>` : ''}
+      </td></tr>`))
+    );
+  }
 
   const inner = `
     <p style="margin:0 0 4px;font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:1px;color:#9ca3af;">Tages-Briefing · ${escapeHtml(input.dateLabel)}</p>
     <h1 style="margin:6px 0 0;font-size:22px;font-weight:800;color:${NAVY};">${hi}! ☀️</h1>
+    ${pipelineHtml}
     ${kudosHtml}
     ${sections.join('')}
     <p style="margin:28px 0 0;">

--- a/src/lib/staffStore.ts
+++ b/src/lib/staffStore.ts
@@ -26,13 +26,15 @@ export interface Employee {
   vacation_days_per_year: number;
   employment_start: string | null;
   notes: string;
+  /** Kein tägliches Briefing per Mail erhalten (TASK-00103). */
+  briefing_opt_out: boolean;
 }
 
 interface EmployeeRow {
   id: string; created_at: string; last_login_at: string | null;
   name: string; email: string; role: 'admin' | 'mitarbeiter';
   active: number; weekly_hours: string; vacation_days_per_year: number;
-  employment_start: string | null; notes: string;
+  employment_start: string | null; notes: string; briefing_opt_out: number;
 }
 
 function rowToEmployee(r: EmployeeRow): Employee {
@@ -41,7 +43,7 @@ function rowToEmployee(r: EmployeeRow): Employee {
     const parsed = JSON.parse(r.weekly_hours);
     if (Array.isArray(parsed) && parsed.length === 7) weekly = parsed as WeeklyHours;
   } catch { /* default */ }
-  return { ...r, active: !!r.active, weekly_hours: weekly };
+  return { ...r, active: !!r.active, weekly_hours: weekly, briefing_opt_out: !!r.briefing_opt_out };
 }
 
 /** Upsert beim Microsoft-Login: legt Mitarbeiter an bzw. aktualisiert Name/E-Mail/Login-Zeit. */
@@ -78,6 +80,7 @@ export interface EmployeeUpdate {
   employment_start?: string | null;
   notes?: string;
   name?: string;
+  briefing_opt_out?: boolean;
 }
 
 export async function updateEmployee(id: string, u: EmployeeUpdate): Promise<Employee | null> {
@@ -86,7 +89,7 @@ export async function updateEmployee(id: string, u: EmployeeUpdate): Promise<Emp
   await dbRun(`
     UPDATE employees SET
       role = ?, active = ?, weekly_hours = ?, vacation_days_per_year = ?,
-      employment_start = ?, notes = ?, name = ?
+      employment_start = ?, notes = ?, name = ?, briefing_opt_out = ?
     WHERE id = ?
   `, [
     u.role ?? cur.role,
@@ -96,6 +99,7 @@ export async function updateEmployee(id: string, u: EmployeeUpdate): Promise<Emp
     u.employment_start !== undefined ? u.employment_start : cur.employment_start,
     u.notes ?? cur.notes,
     u.name ?? cur.name,
+    (u.briefing_opt_out ?? cur.briefing_opt_out) ? 1 : 0,
     id,
   ]);
   return getEmployee(id);
@@ -877,6 +881,36 @@ export interface TaskMessage {
   graph_message_id: string | null;
   created_at: string;
   created_by: string;
+}
+
+export interface UnansweredTaskInbound {
+  task_id: string;
+  ticket_number: number | null;
+  title: string;
+  status: string;
+  assignee_id: string | null;
+  /** created_at der neuesten unbeantworteten eingehenden Mail. */
+  last_in_at: string;
+}
+
+/**
+ * Offene Tickets, bei denen die letzte eingehende Mail ('in') neuer ist als die
+ * letzte ausgehende Antwort ('out') — fürs Tages-Briefing. Aggregat-Ausdrücke
+ * im HAVING bewusst wiederholt (Postgres erlaubt keine SELECT-Aliase dort).
+ */
+export async function listUnansweredTaskInbound(): Promise<UnansweredTaskInbound[]> {
+  return dbAll<UnansweredTaskInbound>(`
+    SELECT s.id AS task_id, s.ticket_number, s.title, s.status, s.assignee_id,
+           MAX(CASE WHEN m.direction = 'in' THEN m.created_at END) AS last_in_at
+    FROM staff_tasks s
+    JOIN task_messages m ON m.task_id = s.id
+    WHERE s.status != 'erledigt'
+    GROUP BY s.id, s.ticket_number, s.title, s.status, s.assignee_id
+    HAVING MAX(CASE WHEN m.direction = 'in' THEN m.created_at END) IS NOT NULL
+       AND (MAX(CASE WHEN m.direction = 'out' THEN m.created_at END) IS NULL
+            OR MAX(CASE WHEN m.direction = 'out' THEN m.created_at END) < MAX(CASE WHEN m.direction = 'in' THEN m.created_at END))
+    ORDER BY MAX(CASE WHEN m.direction = 'in' THEN m.created_at END) ASC
+  `);
 }
 
 export async function listTaskMessages(taskId: string): Promise<TaskMessage[]> {


### PR DESCRIPTION
## Zusammenfassung
Ausbau des täglichen Team-Briefings (TASK-00103, Follow-up zu TASK-00091) — alle gewünschten Erweiterungen außer Tippspiel:

- **📬 Unbeantwortete Kundenmails (>24 h)** — oberste Sektion: offene CRM-Anfragen UND Tickets, bei denen die letzte Kundenmail neuer ist als die letzte Team-Antwort; mit Zuständigkeit und „seit X Tagen unbeantwortet". Zählt auch im Mail-Betreff.
- **Pipeline-Chips** direkt unter der Begrüßung: „4 neu · 7 in Bearbeitung · 86.000 € offenes Volumen" (EUR-Format wie Dashboard).
- **🗓 Event-Countdowns**: die nächsten 3 Events mit Tagen bis Start und offenen Anfragen je Event.
- **📊 Wochen-Rückblick freitags**: erledigte Aufgaben, Buchungen, neue Anfragen, gebuchte Zeiten (Team gesamt + eigener Anteil).
- **🔥 Streaks** in der Schulterklopf-Box: zusammenhängende Arbeitstage (Mo–Fr) mit Zeitbuchungen; Wochenenden unterbrechen nicht.
- **Opt-out pro Mitarbeiter:in**: neue Spalte `employees.briefing_opt_out` (SQLite-Migration nach dem addColumn-Muster + `ADD COLUMN IF NOT EXISTS` für Postgres), Toggle „Tages-Briefing per Mail erhalten" in der Team-Verwaltung, Filter im Versand.

## Technik
- Neue Queries `listUnansweredBookingInbound()` / `listUnansweredTaskInbound()` — Aggregate im HAVING bewusst wiederholt (Postgres erlaubt dort keine SELECT-Aliase), vollständiges GROUP BY.
- Zeiten-Daten (Streak + Wochen-Rückblick) aus EINEM `listTaskTimeEntries`-Abruf (letzte 30 Tage).
- Alle neuen Template-Felder optional — bestehendes Verhalten unverändert, wenn leer.

## Verifikation
- `npx tsc --noEmit` grün.
- Beide neuen SQL-Queries gegen lokale SQLite ausgeführt (Syntax ok).
- Template-Rendertest: alle neuen Sektionen erscheinen, leere werden weggelassen.
- Streak-Logik: 4-Tage-Streak, Wochenend-Brücke (Fr→Mo), Null-Fall — alle korrekt.
- Store-Funktionen end-to-end per tsx gegen lokale Daten ausgeführt.

Ticket: TASK-00103

🤖 Generated with [Claude Code](https://claude.com/claude-code)