### PR TITLE
fix(anrede): Anrede überall auf Herr/Frau normalisieren (TASK-00107)

### DIFF
--- a/src/app/api/admin/db/normalize-salutations/route.ts
+++ b/src/app/api/admin/db/normalize-salutations/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from 'next/server';
+import { dbAll, dbRun } from '@/lib/dbq';
+import { normalizeSalutation } from '@/lib/customerStore';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 120;
+
+/**
+ * POST /api/admin/db/normalize-salutations
+ * Einmaliger Daten-Fix (TASK-00107): vereinheitlicht bestehende Anreden auf
+ * "Herr"/"Frau" — in customers.salutation UND in bookings.travelers[].salutation.
+ * Idempotent (mehrfach ausführbar, ändert nur, was abweicht). Admin-gated über
+ * die Middleware (/api/admin/*).
+ */
+export async function POST() {
+  try {
+    // 1) Kundenstamm
+    const customers = await dbAll<{ id: string; salutation: string | null }>(
+      'SELECT id, salutation FROM customers'
+    );
+    let customersFixed = 0;
+    for (const c of customers) {
+      const norm = normalizeSalutation(c.salutation || '');
+      if (norm !== (c.salutation || '')) {
+        await dbRun("UPDATE customers SET salutation = ?, updated_at = datetime('now') WHERE id = ?", [norm, c.id]);
+        customersFixed++;
+      }
+    }
+
+    // 2) Reisende je Anfrage (travelers-JSON)
+    const bookings = await dbAll<{ id: string; travelers: string | null }>(
+      'SELECT id, travelers FROM booking_requests'
+    );
+    let bookingsFixed = 0;
+    let travelersFixed = 0;
+    for (const b of bookings) {
+      if (!b.travelers) continue;
+      let arr: unknown;
+      try {
+        arr = JSON.parse(b.travelers);
+      } catch {
+        continue;
+      }
+      if (!Array.isArray(arr)) continue;
+      let changed = 0;
+      const out = arr.map((t) => {
+        if (t && typeof t === 'object' && 'salutation' in t) {
+          const cur = String((t as { salutation?: unknown }).salutation ?? '');
+          const norm = normalizeSalutation(cur);
+          if (norm !== cur) {
+            changed++;
+            return { ...t, salutation: norm };
+          }
+        }
+        return t;
+      });
+      if (changed > 0) {
+        await dbRun("UPDATE booking_requests SET travelers = ?, updated_at = datetime('now') WHERE id = ?", [
+          JSON.stringify(out),
+          b.id,
+        ]);
+        bookingsFixed++;
+        travelersFixed += changed;
+      }
+    }
+
+    return NextResponse.json({
+      success: true,
+      customers_scanned: customers.length,
+      customers_fixed: customersFixed,
+      bookings_scanned: bookings.length,
+      bookings_fixed: bookingsFixed,
+      travelers_fixed: travelersFixed,
+    });
+  } catch (error) {
+    return NextResponse.json({ success: false, error: (error as Error).message }, { status: 500 });
+  }
+}

--- a/src/lib/customerStore.ts
+++ b/src/lib/customerStore.ts
@@ -247,7 +247,8 @@ export async function updateCustomer(id: string, updates: CustomerUpdate): Promi
   for (const f of fields) {
     if (f in updates && updates[f] !== undefined) {
       sets.push(`${f} = ?`);
-      vals.push(String(updates[f] ?? ''));
+      // Anrede immer auf "Herr"/"Frau" normalisieren (auch bei Admin-Edits).
+      vals.push(f === 'salutation' ? normalizeSalutation(String(updates[f] ?? '')) : String(updates[f] ?? ''));
     }
   }
   // Wenn Vor-/Nachname geändert werden, kombiniertes `name`-Feld konsistent halten.

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -7,6 +7,30 @@
 import { sqlite, dbGet, dbAll, dbRun, ensurePgSchema, db } from './dbq';
 import { pgEnabled } from './pg';
 import type { BookingRequest, BookingMessage, Traveler } from './supabase';
+import { normalizeSalutation } from './customerStore';
+
+/**
+ * Normalisiert die Anrede in einem travelers-JSON-String auf "Herr"/"Frau".
+ * Defensiv: unlesbares JSON wird unverändert durchgereicht.
+ */
+function normalizeTravelersJson(travelers: string): string {
+  try {
+    const arr = JSON.parse(travelers);
+    if (!Array.isArray(arr)) return travelers;
+    let changed = false;
+    const out = arr.map((t) => {
+      if (t && typeof t === 'object' && 'salutation' in t) {
+        const norm = normalizeSalutation(String((t as { salutation?: unknown }).salutation ?? ''));
+        if (norm !== (t as { salutation?: unknown }).salutation) changed = true;
+        return { ...t, salutation: norm };
+      }
+      return t;
+    });
+    return changed ? JSON.stringify(out) : travelers;
+  } catch {
+    return travelers;
+  }
+}
 
 export { db };
 
@@ -586,7 +610,7 @@ export async function insertBooking(booking: Omit<BookingRequest, 'id' | 'create
       (booking as { travel_period?: string }).travel_period || '',
       booking.package_id, booking.package_title, booking.start_date,
       booking.number_of_persons, booking.double_rooms, booking.single_rooms,
-      booking.travelers, booking.email, booking.phone, booking.message,
+      normalizeTravelersJson(booking.travelers as unknown as string), booking.email, booking.phone, booking.message,
       booking.status, booking.total_price, booking.notes,
       (booking as { source?: string }).source || '',
     ]


### PR DESCRIPTION
Die Anrede war inkonsistent gespeichert (customer_salutation 344x groß,
236x klein 'herr'/'frau'; travelers-JSON fast durchweg klein). Das war die
Wurzel des Restore-Anrede-Bugs und ein Risiko an jeder neuen Lesestelle.

Neue Daten:
- updateCustomer normalisiert salutation jetzt auch bei Admin-Edits
  (bisher wurde der Rohwert gespeichert)
- insertBooking normalisiert travelers[].salutation im JSON (deckt alle
  createBooking-Aufrufer ab); defensiv, unlesbares JSON bleibt unverändert

Bestehende Daten:
- POST /api/admin/db/normalize-salutations vereinheitlicht customers.salutation
  und bookings.travelers auf Herr/Frau — idempotent, admin-gated, einmalig
  auszuführen

normalizeSalutation-Logik isoliert getestet (klein→groß, mr/ms→Herr/Frau,
leer bleibt leer, 'Divers' unangetastet, JSON idempotent). tsc grün.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
