### PR TITLE
feat(aufgaben): KI-Check beim Anlegen + „KI übernimmt"-Flag (TASK-00098)

### DIFF
--- a/src/app/admin/aufgaben/page.tsx
+++ b/src/app/admin/aufgaben/page.tsx
@@ -5,7 +5,7 @@ import AdminShell from '@/components/admin/AdminShell';
 import {
   PageHeader, Card, SectionCard, Button, Field, TextInput, SelectInput, TextArea, Badge, Spinner, COLORS,
 } from '@/components/admin/ui';
-import { Plus, Trash2, ChevronRight, ChevronLeft, ListTodo, GripVertical, FolderKanban } from 'lucide-react';
+import { Plus, Trash2, ChevronRight, ChevronLeft, ListTodo, GripVertical, FolderKanban, Sparkles } from 'lucide-react';
 import Link from 'next/link';
 import { DndContext, useDraggable, useDroppable, PointerSensor, useSensor, useSensors, type DragEndEvent } from '@dnd-kit/core';
 import TaskDrawer from '@/components/admin/TaskDrawer';
@@ -27,6 +27,7 @@ interface StaffTask {
   created_by: string | null;
   project_id?: string | null;
   project_name?: string | null;
+  ai_requested?: number;
 }
 
 interface ProjectLite { id: string; name: string; status?: 'aktiv' | 'archiviert' }
@@ -138,7 +139,10 @@ function TaskCard({
               )}
             </div>
           </div>
-          <Badge tone={PRIO_TONE[t.priority]}>{t.priority}</Badge>
+          <div className="flex flex-col items-end gap-1">
+            <Badge tone={PRIO_TONE[t.priority]}>{t.priority}</Badge>
+            {!!t.ai_requested && <Badge tone="info">🤖 KI</Badge>}
+          </div>
         </div>
         {isWaiting(t.status) && (
           <button
@@ -196,6 +200,14 @@ export default function AufgabenPage() {
   const [filterProject, setFilterProject] = useState('');
   const [form, setForm] = useState({ title: '', description: '', assignee_id: '', due_date: '', priority: 'normal', project_id: '' });
   const [saving, setSaving] = useState(false);
+  // KI-Check beim Anlegen (TASK-00098)
+  const [aiCheck, setAiCheck] = useState<{
+    ai_doable: boolean; confidence: number; clear: boolean; questions: string[];
+    improved_title: string; improved_description: string; category: string;
+  } | null>(null);
+  const [aiChecking, setAiChecking] = useState(false);
+  const [aiError, setAiError] = useState('');
+  const [aiRequested, setAiRequested] = useState(false);
   const [selected, setSelected] = useState<StaffTask | null>(null);
   const [showProjects, setShowProjects] = useState(false);
 
@@ -267,12 +279,38 @@ export default function AufgabenPage() {
           due_date: form.due_date || null,
           priority: form.priority,
           project_id: form.project_id || null,
+          ai_requested: aiRequested,
         }),
       });
       setForm({ title: '', description: '', assignee_id: '', due_date: '', priority: 'normal', project_id: form.project_id });
+      setAiCheck(null);
+      setAiRequested(false);
       await load();
     } finally {
       setSaving(false);
+    }
+  };
+
+  const runAiCheck = async () => {
+    if (!form.title) return;
+    setAiChecking(true);
+    setAiError('');
+    try {
+      const r = await fetch('/api/admin/tasks/ai-check', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: form.title, description: form.description }),
+      }).then((x) => x.json());
+      if (r.success) {
+        setAiCheck(r.data);
+        setAiRequested(false);
+      } else {
+        setAiError(r.error || 'KI-Check fehlgeschlagen.');
+      }
+    } catch {
+      setAiError('Verbindungsfehler beim KI-Check.');
+    } finally {
+      setAiChecking(false);
     }
   };
 
