### PR TITLE
fix(crm): Event automatisch im Antwort-Betreff (TASK-00097)

### DIFF
--- a/src/app/api/bookings/[id]/reply/route.ts
+++ b/src/app/api/bookings/[id]/reply/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getBooking, addMessage } from '@/lib/bookingStore';
-import { getEventBySlug } from '@/lib/eventData';
+import { bookingEventName } from '@/lib/eventData';
 import { sendGraphMail, isGraphConfigured, getMailbox, getFromName, type MailAttachment } from '@/lib/graphMailer';
 import { replyEmailHtml, replySubject } from '@/lib/emailTemplates';
 import { addMessageAttachment, MAX_FILE_BYTES } from '@/lib/documentStore';
@@ -62,6 +62,7 @@ export async function POST(
       email: string;
       request_number?: string | null;
       event_slug?: string | null;
+      package_title?: string | null;
     };
 
     const requestNumber = b.request_number || '';
@@ -72,12 +73,8 @@ export async function POST(
       );
     }
 
-    // Event-Name für Betreff
-    let eventName: string | undefined;
-    if (b.event_slug) {
-      const ev = await getEventBySlug(b.event_slug).catch(() => null);
-      eventName = ev?.name || ev?.title || undefined;
-    }
+    // Event-Name für Betreff (Fallback Paket-Titel, TASK-00097)
+    const eventName = await bookingEventName(b);
 
     const subject = replySubject(requestNumber, eventName);
     const html = replyEmailHtml({

--- a/src/app/api/ext/bookings/[id]/reply/route.ts
+++ b/src/app/api/ext/bookings/[id]/reply/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { apiKeyOr401 } from '@/lib/extAuth';
 import { getBooking, addMessage } from '@/lib/bookingStore';
-import { getEventBySlug } from '@/lib/eventData';
+import { bookingEventName } from '@/lib/eventData';
 import { sendGraphMail, isGraphConfigured, getMailbox, getFromName } from '@/lib/graphMailer';
 import { replyEmailHtml, replySubject } from '@/lib/emailTemplates';
 
@@ -16,15 +16,12 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
 
   const booking = await getBooking(id);
   if (!booking) return NextResponse.json({ success: false, error: 'Anfrage nicht gefunden' }, { status: 404 });
-  const b = booking as { id: string; email: string; request_number?: string | null; event_slug?: string | null };
+  const b = booking as { id: string; email: string; request_number?: string | null; event_slug?: string | null; package_title?: string | null };
   const requestNumber = b.request_number || '';
   if (!requestNumber) return NextResponse.json({ success: false, error: 'Anfrage hat keine RQ-Nummer' }, { status: 400 });
 
-  let eventName: string | undefined;
-  if (b.event_slug) {
-    const ev = await getEventBySlug(b.event_slug).catch(() => null);
-    eventName = ev?.name || ev?.title || undefined;
-  }
+  // Event-Name für Betreff (Fallback Paket-Titel, TASK-00097)
+  const eventName = await bookingEventName(b);
 
   const subject = replySubject(requestNumber, eventName);
   const html = replyEmailHtml({ bodyText: text, requestNumber, eventName, agentName: body?.agentName || undefined });

--- a/src/lib/eventData.ts
+++ b/src/lib/eventData.ts
@@ -260,6 +260,20 @@ export interface PackageCardData {
   badgeText: string;
 }
 
+/**
+ * Event-Name für Kunden-Mail-Betreffe: Event-Lookup via slug, sonst Fallback
+ * auf den Paket-Titel — so steht das Event auch bei Anfragen ohne event_slug
+ * (Alt-/CF7-Anfragen) automatisch im Betreff (TASK-00097).
+ */
+export async function bookingEventName(b: { event_slug?: string | null; package_title?: string | null }): Promise<string | undefined> {
+  if (b.event_slug) {
+    const ev = await getEventBySlug(b.event_slug).catch(() => null);
+    const name = ev?.name || ev?.title;
+    if (name) return name;
+  }
+  return (b.package_title || '').trim() || undefined;
+}
+
 export async function getEventBySlug(slug: string): Promise<EventRecord | null> {
   if (!isSupabaseConfigured() || !supabase) {
     return (findEventBySlug(slug) as EventRecord | null) || null;


### PR DESCRIPTION
## Zusammenfassung
**TASK-00097** (Natalie): Beim Antworten auf Kundenanfragen soll das Event automatisch im Betreff stehen.

Der Betreff wird serverseitig bereits als `Re: Ihre Anfrage – <Event> [RQ-…]` gebaut — aber nur, wenn die Anfrage einen `event_slug` hat. Alt- und CF7-/WordPress-Anfragen haben keinen → der Betreff kam ohne Event und Natalie musste es manuell einfügen.

**Fix:** Neuer Helper `bookingEventName()` in `eventData.ts`: Event-Lookup via Slug, sonst Fallback auf den immer gesetzten `package_title` der Anfrage. Verwendet in der Admin-Reply-Route und der ext-API-Reply-Route (gleiche Logik, eine Stelle).

## Verifikation
- `npx tsc --noEmit` grün
- tsx-Test aller vier Pfade: mit Slug (Event-Name), ohne Slug (Paket-Titel), unbekannter Slug (Fallback), komplett leer (undefined → Betreff ohne Event wie bisher)

Ticket: TASK-00097

🤖 Generated with [Claude Code](https://claude.com/claude-code)