### PR TITLE
feat(mail): Sent-Items-Log für Auto-Antwort-Wiederherstellung

### DIFF
--- a/src/app/api/admin/mail/sent/route.ts
+++ b/src/app/api/admin/mail/sent/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+import { isGraphConfigured, listSentMessages } from '@/lib/graphMailer';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/admin/mail/sent?since=2026-06-01T00:00:00Z&top=25&skip=0
+ *
+ * Liest versendete Mails aus den Sent Items des konfigurierten Postfachs
+ * (nur Metadaten + Body, Anhänge als Name/Größe). Grundlage für die
+ * Wiederherstellung der per Event konfigurierten Auto-Antworten aus den
+ * tatsächlich verschickten Mails. Auth über die Admin-Middleware (/api/admin/*).
+ */
+export async function GET(request: Request) {
+  if (!isGraphConfigured()) {
+    return NextResponse.json({ success: false, error: 'Graph/M365 ist nicht konfiguriert.' }, { status: 503 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const since = searchParams.get('since') || undefined;
+  const top = Math.min(Math.max(parseInt(searchParams.get('top') || '25', 10) || 25, 1), 50);
+  const skip = Math.max(parseInt(searchParams.get('skip') || '0', 10) || 0, 0);
+
+  if (since && isNaN(Date.parse(since))) {
+    return NextResponse.json({ success: false, error: 'Ungültiges since-Datum (ISO erwartet).' }, { status: 400 });
+  }
+
+  try {
+    const messages = await listSentMessages(since, top, skip);
+    return NextResponse.json({ success: true, count: messages.length, skip, data: messages });
+  } catch (e) {
+    console.error('[Admin] mail/sent Fehler:', e);
+    return NextResponse.json({ success: false, error: (e as Error).message }, { status: 500 });
+  }
+}

--- a/src/lib/graphMailer.ts
+++ b/src/lib/graphMailer.ts
@@ -381,6 +381,81 @@ export async function listInboxMessages(
   }));
 }
 
+export interface GraphSentMessage {
+  id: string;
+  subject: string;
+  toAddress: string;
+  toName: string;
+  sentAt: string;
+  bodyHtml: string;
+  hasAttachments: boolean;
+  attachments: Array<{ name: string; size: number; contentType: string }>;
+}
+
+/**
+ * Liest versendete Mails aus den Sent Items des Postfachs (neueste zuerst).
+ * Dient der Wiederherstellung von per Event konfigurierten Auto-Antworten
+ * aus den tatsächlich verschickten Mails (Anhänge nur als Metadaten).
+ * @param sinceIso nur Mails ab diesem Zeitpunkt (ISO), optional
+ * @param top max. Anzahl pro Seite (default 25)
+ * @param skip Offset fürs Blättern (default 0)
+ */
+export async function listSentMessages(
+  sinceIso?: string,
+  top = 25,
+  skip = 0
+): Promise<GraphSentMessage[]> {
+  if (!isGraphConfigured()) return [];
+  const token = await getGraphToken();
+  if (!token) return [];
+
+  const mailbox = getMailbox();
+  const filter = sinceIso ? `&$filter=sentDateTime ge ${encodeURIComponent(sinceIso)}` : '';
+  const url =
+    `${GRAPH_BASE}/users/${encodeURIComponent(mailbox)}/mailFolders/sentitems/messages` +
+    `?$top=${top}&$skip=${skip}` +
+    `&$select=id,subject,toRecipients,sentDateTime,body,hasAttachments` +
+    `&$expand=attachments($select=name,size,contentType)` +
+    `&$orderby=sentDateTime desc${filter}`;
+
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!res.ok) {
+    const txt = await res.text().catch(() => '');
+    console.error(`[Graph] listSent Fehler (App ${mailConfig().clientId}, Postfach ${mailbox}):`, res.status, txt);
+    return [];
+  }
+
+  const json = (await res.json()) as {
+    value: Array<{
+      id: string;
+      subject: string;
+      toRecipients?: Array<{ emailAddress?: { address?: string; name?: string } }>;
+      sentDateTime: string;
+      body?: { contentType: string; content: string };
+      hasAttachments?: boolean;
+      attachments?: Array<{ name?: string; size?: number; contentType?: string }>;
+    }>;
+  };
+
+  return (json.value || []).map((m) => ({
+    id: m.id,
+    subject: m.subject || '',
+    toAddress: m.toRecipients?.[0]?.emailAddress?.address || '',
+    toName: m.toRecipients?.[0]?.emailAddress?.name || '',
+    sentAt: m.sentDateTime,
+    bodyHtml: m.body?.content || '',
+    hasAttachments: !!m.hasAttachments,
+    attachments: (m.attachments || []).map((a) => ({
+      name: a.name || '',
+      size: a.size || 0,
+      contentType: a.contentType || '',
+    })),
+  }));
+}
+
 /** Health-Check fürs M365/Graph: Ist es konfiguriert und lässt sich ein Token holen? */
 export async function graphHealth(): Promise<{ configured: boolean; tokenOk: boolean; error?: string }> {
   if (!isGraphConfigured()) return { configured: false, tokenOk: false };


### PR DESCRIPTION
## Kontext (Prod-Vorfall 09.07.)
Stefans Meldung: individuelle Anfrage-Antworten kommen nicht mehr an, überall nur noch die Standard-Bestätigung ("Guten Abend … wir melden uns"). Analyse: **das Content-Volume (data/events.json, series, faqs, packages) wurde auf Seed-Stand zurückgesetzt** — 70/75 Events sind byte-identisch mit data-seed, nur 3 Events haben noch eine aktive Auto-Antwort. Die von Natalie gepflegten auto_reply_-Konfigurationen sind weg.

## Was dieser PR macht
Die tatsächlich versendeten Auto-Antworten liegen als Kopien in den **Sent Items des request@-Postfachs**. Dieser PR macht sie per Admin-API lesbar, damit die Konfigurationen daraus rekonstruiert werden können:

- `graphMailer.listSentMessages()` — Sent Items via Graph (Body + Anhangs-Metadaten, `since`-Filter, Paging), analog zu `listInboxMessages()`
- `GET /api/admin/mail/sent?since=&top=&skip=` — admin-gated via Middleware (`/api/admin/*`)

Kein UI, keine Schreiboperationen, keine Änderung am Mail-Versand.

## Nächste Schritte (separat)
1. Je Event die zuletzt versendete individuelle Antwort extrahieren → `auto_reply_subject/message/links` wieder einspielen (Admin-API)
2. Ursache des Seed-Resets auf dem Server verifizieren (Datei-mtimes, Backups) + Schutz einbauen

Ticket folgt (App war beim Anlegen gerade im Deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)