@@ -398,11 +436,57 @@ export default function AufgabenPage() {
             </SelectInput>
           </Field>
         </div>
-        <div className="mt-3">
+        <div className="mt-3 flex flex-wrap items-center gap-2">
           <Button variant="accent" onClick={create} disabled={saving || !form.title}>
             {saving ? <Spinner className="h-4 w-4" /> : <Plus className="h-4 w-4" />} Aufgabe anlegen
           </Button>
+          <Button variant="secondary" onClick={runAiCheck} disabled={aiChecking || !form.title}>
+            {aiChecking ? <Spinner className="h-4 w-4" /> : <Sparkles className="h-4 w-4" />} KI-Check
+          </Button>
+          {aiError && <span className="text-sm" style={{ color: COLORS.danger }}>{aiError}</span>}
         </div>
+
+        {/* KI-Check-Ergebnis (TASK-00098) */}
+        {aiCheck && (
+          <div className="mt-4 rounded-xl border p-4" style={{ borderColor: aiCheck.ai_doable ? '#c7dcf5' : '#e5e8ed', background: aiCheck.ai_doable ? '#f0f5fa' : '#fafafa' }}>
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge tone={aiCheck.ai_doable ? 'accent' : 'muted'}>
+                {aiCheck.ai_doable ? `🤖 KI-geeignet (${aiCheck.confidence} %)` : 'Nicht KI-geeignet'}
+              </Badge>
+              <Badge tone="navy">{aiCheck.category.replace('_', '-')}</Badge>
+              {!aiCheck.clear && <Badge tone="warn">Beschreibung unklar</Badge>}
+            </div>
+            {aiCheck.questions.length > 0 && (
+              <div className="mt-3">
+                <div className="text-xs font-bold uppercase tracking-wide" style={{ color: COLORS.textMuted }}>Rückfragen der KI</div>
+                <ul className="mt-1.5 list-disc space-y-1 pl-5 text-sm" style={{ color: COLORS.navy }}>
+                  {aiCheck.questions.map((q, i) => <li key={i}>{q}</li>)}
+                </ul>
+                <p className="mt-1.5 text-xs" style={{ color: COLORS.textMuted }}>
+                  Antworten am besten direkt in die Beschreibung einarbeiten und den KI-Check erneut ausführen.
+                </p>
+              </div>
+            )}
+            <div className="mt-3">
+              <div className="text-xs font-bold uppercase tracking-wide" style={{ color: COLORS.textMuted }}>Optimierter Vorschlag</div>
+              <div className="mt-1.5 rounded-lg border border-gray-200 bg-white p-3 text-sm">
+                <div className="font-semibold" style={{ color: COLORS.navy }}>{aiCheck.improved_title}</div>
+                <div className="mt-1 whitespace-pre-line" style={{ color: '#4b5563' }}>{aiCheck.improved_description}</div>
+              </div>
+              <div className="mt-2 flex flex-wrap items-center gap-3">
+                <Button size="sm" variant="secondary" onClick={() => setForm({ ...form, title: aiCheck.improved_title, description: aiCheck.improved_description })}>
+                  Vorschlag übernehmen
+                </Button>
+                {aiCheck.ai_doable && (
+                  <label className="flex cursor-pointer items-center gap-2 text-sm font-semibold" style={{ color: COLORS.navy }}>
+                    <input type="checkbox" checked={aiRequested} onChange={(e) => setAiRequested(e.target.checked)} />
+                    🤖 KI soll diese Aufgabe übernehmen (Bestätigung per Mail)
+                  </label>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
       </SectionCard>
 
       {/* Board */}

--- a/src/app/api/admin/tasks/ai-check/route.ts
+++ b/src/app/api/admin/tasks/ai-check/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from 'next/server';
+import { getSessionEmployee } from '@/lib/serverSession';
+import { anthropicMessage, parseJsonLoose, isAiConfigured } from '@/lib/aiAssist';
+
+export interface AiTaskCheck {
+  /** Kann die Aufgabe grundsätzlich von einer KI (Dev-Agent) übernommen werden? */
+  ai_doable: boolean;
+  /** 0–100: Zuversicht der Einschätzung. */
+  confidence: number;
+  /** Ist die Beschreibung eindeutig genug, um loszulegen? */
+  clear: boolean;
+  /** Rückfragen bei Unklarheiten (leer, wenn alles klar). */
+  questions: string[];
+  improved_title: string;
+  /** Optimierte Beschreibung — bei Portal-Themen als klare User-Story. */
+  improved_description: string;
+  category: 'portal_entwicklung' | 'kommunikation' | 'administration' | 'sonstiges';
+}
+
+const SYSTEM_PROMPT = [
+  'Du bist der KI-Assistent des Faltin-Travel-Adminportals (Sportreisen-Buchungsplattform: CRM, Aufgaben, Rechnungen, Events, Mail).',
+  'Du prüfst neue Aufgaben VOR dem Anlegen. Deine Einschätzung entscheidet, ob die Aufgabe einem KI-Dev-Agenten angeboten wird.',
+  'KI-geeignet (ai_doable=true) sind vor allem: Weiterentwicklungen und Bugfixes des Portals, Textentwürfe, Auswertungen, Recherchen.',
+  'NICHT KI-geeignet: physische Tätigkeiten (Hardware, Post, Termine vor Ort), Entscheidungen der Geschäftsleitung, Aufgaben die persönliche Gespräche erfordern.',
+  'Bewerte die Beschreibung: Ist sie eindeutig genug, um ohne Rückfragen loszulegen (clear)? Wenn nicht: formuliere konkrete, kurze Rückfragen (questions).',
+  'Formuliere improved_title (prägnant, max. 80 Zeichen) und improved_description: bei Portal-Entwicklung/Bugfix als klare User-Story',
+  '("Als <Rolle> möchte ich <Ziel>, damit <Nutzen>." plus Akzeptanzkriterien als Liste), sonst als präzise strukturierte Beschreibung.',
+  'Erfinde keine Anforderungen — offene Punkte gehören in questions, nicht in die Beschreibung.',
+  'Antworte AUSSCHLIESSLICH mit einem JSON-Objekt:',
+  '{ "ai_doable": boolean, "confidence": 0-100, "clear": boolean, "questions": string[], "improved_title": string, "improved_description": string, "category": "portal_entwicklung"|"kommunikation"|"administration"|"sonstiges" }',
+].join(' ');
+
+/** POST { title, description? } → KI-Einschätzung + optimierte Beschreibung (TASK-00098). */
+export async function POST(req: Request) {
+  const ctx = await getSessionEmployee();
+  if (!ctx) return NextResponse.json({ success: false, error: 'Nicht angemeldet' }, { status: 401 });
+  if (!isAiConfigured()) {
+    return NextResponse.json({ success: false, error: 'KI nicht konfiguriert (Admin → KI-Redaktion).' }, { status: 409 });
+  }
+
+  const body = await req.json().catch(() => ({}));
+  const title = String(body.title || '').trim();
+  const description = String(body.description || '').trim();
+  if (!title) return NextResponse.json({ success: false, error: 'title erforderlich' }, { status: 400 });
+
+  const res = await anthropicMessage({
+    system: SYSTEM_PROMPT,
+    userText: `Titel: ${title}\n\nBeschreibung:\n${description || '(keine Beschreibung angegeben)'}`,
+    maxTokens: 1500,
+  });
+  if (!res.ok || !res.text) {
+    return NextResponse.json({ success: false, error: res.error || 'KI-Antwort leer.' }, { status: 502 });
+  }
+
+  const parsed = parseJsonLoose(res.text) as Partial<AiTaskCheck> | null;
+  if (!parsed || typeof parsed.ai_doable !== 'boolean') {
+    return NextResponse.json({ success: false, error: 'KI-Antwort nicht auswertbar.' }, { status: 502 });
+  }
+
+  const data: AiTaskCheck = {
+    ai_doable: !!parsed.ai_doable,
+    confidence: Math.min(100, Math.max(0, Math.round(Number(parsed.confidence ?? 0)) || 0)),
+    clear: !!parsed.clear,
+    questions: Array.isArray(parsed.questions) ? parsed.questions.map(String).slice(0, 6) : [],
+    improved_title: String(parsed.improved_title || title).slice(0, 200),
+    improved_description: String(parsed.improved_description || description),
+    category: (['portal_entwicklung', 'kommunikation', 'administration', 'sonstiges'] as const)
+      .find((c) => c === parsed.category) || 'sonstiges',
+  };
+  return NextResponse.json({ success: true, data });
+}

--- a/src/app/api/admin/tasks/route.ts
+++ b/src/app/api/admin/tasks/route.ts
@@ -35,5 +35,37 @@ export async function POST(req: Request) {
     }).catch(() => { /* nie blockierend */ });
   }
 
+  // KI-Umsetzung angefragt → Bestätigung an die Ersteller:in (Mail + Glocke), nie blockierend.
+  if (task.ai_requested && ctx.employee?.email) {
+    const ticket = formatTicketNo(task.ticket_number) || 'Ticket';
+    addNotification({
+      employee_id: ctx.employee.id,
+      type: 'info',
+      task_id: task.id,
+      title: `🤖 ${ticket} für KI-Umsetzung vorgemerkt – ${task.title}`,
+      body: 'Du bekommst eine Mail, sobald die KI mit der Umsetzung startet und wenn sie fertig ist.',
+      created_by: 'KI-Assistent',
+    }).catch(() => { /* nie blockierend */ });
+    (async () => {
+      const { isGraphConfigured, sendGraphMail } = await import('@/lib/graphMailer');
+      if (!isGraphConfigured()) return;
+      const { taskNotifyEmailHtml, taskSubjectTag } = await import('@/lib/emailTemplates');
+      const { getSettings } = await import('@/lib/settingsStore');
+      const base = (getSettings().mail?.login_base_url || 'https://next.faltintravel.com').replace(/\/+$/, '');
+      await sendGraphMail({
+        to: ctx.employee!.email,
+        toName: ctx.employee!.name,
+        subject: `🤖 KI-Auftrag registriert ${taskSubjectTag(ticket)} – ${task.title}`.slice(0, 200),
+        html: taskNotifyEmailHtml({
+          bodyText: 'Deine Aufgabe wurde für die Umsetzung durch die KI vorgemerkt. Sobald die KI startet bzw. fertig ist, bekommst du je eine Mail mit dem Stand direkt am Ticket.',
+          ticketNo: ticket,
+          taskTitle: task.title,
+          kindLabel: 'KI-Auftrag registriert',
+          ticketUrl: `${base}/admin/aufgaben/${task.id}`,
+        }),
+      });
+    })().catch((e) => console.warn('[ai-task] Bestätigungs-Mail fehlgeschlagen:', (e as Error).message));
+  }
+
   return NextResponse.json({ success: true, data: task });
 }

--- a/src/app/api/ext/tasks/route.ts
+++ b/src/app/api/ext/tasks/route.ts
@@ -13,6 +13,7 @@ export async function GET(req: Request) {
     assignee_id: url.searchParams.get('assignee') || undefined,
     booking_id: url.searchParams.get('booking') || undefined,
     project_id: url.searchParams.get('project') || undefined,
+    ai_requested: url.searchParams.get('ai') === '1' || undefined,
   });
   return NextResponse.json({ success: true, data: tasks.map(withTicket) });
 }

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -511,6 +511,7 @@ export function initDatabase() {
   sqlite.exec(`CREATE INDEX IF NOT EXISTS idx_task_time_report ON task_time(report_id)`);
   const stcols2 = sqlite.prepare(`PRAGMA table_info(staff_tasks)`).all() as Array<{ name: string }>;
   if (stcols2.length && !stcols2.some((c) => c.name === 'project_id')) addColumn('staff_tasks', 'project_id TEXT');
+  if (stcols2.length && !stcols2.some((c) => c.name === 'ai_requested')) addColumn('staff_tasks', 'ai_requested INTEGER NOT NULL DEFAULT 0');
   // Backfill: bestehende Tasks ohne Nummer fortlaufend ab 10 nummerieren (nach Erstellzeit).
   try {
     const missing = sqlite.prepare(`SELECT id FROM staff_tasks WHERE ticket_number IS NULL ORDER BY created_at, id`).all() as Array<{ id: string }>;

--- a/src/lib/dbq.ts
+++ b/src/lib/dbq.ts
@@ -202,6 +202,8 @@ export async function applyPgSchemaEnhancements(): Promise<void> {
     try { await pool.query(`ALTER TABLE booking_requests ADD COLUMN IF NOT EXISTS travel_period text DEFAULT ''`); } catch { /* ignore */ }
     // Tages-Briefing: Opt-out pro Mitarbeiter:in (TASK-00103)
     try { await pool.query(`ALTER TABLE employees ADD COLUMN IF NOT EXISTS briefing_opt_out integer NOT NULL DEFAULT 0`); } catch { /* ignore */ }
+    // KI-Task-Assistent: Umsetzung durch KI angefragt (TASK-00098)
+    try { await pool.query(`ALTER TABLE staff_tasks ADD COLUMN IF NOT EXISTS ai_requested integer NOT NULL DEFAULT 0`); } catch { /* ignore */ }
     try { await pool.query(`INSERT INTO counters (name, value) SELECT 'booking_number', 1000 WHERE NOT EXISTS (SELECT 1 FROM counters WHERE name = 'booking_number')`); } catch { /* ignore */ }
 
     // Kundenportal-Tabellen (in PG zusätzlich anlegen – Migration introspektiert nur Bestandstabellen).

--- a/src/lib/staffStore.ts
+++ b/src/lib/staffStore.ts
@@ -393,6 +393,8 @@ export interface StaffTask {
   status: TaskStatus;
   created_by: string | null;
   project_id: string | null;
+  /** 1 = Ersteller:in wünscht Umsetzung durch die KI (TASK-00098). */
+  ai_requested?: number;
   /** Aus dem Join in listStaffTasks (LEFT JOIN projects). */
   project_name?: string | null;
 }
@@ -410,12 +412,12 @@ export async function createStaffTask(input: Partial<StaffTask> & { title: strin
     const row = await q.get<{ n: number }>(`SELECT COALESCE(MAX(ticket_number), 9) + 1 AS n FROM staff_tasks`);
     const next = row?.n ?? 10;
     await q.run(`
-      INSERT INTO staff_tasks (id, ticket_number, title, description, assignee_id, booking_id, due_date, priority, status, created_by, project_id)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO staff_tasks (id, ticket_number, title, description, assignee_id, booking_id, due_date, priority, status, created_by, project_id, ai_requested)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `, [id, next, input.title, input.description || '', input.assignee_id || null,
       input.booking_id || null, input.due_date || null,
       input.priority || 'normal', input.status || 'offen', input.created_by || null,
-      input.project_id || null]);
+      input.project_id || null, input.ai_requested ? 1 : 0]);
   });
   return (await dbGet<StaffTask>('SELECT * FROM staff_tasks WHERE id = ?', [id]))!;
 }
@@ -455,10 +457,11 @@ export async function deleteStaffTask(id: string): Promise<boolean> {
   return (await dbRun('DELETE FROM staff_tasks WHERE id = ?', [id])).changes > 0;
 }
 
-export async function listStaffTasks(filter?: { assignee_id?: string; status?: string; booking_id?: string; project_id?: string }): Promise<StaffTask[]> {
+export async function listStaffTasks(filter?: { assignee_id?: string; status?: string; booking_id?: string; project_id?: string; ai_requested?: boolean }): Promise<StaffTask[]> {
   const where: string[] = [];
   const params: string[] = [];
   if (filter?.assignee_id) { where.push('t.assignee_id = ?'); params.push(filter.assignee_id); }
+  if (filter?.ai_requested) { where.push('t.ai_requested = 1'); }
   if (filter?.status) { where.push('t.status = ?'); params.push(filter.status); }
   if (filter?.booking_id) { where.push('t.booking_id = ?'); params.push(filter.booking_id); }
   if (filter?.project_id) {


### PR DESCRIPTION
## Zusammenfassung
Erster Ausbauschritt von **TASK-00098** (KI-Unterstützung beim Anlegen von Aufgaben):

- **KI-Check-Button** im „Neue Aufgabe"-Formular: Die KI (bestehende `settings.ai`-Infrastruktur, Anthropic) bewertet Titel+Beschreibung —
  - **KI-geeignet ja/nein** mit Konfidenz (z. B. Portal-Weiterentwicklung/Bugfixes ja; physische Aufgaben nein)
  - **Klarheits-Check**: Ist die Beschreibung eindeutig genug? Wenn nicht: konkrete **Rückfragen** (in die Beschreibung einarbeiten → erneut prüfen)
  - **Optimierter Vorschlag**: prägnanter Titel + Beschreibung, bei Portal-Themen als **User-Story mit Akzeptanzkriterien** — per Klick übernehmbar
- **„🤖 KI soll diese Aufgabe übernehmen"**: Checkbox (nur bei KI-geeignet) → `staff_tasks.ai_requested`, 🤖-Badge auf der Board-Karte, **Bestätigungs-Mail + Benachrichtigung** an die Ersteller:in
- **ext-API**: `GET /api/ext/tasks?ai=1` liefert die KI-Aufträge — ausführende KI-Sessions (wie diese) können sie damit abholen; Start-/Fertig-Mails laufen über die bestehenden Ticket-Benachrichtigungen (Notizen/Status)

Basiert auf `feature/briefing-v2` (#83), da beide dieselben Migrations-Bereiche anfassen.

## Verifikation
- `npx tsc --noEmit` grün
- Dev-Server: Migration legt `ai_requested` an; Task mit `ai_requested: true` erstellt → persistiert (1) → gelöscht; `POST /api/admin/tasks/ai-check` ohne KI-Key → sauberer 409; UI-Button + Formular im Browser geprüft

Ticket: TASK-00098

🤖 Generated with [Claude Code](https://claude.com/claude-code)