### PR TITLE
feat(kalkulation): Angebotskalkulator mit EK-Fremdwährungen, FX-Snapshot, Marge & Kundenansicht (TASK-00115)

### DIFF
--- a/src/app/admin/kalkulation/[id]/angebot/page.tsx
+++ b/src/app/admin/kalkulation/[id]/angebot/page.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+/**
+ * /admin/kalkulation/[id]/angebot — Kundenansicht einer Angebotskalkulation
+ * (TASK-00115). Zeigt NUR die Leistungen und den Gesamtpreis in der
+ * Zielwährung — keine EK-Preise, keine Marge, keine internen Notizen.
+ * Druck-/PDF-optimiert (Browser-Druck), ohne Admin-Chrome.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+import { useParams } from 'next/navigation';
+import { ArrowLeft, Printer, AlertTriangle } from 'lucide-react';
+import { COLORS, Button, Spinner } from '@/components/admin/ui';
+import { CALC_CATEGORIES, computeTotals, fmtMoney, type CalcItem, type MarginMode } from '@/lib/calcModel';
+import type { CalcCurrency, RatesSnapshot } from '@/lib/fxRates';
+
+interface CalcData {
+  id: string;
+  calc_number: string;
+  created_at: string;
+  title: string;
+  customer_name: string | null;
+  request_number: string | null;
+  target_currency: CalcCurrency;
+  margin_mode: MarginMode;
+  margin_value: number;
+  items: CalcItem[];
+  rates_snapshot: RatesSnapshot | null;
+}
+
+export default function KalkulationAngebotPage() {
+  const params = useParams<{ id: string }>();
+  const id = params.id;
+
+  const [calc, setCalc] = useState<CalcData | null>(null);
+  const [currentRates, setCurrentRates] = useState<RatesSnapshot | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/admin/calculations/${id}`).then((r) => r.json());
+      if (res?.success) {
+        setCalc(res.data);
+        setCurrentRates(res.current_rates || null);
+      } else {
+        setErr(res?.error || 'Kalkulation nicht gefunden');
+      }
+    } catch {
+      setErr('Laden fehlgeschlagen');
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => { load(); }, [load]);
+
+  if (loading) {
+    return <div className="flex min-h-screen items-center justify-center bg-white"><Spinner /></div>;
+  }
+  if (err || !calc) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center gap-3 bg-white">
+        <p className="font-semibold" style={{ color: COLORS.danger }}>{err || 'Kalkulation nicht gefunden'}</p>
+        <Link href="/admin/kalkulation" className="text-sm font-semibold" style={{ color: COLORS.accent }}>← Zur Übersicht</Link>
+      </div>
+    );
+  }
+
+  // Preisbasis: festgeschriebener Kurs-Snapshot; Fallback aktuelle Kurse (mit internem Hinweis).
+  const rates = calc.rates_snapshot ?? currentRates;
+  const totals = computeTotals(calc.items, calc.target_currency, rates, calc.margin_mode, calc.margin_value);
+  const categories = CALC_CATEGORIES
+    .map((cat) => ({ ...cat, items: calc.items.filter((i) => i.category === cat.id && (i.description.trim() || i.amount > 0)) }))
+    .filter((cat) => cat.items.length > 0);
+  const dateStr = (calc.created_at || '').slice(0, 10).split('-').reverse().join('.');
+
+  return (
+    <div className="min-h-screen bg-gray-100 print:bg-white">
+      {/* Toolbar (nur Bildschirm) */}
+      <div className="sticky top-0 z-10 border-b bg-white/90 backdrop-blur print:hidden" style={{ borderColor: COLORS.stroke }}>
+        <div className="mx-auto flex max-w-3xl items-center gap-3 px-4 py-3">
+          <Link href={`/admin/kalkulation/${calc.id}`}>
+            <Button variant="ghost" size="sm"><ArrowLeft className="h-4 w-4" /> Zur Kalkulation</Button>
+          </Link>
+          <span className="text-xs" style={{ color: COLORS.textMuted }}>
+            Kundenansicht — ohne EK, Marge &amp; interne Notizen.
+          </span>
+          <div className="ml-auto">
+            <Button variant="accent" size="sm" onClick={() => window.print()}>
+              <Printer className="h-4 w-4" /> Drucken / PDF
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {/* Interner Hinweis, falls ohne festgeschriebene Kurse gerechnet wird */}
+      {!calc.rates_snapshot && (
+        <div className="mx-auto mt-4 max-w-3xl px-4 print:hidden">
+          <div className="flex items-start gap-2 rounded-xl border px-3 py-2.5 text-xs font-medium" style={{ borderColor: '#fde68a', background: '#fffbeb', color: COLORS.warn }}>
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+            Für diese Kalkulation sind keine Kurse festgeschrieben — der Preis basiert auf dem aktuellen Kursstand.
+          </div>
+        </div>
+      )}
+
+      {/* Angebots-Dokument */}
+      <div className="mx-auto my-6 max-w-3xl bg-white px-8 py-10 shadow-sm print:my-0 print:max-w-none print:px-0 print:py-0 print:shadow-none sm:px-12">
+        {/* Kopf */}
+        <div className="flex items-start justify-between gap-6 border-b-4 pb-6" style={{ borderColor: COLORS.navy }}>
+          <Image src="/faltin-logo-email.png" alt="Faltin Travel" width={150} height={48} className="h-12 w-auto" />
+          <div className="text-right">
+            <div className="text-2xl font-extrabold tracking-tight" style={{ color: COLORS.navy }}>Angebot</div>
+            <div className="mt-1 text-xs" style={{ color: COLORS.textMuted }}>
+              {calc.calc_number && <div>Angebots-Nr. {calc.calc_number}</div>}
+              {calc.request_number && <div>Referenz {calc.request_number}</div>}
+              <div>Datum {dateStr}</div>
+            </div>
+          </div>
+        </div>
+
+        {/* Empfänger + Titel */}
+        <div className="mt-8">
+          {calc.customer_name && (
+            <p className="text-xs font-semibold uppercase tracking-wider" style={{ color: COLORS.textMuted }}>
+              Erstellt für {calc.customer_name}
+            </p>
+          )}
+          <h1 className="mt-1 text-xl font-extrabold" style={{ color: COLORS.navy }}>
+            {calc.title || 'Ihr Reise-Arrangement'}
+          </h1>
+        </div>
+
+        {/* Leistungen */}
+        <div className="mt-6">
+          <p className="border-b pb-2 text-xs font-bold uppercase tracking-widest" style={{ color: COLORS.navy, borderColor: COLORS.stroke }}>
+            Inkludierte Leistungen
+          </p>
+          {categories.length === 0 ? (
+            <p className="py-6 text-sm" style={{ color: COLORS.textMuted }}>Noch keine Leistungen erfasst.</p>
+          ) : (
+            <div className="divide-y" style={{ borderColor: COLORS.stroke }}>
+              {categories.map((cat) => (
+                <div key={cat.id} className="py-4">
+                  <p className="text-sm font-bold" style={{ color: COLORS.accent }}>{cat.label}</p>
+                  <ul className="mt-1.5 space-y-1">
+                    {cat.items.map((item) => (
+                      <li key={item.id} className="flex gap-2 text-sm leading-relaxed" style={{ color: COLORS.navy }}>
+                        <span className="select-none" style={{ color: COLORS.accent }}>•</span>
+                        <span>
+                          {item.qty > 1 ? `${item.qty}× ` : ''}
+                          {item.description.trim() || cat.label}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Gesamtpreis */}
+        <div className="mt-4 rounded-xl border-2 px-6 py-5" style={{ borderColor: COLORS.navy }}>
+          <div className="flex flex-wrap items-baseline justify-between gap-2">
+            <div>
+              <p className="text-sm font-bold" style={{ color: COLORS.navy }}>Gesamtpreis</p>
+              <p className="text-xs" style={{ color: COLORS.textMuted }}>inkl. aller oben aufgeführten Leistungen</p>
+            </div>
+            <div className="text-3xl font-extrabold tabular-nums" style={{ color: COLORS.navy }}>
+              {totals ? fmtMoney(totals.vkTarget, calc.target_currency) : '—'}
+            </div>
+          </div>
+        </div>
+
+        <p className="mt-3 text-[11px] leading-relaxed" style={{ color: COLORS.textMuted }}>
+          Alle Preise in {calc.target_currency}. Angebot freibleibend — Verfügbarkeit und Preis werden bei Buchung bestätigt.
+        </p>
+
+        {/* Fuß */}
+        <div className="mt-10 flex items-center justify-between gap-4 border-t pt-5" style={{ borderColor: COLORS.stroke }}>
+          <p className="text-xs" style={{ color: COLORS.textMuted }}>
+            <span className="font-bold" style={{ color: COLORS.navy }}>Faltin Travel AG</span> · Ihr Partner für Sport-Events &amp; Hospitality · faltintravel.com
+          </p>
+          <Image src="/schweizer-reisegarantie-logo.svg" alt="Schweizer Reisegarantie" width={110} height={44} className="h-10 w-auto" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/kalkulation/[id]/page.tsx
+++ b/src/app/admin/kalkulation/[id]/page.tsx
@@ -1,0 +1,594 @@
+'use client';
+
+/**
+ * /admin/kalkulation/[id] — Editor einer Angebotskalkulation (TASK-00115).
+ * id = "neu" legt eine neue Kalkulation an. Positionen je Kategorie mit EK in
+ * EUR/USD/CHF/GBP, Live-Umrechnung in die Zielwährung (Kursbasis = Snapshot
+ * bei Erstellung), Marge als Prozent (Slider 0–200 %) oder Fixbetrag,
+ * FX-Alert bei Kursveränderung, Kunden-/Anfrage-Zuordnung, Kundenansicht.
+ */
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { useParams, useRouter } from 'next/navigation';
+import AdminShell from '@/components/admin/AdminShell';
+import {
+  COLORS, SectionCard, Card, Spinner, Button, Field, TextInput, TextArea, SelectInput, InputField, Badge, PageHeader,
+} from '@/components/admin/ui';
+import {
+  ArrowLeft, Plus, X, Save, Trash2, FileText, TrendingDown, TrendingUp, Minus, RefreshCw, AlertTriangle, Landmark,
+} from 'lucide-react';
+import {
+  CALC_CATEGORIES, computeTotals, compareEk, itemEk, fmtMoney, fmtPct,
+  type CalcItem, type MarginMode,
+} from '@/lib/calcModel';
+import { CALC_CURRENCIES, convertAmount, type CalcCurrency, type RatesSnapshot } from '@/lib/fxRates';
+
+type CalcStatus = 'entwurf' | 'aktiv' | 'archiviert';
+
+interface CustomerOption { id: string; name: string; company: string; primary_email: string }
+interface BookingOption { id: string; request_number: string | null; package_title: string; email: string; customer_id?: string | null }
+
+function newItem(category: string, currency: CalcCurrency): CalcItem {
+  return { id: crypto.randomUUID(), category, description: '', currency, amount: 0, qty: 1 };
+}
+
+export default function KalkulationEditorPage() {
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+  const id = params.id;
+  const isNew = id === 'neu';
+
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const [calcNumber, setCalcNumber] = useState('');
+  const [createdAt, setCreatedAt] = useState('');
+  const [title, setTitle] = useState('');
+  const [customerId, setCustomerId] = useState('');
+  const [bookingId, setBookingId] = useState('');
+  const [target, setTarget] = useState<CalcCurrency>('CHF');
+  const [marginMode, setMarginMode] = useState<MarginMode>('percent');
+  const [marginValue, setMarginValue] = useState(10);
+  const [items, setItems] = useState<CalcItem[]>([]);
+  const [status, setStatus] = useState<CalcStatus>('entwurf');
+  const [notes, setNotes] = useState('');
+  const [snapshot, setSnapshot] = useState<RatesSnapshot | null>(null);
+  const [current, setCurrent] = useState<RatesSnapshot | null>(null);
+
+  const [customers, setCustomers] = useState<CustomerOption[]>([]);
+  const [bookings, setBookings] = useState<BookingOption[]>([]);
+  const [confirmAction, setConfirmAction] = useState<null | 'delete' | 'rebase'>(null);
+
+  /* ─── Laden ─────────────────────────────────────────────────────────── */
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setErr(null);
+    try {
+      const [customersRes, bookingsRes] = await Promise.all([
+        fetch('/api/admin/customers').then((r) => r.json()).catch(() => null),
+        fetch('/api/bookings').then((r) => r.json()).catch(() => null),
+      ]);
+      if (customersRes?.success) setCustomers(customersRes.data || []);
+      if (bookingsRes?.success) setBookings(bookingsRes.data || []);
+
+      if (isNew) {
+        const ratesRes = await fetch('/api/admin/calculations/rates').then((r) => r.json()).catch(() => null);
+        if (ratesRes?.success) setCurrent(ratesRes.data);
+        else setNotice('Wechselkurse sind aktuell nicht abrufbar — die Vorschau bleibt leer, Kurse werden beim Speichern nachgeholt.');
+      } else {
+        const res = await fetch(`/api/admin/calculations/${id}`).then((r) => r.json());
+        if (!res?.success) {
+          setErr(res?.error || 'Kalkulation nicht gefunden');
+          return;
+        }
+        const d = res.data;
+        setCalcNumber(d.calc_number || '');
+        setCreatedAt(d.created_at || '');
+        setTitle(d.title || '');
+        setCustomerId(d.customer_id || '');
+        setBookingId(d.booking_id || '');
+        setTarget(d.target_currency || 'CHF');
+        setMarginMode(d.margin_mode || 'percent');
+        setMarginValue(Number(d.margin_value) || 0);
+        setItems(Array.isArray(d.items) ? d.items : []);
+        setStatus(d.status || 'entwurf');
+        setNotes(d.notes || '');
+        setSnapshot(d.rates_snapshot || null);
+        setCurrent(res.current_rates || null);
+      }
+    } catch {
+      setErr('Laden fehlgeschlagen');
+    } finally {
+      setLoading(false);
+    }
+  }, [id, isNew]);
+
+  useEffect(() => { load(); }, [load]);
+
+  /* ─── Abgeleitete Werte ─────────────────────────────────────────────── */
+
+  /** Kursbasis der Kalkulation: festgeschriebener Snapshot, bei Neuanlage die aktuellen Kurse. */
+  const baseRates = snapshot ?? current;
+  const totals = useMemo(
+    () => computeTotals(items, target, baseRates, marginMode, marginValue),
+    [items, target, baseRates, marginMode, marginValue]
+  );
+  const fx = useMemo(
+    () => compareEk(items, target, snapshot, current),
+    [items, target, snapshot, current]
+  );
+
+  /* ─── Positionen ────────────────────────────────────────────────────── */
+
+  const addItem = (category: string) => setItems((prev) => [...prev, newItem(category, target)]);
+  const removeItem = (itemId: string) => setItems((prev) => prev.filter((i) => i.id !== itemId));
+  const patchItem = (itemId: string, patch: Partial<CalcItem>) =>
+    setItems((prev) => prev.map((i) => (i.id === itemId ? { ...i, ...patch } : i)));
+
+  const onBookingChange = (v: string) => {
+    setBookingId(v);
+    if (v && !customerId) {
+      const b = bookings.find((x) => x.id === v);
+      if (b?.customer_id) setCustomerId(b.customer_id);
+    }
+  };
+
+  /* ─── Aktionen ──────────────────────────────────────────────────────── */
+
+  const save = async () => {
+    setSaving(true);
+    setErr(null);
+    setNotice(null);
+    const payload = {
+      title, customer_id: customerId || null, booking_id: bookingId || null,
+      target_currency: target, margin_mode: marginMode, margin_value: marginValue,
+      items, status, notes,
+    };
+    try {
+      if (isNew) {
+        const res = await fetch('/api/admin/calculations', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload),
+        }).then((r) => r.json());
+        if (!res?.success) { setErr(res?.error || 'Speichern fehlgeschlagen'); return; }
+        router.replace(`/admin/kalkulation/${res.data.id}`);
+      } else {
+        const res = await fetch(`/api/admin/calculations/${id}`, {
+          method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload),
+        }).then((r) => r.json());
+        if (!res?.success) { setErr(res?.error || 'Speichern fehlgeschlagen'); return; }
+        setSnapshot(res.data?.rates_snapshot || null);
+        if (res.current_rates) setCurrent(res.current_rates);
+        setNotice('Gespeichert.');
+      }
+    } catch {
+      setErr('Speichern fehlgeschlagen');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  /** Kurs-Snapshot neu auf den aktuellen Stand festschreiben (neue Kalkulationsbasis). */
+  const rebaseRates = async () => {
+    if (confirmAction !== 'rebase') { setConfirmAction('rebase'); return; }
+    setConfirmAction(null);
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/admin/calculations/${id}`, {
+        method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ refresh_rates: true }),
+      }).then((r) => r.json());
+      if (!res?.success) { setErr(res?.error || 'Kurse konnten nicht aktualisiert werden'); return; }
+      setSnapshot(res.data?.rates_snapshot || null);
+      if (res.current_rates) setCurrent(res.current_rates);
+      setNotice('Kurse neu festgeschrieben — die Kalkulation rechnet ab jetzt mit dem aktuellen Stand.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const remove = async () => {
+    if (confirmAction !== 'delete') { setConfirmAction('delete'); return; }
+    setConfirmAction(null);
+    const res = await fetch(`/api/admin/calculations/${id}`, { method: 'DELETE' }).then((r) => r.json()).catch(() => null);
+    if (res?.success) router.push('/admin/kalkulation');
+    else setErr(res?.error || 'Löschen fehlgeschlagen');
+  };
+
+  /* ─── Render ────────────────────────────────────────────────────────── */
+
+  if (loading) {
+    return (
+      <AdminShell title="Angebotskalkulation">
+        <div className="py-16 text-center"><Spinner /></div>
+      </AdminShell>
+    );
+  }
+
+  if (err && !isNew && !calcNumber) {
+    return (
+      <AdminShell title="Angebotskalkulation">
+        <Card className="mx-auto max-w-lg text-center">
+          <p className="font-semibold" style={{ color: COLORS.danger }}>{err}</p>
+          <Link href="/admin/kalkulation" className="mt-3 inline-block text-sm font-semibold" style={{ color: COLORS.accent }}>
+            ← Zur Übersicht
+          </Link>
+        </Card>
+      </AdminShell>
+    );
+  }
+
+  const usedCurrencies = Array.from(new Set(items.map((i) => i.currency)));
+
+  return (
+    <AdminShell title={isNew ? 'Neue Kalkulation' : `Kalkulation ${calcNumber}`}>
+      <PageHeader
+        title={isNew ? 'Neue Angebotskalkulation' : `${calcNumber || 'Kalkulation'}${title ? ` — ${title}` : ''}`}
+        description={
+          isNew
+            ? 'Positionen erfassen, EK in der Einkaufswährung eingeben — beim Speichern werden die aktuellen EZB-Kurse festgeschrieben.'
+            : `Angelegt am ${(createdAt || '').slice(0, 10)}${snapshot ? ` · Kursbasis EZB ${snapshot.date}` : ' · noch keine Kurse festgeschrieben'}`
+        }
+        actions={
+          <>
+            <Link href="/admin/kalkulation">
+              <Button variant="ghost"><ArrowLeft className="h-4 w-4" /> Übersicht</Button>
+            </Link>
+            {!isNew && (
+              <Link href={`/admin/kalkulation/${id}/angebot`}>
+                <Button variant="secondary"><FileText className="h-4 w-4" /> Kundenansicht</Button>
+              </Link>
+            )}
+            <Button variant="accent" onClick={save} disabled={saving}>
+              {saving ? <Spinner className="h-4 w-4" /> : <Save className="h-4 w-4" />} Speichern
+            </Button>
+          </>
+        }
+      />
+
+      {(err || notice) && (
+        <div
+          className="mb-4 rounded-xl border px-4 py-3 text-sm font-medium"
+          style={err
+            ? { borderColor: '#fecaca', background: '#fef2f2', color: COLORS.danger }
+            : { borderColor: '#bbf7d0', background: '#f0fdf4', color: COLORS.ok }}
+        >
+          {err || notice}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        {/* ─── Linke Spalte: Stammdaten + Positionen ─── */}
+        <div className="space-y-6 lg:col-span-2">
+          <SectionCard title="Stammdaten" description="Titel, Zuordnung zu Kunde und Anfrage (RQ), Status.">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div className="sm:col-span-2">
+                <InputField
+                  label="Titel" required placeholder="z. B. Super Bowl LXII — VIP-Arrangement 4 Personen"
+                  value={title} onChange={(e) => setTitle(e.target.value)}
+                />
+              </div>
+              <Field label="Kunde">
+                <SelectInput value={customerId} onChange={(e) => setCustomerId(e.target.value)}>
+                  <option value="">— kein Kunde zugeordnet —</option>
+                  {customers.map((c) => (
+                    <option key={c.id} value={c.id}>
+                      {(c.name || c.primary_email || c.id.slice(0, 8)) + (c.company ? ` · ${c.company}` : '')}
+                    </option>
+                  ))}
+                </SelectInput>
+              </Field>
+              <Field label="Anfrage (REQ)" hint="Verknüpft die Kalkulation mit einer Buchungsanfrage.">
+                <SelectInput value={bookingId} onChange={(e) => onBookingChange(e.target.value)}>
+                  <option value="">— keine Anfrage zugeordnet —</option>
+                  {bookings.map((b) => (
+                    <option key={b.id} value={b.id}>
+                      {(b.request_number || b.id.slice(0, 8)) + (b.package_title ? ` · ${b.package_title}` : '') + (b.email ? ` · ${b.email}` : '')}
+                    </option>
+                  ))}
+                </SelectInput>
+              </Field>
+              <Field label="Status">
+                <SelectInput value={status} onChange={(e) => setStatus(e.target.value as CalcStatus)}>
+                  <option value="entwurf">Entwurf</option>
+                  <option value="aktiv">Aktiv</option>
+                  <option value="archiviert">Archiviert</option>
+                </SelectInput>
+              </Field>
+              <div className="sm:col-span-2">
+                <Field label="Interne Notizen" hint="Nur intern — erscheint nicht in der Kundenansicht.">
+                  <TextArea rows={2} value={notes} onChange={(e) => setNotes(e.target.value)} placeholder="z. B. Ticket-Kontingent bei Broker XY angefragt…" />
+                </Field>
+              </div>
+            </div>
+          </SectionCard>
+
+          <SectionCard
+            title="Positionen (EK)"
+            description="Einkaufspreise je Position in der jeweiligen Einkaufswährung — pro Kategorie beliebig viele Positionen (z. B. mehrere Transfers)."
+          >
+            <div className="space-y-5">
+              {CALC_CATEGORIES.map((cat) => {
+                const catItems = items.filter((i) => i.category === cat.id);
+                const catSum = baseRates
+                  ? catItems.reduce((s, i) => s + convertAmount(itemEk(i), i.currency, target, baseRates), 0)
+                  : null;
+                return (
+                  <div key={cat.id} className="rounded-xl border" style={{ borderColor: COLORS.stroke }}>
+                    <div className="flex items-center justify-between gap-3 px-4 py-2.5" style={{ background: COLORS.surfaceMuted, borderRadius: '0.75rem 0.75rem 0 0' }}>
+                      <span className="text-sm font-bold" style={{ color: COLORS.navy }}>{cat.label}</span>
+                      <div className="flex items-center gap-3">
+                        {catItems.length > 0 && catSum !== null && (
+                          <span className="text-xs font-semibold tabular-nums" style={{ color: COLORS.textMuted }}>
+                            {fmtMoney(catSum, target)}
+                          </span>
+                        )}
+                        <Button variant="secondary" size="sm" onClick={() => addItem(cat.id)}>
+                          <Plus className="h-3.5 w-3.5" /> Position
+                        </Button>
+                      </div>
+                    </div>
+                    {catItems.length > 0 && (
+                      <div className="space-y-2 p-3">
+                        {catItems.map((item) => {
+                          const ek = itemEk(item);
+                          const inTarget = baseRates ? convertAmount(ek, item.currency, target, baseRates) : null;
+                          return (
+                            <div key={item.id} className="flex flex-wrap items-center gap-2">
+                              <TextInput
+                                className="min-w-40 flex-1"
+                                placeholder="Beschreibung, z. B. Kat.-1-Ticket Unterrang"
+                                value={item.description}
+                                onChange={(e) => patchItem(item.id, { description: e.target.value })}
+                              />
+                              <TextInput
+                                type="number" min={0} step={1} title="Menge"
+                                className="w-16 text-center"
+                                value={item.qty}
+                                onChange={(e) => patchItem(item.id, { qty: Math.max(0, Number(e.target.value) || 0) })}
+                              />
+                              <SelectInput
+                                className="w-24" title="Einkaufswährung"
+                                value={item.currency}
+                                onChange={(e) => patchItem(item.id, { currency: e.target.value as CalcCurrency })}
+                              >
+                                {CALC_CURRENCIES.map((c) => <option key={c} value={c}>{c}</option>)}
+                              </SelectInput>
+                              <TextInput
+                                type="number" min={0} step={0.01} title="EK je Einheit"
+                                className="w-28 text-right"
+                                value={item.amount}
+                                onChange={(e) => patchItem(item.id, { amount: Math.max(0, Number(e.target.value) || 0) })}
+                              />
+                              <span className="w-28 text-right text-xs font-bold tabular-nums" style={{ color: COLORS.navy }}>
+                                {inTarget !== null ? fmtMoney(inTarget, target) : '—'}
+                              </span>
+                              <button
+                                onClick={() => removeItem(item.id)}
+                                className="rounded-lg p-1.5 text-gray-400 transition hover:bg-red-50 hover:text-red-500"
+                                title="Position entfernen"
+                              >
+                                <X className="h-4 w-4" />
+                              </button>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </SectionCard>
+        </div>
+
+        {/* ─── Rechte Spalte: Kalkulation + Kurse ─── */}
+        <div className="h-fit space-y-6 lg:sticky lg:top-20">
+          <SectionCard title="Kalkulation" description="Zielwährung, Marge und Summen.">
+            <div className="space-y-4">
+              <Field label="Zielwährung" hint="Die gesamte Kalkulation wird in diese Währung umgerechnet.">
+                <SelectInput value={target} onChange={(e) => setTarget(e.target.value as CalcCurrency)}>
+                  {CALC_CURRENCIES.map((c) => <option key={c} value={c}>{c}</option>)}
+                </SelectInput>
+              </Field>
+
+              <Field label="Marge">
+                <div className="flex gap-2">
+                  <SelectInput
+                    className="w-36 shrink-0"
+                    value={marginMode}
+                    onChange={(e) => setMarginMode(e.target.value as MarginMode)}
+                  >
+                    <option value="percent">Prozent (%)</option>
+                    <option value="fixed">Fixbetrag ({target})</option>
+                  </SelectInput>
+                  <TextInput
+                    type="number" min={0} step={marginMode === 'percent' ? 0.5 : 10}
+                    className="text-right"
+                    value={marginValue}
+                    onChange={(e) => setMarginValue(Math.max(0, Number(e.target.value) || 0))}
+                  />
+                </div>
+                {marginMode === 'percent' && (
+                  <input
+                    type="range" min={0} max={200} step={0.5}
+                    value={Math.min(200, marginValue)}
+                    onChange={(e) => setMarginValue(Number(e.target.value))}
+                    className="mt-3 w-full cursor-pointer"
+                    style={{ accentColor: COLORS.accent }}
+                  />
+                )}
+                {totals && (
+                  <p className="mt-2 text-xs font-semibold" style={{ color: COLORS.textMuted }}>
+                    {marginMode === 'percent'
+                      ? <>= {fmtMoney(totals.marginAmount, target)} Marge</>
+                      : <>= {totals.marginPercent.toFixed(1).replace('.', ',')} % vom EK</>}
+                  </p>
+                )}
+              </Field>
+
+              {totals ? (
+                <div className="rounded-xl border p-4" style={{ borderColor: COLORS.stroke, background: COLORS.surfaceMuted }}>
+                  <div className="flex items-baseline justify-between text-sm">
+                    <span style={{ color: COLORS.textMuted }}>EK gesamt</span>
+                    <span className="font-bold tabular-nums" style={{ color: COLORS.navy }}>{fmtMoney(totals.ekTarget, target)}</span>
+                  </div>
+                  <div className="mt-1 flex items-baseline justify-between text-sm">
+                    <span style={{ color: COLORS.textMuted }}>Marge ({totals.marginPercent.toFixed(1).replace('.', ',')} %)</span>
+                    <span className="font-bold tabular-nums" style={{ color: COLORS.navy }}>{fmtMoney(totals.marginAmount, target)}</span>
+                  </div>
+                  <div className="mt-2 flex items-baseline justify-between border-t pt-2" style={{ borderColor: COLORS.stroke }}>
+                    <span className="text-sm font-bold" style={{ color: COLORS.navy }}>VK gesamt</span>
+                    <span className="text-xl font-extrabold tabular-nums" style={{ color: COLORS.accent }}>{fmtMoney(totals.vkTarget, target)}</span>
+                  </div>
+                  {totals.byCurrency.length > 0 && (
+                    <div className="mt-3 space-y-1 border-t pt-2 text-xs" style={{ borderColor: COLORS.stroke, color: COLORS.textMuted }}>
+                      {totals.byCurrency.map((bc) => (
+                        <div key={bc.currency} className="flex justify-between tabular-nums">
+                          <span>EK-Anteil {bc.currency}</span>
+                          <span>{fmtMoney(bc.sum, bc.currency)}{bc.currency !== target ? ` → ${fmtMoney(bc.inTarget, target)}` : ''}</span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <div className="flex items-start gap-2 rounded-xl border px-3 py-2.5 text-xs font-medium" style={{ borderColor: '#fde68a', background: '#fffbeb', color: COLORS.warn }}>
+                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                  Keine Wechselkurse verfügbar — Summen können nicht berechnet werden. Beim Speichern wird der Abruf erneut versucht.
+                </div>
+              )}
+            </div>
+          </SectionCard>
+
+          {/* FX-Alert: Kursveränderung seit Festschreibung */}
+          {!isNew && snapshot && (
+            <SectionCard
+              title="Wechselkurs-Check"
+              description={`Kursbasis: EZB ${snapshot.date} · Vergleich mit aktuellem Stand${current ? ` (${current.date})` : ''}.`}
+              icon={<Landmark className="h-5 w-5" />}
+            >
+              {fx ? (
+                <div
+                  className="rounded-xl border p-4"
+                  style={fx.diffPct >= 1
+                    ? { borderColor: '#fecaca', background: '#fef2f2' }
+                    : fx.diffPct <= -1
+                      ? { borderColor: '#bbf7d0', background: '#f0fdf4' }
+                      : { borderColor: COLORS.stroke, background: COLORS.surfaceMuted }}
+                >
+                  <div className="flex items-center gap-2">
+                    {fx.diffPct <= -1 ? (
+                      <TrendingDown className="h-5 w-5" style={{ color: COLORS.ok }} />
+                    ) : fx.diffPct >= 1 ? (
+                      <TrendingUp className="h-5 w-5" style={{ color: COLORS.danger }} />
+                    ) : (
+                      <Minus className="h-5 w-5" style={{ color: COLORS.textMuted }} />
+                    )}
+                    <span className="text-lg font-extrabold tabular-nums" style={{ color: fx.diffPct >= 1 ? COLORS.danger : fx.diffPct <= -1 ? COLORS.ok : COLORS.navy }}>
+                      EK {fmtPct(fx.diffPct)}
+                    </span>
+                    <span className="ml-auto text-xs font-semibold tabular-nums" style={{ color: COLORS.textMuted }}>
+                      {fmtMoney(fx.diffAbs, target)}
+                    </span>
+                  </div>
+                  <p className="mt-2 text-xs leading-relaxed" style={{ color: COLORS.navy }}>
+                    {fx.diffPct <= -1 && (
+                      <>Der EK ist durch die Kursentwicklung <b>gesunken</b> ({fmtMoney(fx.ekAtSnapshot, target)} → {fmtMoney(fx.ekAtCurrent, target)}). <b>Mehr Marge</b> als ursprünglich kalkuliert.</>
+                    )}
+                    {fx.diffPct >= 1 && (
+                      <>Der EK ist durch die Kursentwicklung <b>gestiegen</b> ({fmtMoney(fx.ekAtSnapshot, target)} → {fmtMoney(fx.ekAtCurrent, target)}). Die Marge <b>schrumpft</b> entsprechend — Kalkulation prüfen.</>
+                    )}
+                    {Math.abs(fx.diffPct) < 1 && (
+                      <>Kurse seit Festschreibung praktisch unverändert ({fmtMoney(fx.ekAtSnapshot, target)} → {fmtMoney(fx.ekAtCurrent, target)}).</>
+                    )}
+                  </p>
+                  {fx.perCurrency.length > 0 && (
+                    <div className="mt-2 flex flex-wrap gap-1.5">
+                      {fx.perCurrency.map((pc) => (
+                        <Badge key={pc.currency} tone={pc.ratePct >= 1 ? 'danger' : pc.ratePct <= -1 ? 'ok' : 'muted'}>
+                          {pc.currency}→{target} {fmtPct(pc.ratePct)}
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <p className="text-xs" style={{ color: COLORS.textMuted }}>
+                  Kein Vergleich möglich — {current ? 'noch keine (umrechenbaren) Positionen erfasst.' : 'aktuelle Kurse sind nicht abrufbar.'}
+                </p>
+              )}
+
+              {/* Kurs-Tabelle Snapshot vs. aktuell */}
+              {usedCurrencies.filter((c) => c !== target).length > 0 && current && (
+                <div className="mt-3 space-y-1 text-xs tabular-nums" style={{ color: COLORS.textMuted }}>
+                  {usedCurrencies.filter((c) => c !== target).map((c) => {
+                    const snapRate = convertAmount(1, c, target, snapshot);
+                    const curRate = convertAmount(1, c, target, current);
+                    return (
+                      <div key={c} className="flex justify-between">
+                        <span>1 {c}</span>
+                        <span>{snapRate.toFixed(4)} → {curRate.toFixed(4)} {target}</span>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+
+              <div className="mt-3">
+                <Button variant="secondary" size="sm" onClick={rebaseRates} disabled={saving || !current}>
+                  <RefreshCw className="h-3.5 w-3.5" />
+                  {confirmAction === 'rebase' ? 'Wirklich? Erneut klicken' : 'Kurse neu festschreiben'}
+                </Button>
+                <p className="mt-1.5 text-[11px]" style={{ color: '#9ca3af' }}>
+                  Setzt die Kalkulationsbasis auf den aktuellen Kursstand — der bisherige Vergleich beginnt von vorn.
+                </p>
+              </div>
+            </SectionCard>
+          )}
+
+          {!isNew && !snapshot && (
+            <SectionCard title="Wechselkurs-Check" icon={<Landmark className="h-5 w-5" />}>
+              <div className="flex items-start gap-2 rounded-xl border px-3 py-2.5 text-xs font-medium" style={{ borderColor: '#fde68a', background: '#fffbeb', color: COLORS.warn }}>
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                Für diese Kalkulation sind noch keine Kurse festgeschrieben.
+              </div>
+              <div className="mt-3">
+                <Button variant="secondary" size="sm" onClick={rebaseRates} disabled={saving}>
+                  <RefreshCw className="h-3.5 w-3.5" />
+                  {confirmAction === 'rebase' ? 'Wirklich? Erneut klicken' : 'Kurse jetzt festschreiben'}
+                </Button>
+              </div>
+            </SectionCard>
+          )}
+
+          {isNew && (
+            <Card>
+              <p className="text-xs leading-relaxed" style={{ color: COLORS.textMuted }}>
+                <b style={{ color: COLORS.navy }}>Kurs-Snapshot:</b> Beim Speichern werden die aktuell gültigen EZB-Referenzkurse
+                {current ? ` (Stand ${current.date})` : ''} als Kalkulationsbasis festgeschrieben. Verändern sich die Kurse danach,
+                zeigt die Kalkulation einen grünen/roten Alert mit der EK-Abweichung in Prozent.
+              </p>
+            </Card>
+          )}
+
+          {baseRates && (
+            <p className="px-1 text-[11px]" style={{ color: '#9ca3af' }}>
+              Kursquelle: {baseRates.source} · Kursdatum {baseRates.date}
+            </p>
+          )}
+
+          {!isNew && (
+            <div className="flex justify-end">
+              <Button variant="danger" size="sm" onClick={remove}>
+                <Trash2 className="h-3.5 w-3.5" />
+                {confirmAction === 'delete' ? 'Wirklich löschen? Erneut klicken' : 'Kalkulation löschen'}
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+    </AdminShell>
+  );
+}

--- a/src/app/admin/kalkulation/page.tsx
+++ b/src/app/admin/kalkulation/page.tsx
@@ -1,0 +1,224 @@
+'use client';
+
+/**
+ * /admin/kalkulation — Übersicht der Angebotskalkulationen (TASK-00115).
+ * EK-Kalkulationen mit Fremdwährungs-Positionen, Kurs-Snapshot und FX-Alert:
+ * grün = EK seit Erstellung gesunken (mehr Marge), rot = EK gestiegen.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import AdminShell from '@/components/admin/AdminShell';
+import { COLORS, SectionCard, Spinner, EmptyState, Button, Badge, StatCard, PageHeader } from '@/components/admin/ui';
+import { Calculator, Plus, TrendingDown, TrendingUp, Minus, Trash2, ExternalLink, FileText } from 'lucide-react';
+import { computeTotals, fmtMoney, fmtPct, type CalcItem, type FxComparison, type MarginMode } from '@/lib/calcModel';
+import type { CalcCurrency, RatesSnapshot } from '@/lib/fxRates';
+
+/** Ab dieser EK-Veränderung (±%) erscheint das farbige Alert-Badge in der Liste. */
+const FX_ALERT_THRESHOLD = 1;
+
+interface CalcRow {
+  id: string;
+  calc_number: string;
+  created_at: string;
+  title: string;
+  customer_id: string | null;
+  customer_name: string | null;
+  booking_id: string | null;
+  request_number: string | null;
+  package_title: string | null;
+  target_currency: CalcCurrency;
+  margin_mode: MarginMode;
+  margin_value: number;
+  items: CalcItem[];
+  rates_snapshot: RatesSnapshot | null;
+  status: 'entwurf' | 'aktiv' | 'archiviert';
+  fx: FxComparison | null;
+}
+
+const STATUS_LABEL: Record<CalcRow['status'], { label: string; tone: 'muted' | 'ok' | 'navy' }> = {
+  entwurf: { label: 'Entwurf', tone: 'muted' },
+  aktiv: { label: 'Aktiv', tone: 'ok' },
+  archiviert: { label: 'Archiviert', tone: 'navy' },
+};
+
+function FxBadge({ fx, currency }: { fx: FxComparison | null; currency: string }) {
+  if (!fx) {
+    return <span className="text-xs text-gray-400" title="Kein Kursvergleich möglich (Kurse fehlen oder keine Positionen).">–</span>;
+  }
+  const pct = fx.diffPct;
+  const info = `EK zu aktuellen Kursen: ${fmtMoney(fx.ekAtCurrent, currency)} (Kalkulation: ${fmtMoney(fx.ekAtSnapshot, currency)}, Kursbasis ${fx.snapshotDate})`;
+  if (pct <= -FX_ALERT_THRESHOLD) {
+    return (
+      <Badge tone="ok" className="whitespace-nowrap" >
+        <TrendingDown className="h-3 w-3" />
+        <span title={`${info} — EK gesunken, mehr Marge als kalkuliert.`}>EK {fmtPct(pct)}</span>
+      </Badge>
+    );
+  }
+  if (pct >= FX_ALERT_THRESHOLD) {
+    return (
+      <Badge tone="danger" className="whitespace-nowrap">
+        <TrendingUp className="h-3 w-3" />
+        <span title={`${info} — EK gestiegen, Marge schrumpft.`}>EK {fmtPct(pct)}</span>
+      </Badge>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 text-xs text-gray-400 whitespace-nowrap" title={`${info} — Veränderung unter ${FX_ALERT_THRESHOLD} %.`}>
+      <Minus className="h-3 w-3" /> stabil
+    </span>
+  );
+}
+
+export default function KalkulationListPage() {
+  const [rows, setRows] = useState<CalcRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/admin/calculations').then((r) => r.json());
+      if (res.success) setRows(res.data || []);
+      else setError(res.error || 'Laden fehlgeschlagen');
+    } catch {
+      setError('Laden fehlgeschlagen');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const remove = async (id: string) => {
+    if (confirmDelete !== id) { setConfirmDelete(id); return; }
+    setConfirmDelete(null);
+    const res = await fetch(`/api/admin/calculations/${id}`, { method: 'DELETE' }).then((r) => r.json()).catch(() => null);
+    if (res?.success) setRows((prev) => prev.filter((r) => r.id !== id));
+  };
+
+  const alerts = rows.filter((r) => r.fx && Math.abs(r.fx.diffPct) >= FX_ALERT_THRESHOLD);
+  const better = alerts.filter((r) => (r.fx?.diffPct ?? 0) < 0).length;
+  const worse = alerts.filter((r) => (r.fx?.diffPct ?? 0) > 0).length;
+
+  return (
+    <AdminShell title="Angebotskalkulation">
+      <PageHeader
+        title="Angebotskalkulation"
+        description="EK-Kalkulationen für Arrangements — Positionen in EUR/USD/CHF/GBP, Kurs-Snapshot bei Erstellung, Marge & Kundenansicht."
+        actions={
+          <Link href="/admin/kalkulation/neu">
+            <Button variant="accent"><Plus className="h-4 w-4" /> Neue Kalkulation</Button>
+          </Link>
+        }
+      />
+
+      <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <StatCard icon={<Calculator className="h-4 w-4" />} label="Kalkulationen" value={rows.length} sub={`${rows.filter((r) => r.status === 'entwurf').length} Entwürfe`} />
+        <StatCard icon={<TrendingDown className="h-4 w-4" />} label="EK gesunken" value={better} sub={`Kursvorteil ≥ ${FX_ALERT_THRESHOLD} % — mehr Marge`} tone="ok" />
+        <StatCard icon={<TrendingUp className="h-4 w-4" />} label="EK gestiegen" value={worse} sub={`Kursnachteil ≥ ${FX_ALERT_THRESHOLD} % — Marge prüfen`} tone="danger" />
+      </div>
+
+      <SectionCard
+        title="Alle Kalkulationen"
+        description="EK/VK in der Zielwährung zu festgeschriebenen Kursen. Das FX-Badge zeigt die EK-Veränderung durch Kursbewegungen seit Erstellung."
+      >
+        {loading ? (
+          <div className="py-10 text-center"><Spinner /></div>
+        ) : error ? (
+          <p className="py-6 text-center text-sm" style={{ color: COLORS.danger }}>{error}</p>
+        ) : rows.length === 0 ? (
+          <EmptyState
+            icon={<Calculator className="h-6 w-6" />}
+            title="Noch keine Kalkulation."
+            description="Lege die erste Angebotskalkulation an — Positionen je Kategorie, EK in der Einkaufswährung, Marge, fertig."
+            action={<Link href="/admin/kalkulation/neu"><Button variant="accent"><Plus className="h-4 w-4" /> Neue Kalkulation</Button></Link>}
+          />
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-xs uppercase tracking-wide text-gray-400">
+                  <th className="px-3 py-2">Nr.</th>
+                  <th className="px-3 py-2">Titel</th>
+                  <th className="px-3 py-2">Kunde / Anfrage</th>
+                  <th className="px-3 py-2 text-center">Pos.</th>
+                  <th className="px-3 py-2 text-right">EK gesamt</th>
+                  <th className="px-3 py-2 text-right">Marge</th>
+                  <th className="px-3 py-2 text-right">VK gesamt</th>
+                  <th className="px-3 py-2">Kurs-Alert</th>
+                  <th className="px-3 py-2">Status</th>
+                  <th className="px-3 py-2"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((r) => {
+                  const totals = computeTotals(r.items, r.target_currency, r.rates_snapshot, r.margin_mode, r.margin_value);
+                  return (
+                    <tr key={r.id} className="border-t transition-colors hover:bg-gray-50" style={{ borderColor: '#eef2f7' }}>
+                      <td className="px-3 py-3 font-mono text-xs font-bold" style={{ color: COLORS.navy }}>
+                        <Link href={`/admin/kalkulation/${r.id}`}>{r.calc_number || r.id.slice(0, 8)}</Link>
+                      </td>
+                      <td className="px-3 py-3">
+                        <Link href={`/admin/kalkulation/${r.id}`} className="font-bold" style={{ color: COLORS.navy }}>
+                          {r.title || '(ohne Titel)'}
+                        </Link>
+                        <div className="text-xs text-gray-400">{(r.created_at || '').slice(0, 10)} · Zielwährung {r.target_currency}</div>
+                      </td>
+                      <td className="px-3 py-3">
+                        <div className="text-gray-700">{r.customer_name || <span className="text-gray-400">—</span>}</div>
+                        {r.request_number && (
+                          <div className="text-xs text-gray-400">{r.request_number}{r.package_title ? ` · ${r.package_title}` : ''}</div>
+                        )}
+                      </td>
+                      <td className="px-3 py-3 text-center font-semibold text-gray-700">{r.items.length}</td>
+                      <td className="px-3 py-3 text-right tabular-nums text-gray-700">
+                        {totals ? fmtMoney(totals.ekTarget, r.target_currency) : <span className="text-xs text-gray-400" title="Keine Kurse festgeschrieben.">—</span>}
+                      </td>
+                      <td className="px-3 py-3 text-right tabular-nums text-gray-500">
+                        {totals ? `${fmtMoney(totals.marginAmount, r.target_currency)} · ${totals.marginPercent.toFixed(1).replace('.', ',')} %` : '—'}
+                      </td>
+                      <td className="px-3 py-3 text-right font-bold tabular-nums" style={{ color: COLORS.navy }}>
+                        {totals ? fmtMoney(totals.vkTarget, r.target_currency) : '—'}
+                      </td>
+                      <td className="px-3 py-3"><FxBadge fx={r.fx} currency={r.target_currency} /></td>
+                      <td className="px-3 py-3"><Badge tone={STATUS_LABEL[r.status].tone}>{STATUS_LABEL[r.status].label}</Badge></td>
+                      <td className="px-3 py-3">
+                        <div className="flex items-center justify-end gap-1">
+                          <Link
+                            href={`/admin/kalkulation/${r.id}/angebot`}
+                            className="rounded-lg p-1.5 text-gray-400 transition hover:bg-gray-100 hover:text-gray-600"
+                            title="Kundenansicht öffnen"
+                          >
+                            <FileText className="h-4 w-4" />
+                          </Link>
+                          <Link
+                            href={`/admin/kalkulation/${r.id}`}
+                            className="rounded-lg p-1.5 text-gray-400 transition hover:bg-gray-100 hover:text-gray-600"
+                            title="Kalkulation öffnen"
+                          >
+                            <ExternalLink className="h-4 w-4" />
+                          </Link>
+                          <button
+                            onClick={() => remove(r.id)}
+                            className="rounded-lg p-1.5 transition hover:bg-red-50"
+                            style={{ color: confirmDelete === r.id ? COLORS.danger : '#9ca3af' }}
+                            title={confirmDelete === r.id ? 'Wirklich löschen? Erneut klicken.' : 'Löschen'}
+                          >
+                            {confirmDelete === r.id ? <span className="px-1 text-xs font-bold">Sicher?</span> : <Trash2 className="h-4 w-4" />}
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </SectionCard>
+    </AdminShell>
+  );
+}

--- a/src/app/api/admin/calculations/[id]/route.ts
+++ b/src/app/api/admin/calculations/[id]/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from 'next/server';
+import { getCalculation, updateCalculation, deleteCalculation, type CalculationUpdate } from '@/lib/calculationStore';
+import { getCurrentRates } from '@/lib/fxRates';
+import { compareEk } from '@/lib/calcModel';
+
+/** GET → Kalkulation inkl. `fx`-Vergleich und aktuellem Kursstand. */
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const calc = await getCalculation(id);
+  if (!calc) return NextResponse.json({ success: false, error: 'Kalkulation nicht gefunden' }, { status: 404 });
+  const current = await getCurrentRates();
+  return NextResponse.json({
+    success: true,
+    data: { ...calc, fx: compareEk(calc.items, calc.target_currency, calc.rates_snapshot, current) },
+    current_rates: current,
+  });
+}
+
+/**
+ * PATCH { …Felder } → aktualisiert die Kalkulation.
+ * Sonderfall { refresh_rates: true }: schreibt den Kurs-Snapshot neu auf den
+ * aktuellen Stand fest (neue Kalkulationsbasis).
+ */
+export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const body = (await req.json().catch(() => ({}))) as CalculationUpdate & { refresh_rates?: boolean };
+
+  const updates: CalculationUpdate = {};
+  for (const key of ['title', 'customer_id', 'booking_id', 'target_currency', 'margin_mode', 'margin_value', 'items', 'status', 'notes'] as const) {
+    if (key in body) updates[key] = body[key];
+  }
+  if (body.refresh_rates === true) {
+    const current = await getCurrentRates(true);
+    if (!current) {
+      return NextResponse.json({ success: false, error: 'Wechselkurse sind aktuell nicht abrufbar' }, { status: 502 });
+    }
+    updates.rates_snapshot = current;
+  }
+
+  const calc = await updateCalculation(id, updates);
+  if (!calc) return NextResponse.json({ success: false, error: 'Kalkulation nicht gefunden' }, { status: 404 });
+  const current = await getCurrentRates();
+  return NextResponse.json({
+    success: true,
+    data: { ...calc, fx: compareEk(calc.items, calc.target_currency, calc.rates_snapshot, current) },
+    current_rates: current,
+  });
+}
+
+/** DELETE → Kalkulation löschen. */
+export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const ok = await deleteCalculation(id);
+  if (!ok) return NextResponse.json({ success: false, error: 'Kalkulation nicht gefunden' }, { status: 404 });
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/admin/calculations/rates/route.ts
+++ b/src/app/api/admin/calculations/rates/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+import { getCurrentRates } from '@/lib/fxRates';
+
+/** GET /api/admin/calculations/rates → aktueller Kursstand (für den Editor). */
+export async function GET() {
+  const rates = await getCurrentRates();
+  if (!rates) {
+    return NextResponse.json({ success: false, error: 'Wechselkurse sind aktuell nicht abrufbar' }, { status: 502 });
+  }
+  return NextResponse.json({ success: true, data: rates });
+}

--- a/src/app/api/admin/calculations/route.ts
+++ b/src/app/api/admin/calculations/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+import { listCalculations, createCalculation, type CalculationInput } from '@/lib/calculationStore';
+import { getCurrentRates } from '@/lib/fxRates';
+import { compareEk } from '@/lib/calcModel';
+import { getSessionEmployee } from '@/lib/serverSession';
+
+/**
+ * GET /api/admin/calculations → Liste aller Angebotskalkulationen,
+ * je Zeile inkl. `fx` (EK-Veränderung Snapshot vs. aktuelle Kurse).
+ */
+export async function GET() {
+  const [rows, current] = await Promise.all([listCalculations(), getCurrentRates()]);
+  const data = rows.map((r) => ({
+    ...r,
+    fx: compareEk(r.items, r.target_currency, r.rates_snapshot, current),
+  }));
+  return NextResponse.json({ success: true, data, current_rates: current });
+}
+
+/**
+ * POST /api/admin/calculations { title?, customer_id?, booking_id?, target_currency?,
+ * margin_mode?, margin_value?, items?, notes?, status? }
+ * → legt eine Kalkulation an; die zum Zeitpunkt gültigen Wechselkurse werden
+ * als Snapshot festgeschrieben.
+ */
+export async function POST(req: Request) {
+  const body = (await req.json().catch(() => ({}))) as CalculationInput;
+  const ctx = await getSessionEmployee().catch(() => null);
+  const snapshot = await getCurrentRates();
+  const calc = await createCalculation(body, snapshot, ctx?.employee?.name || ctx?.session?.name || '');
+  if (!calc) return NextResponse.json({ success: false, error: 'Kalkulation konnte nicht angelegt werden' }, { status: 500 });
+  return NextResponse.json({
+    success: true,
+    data: calc,
+    rates_unavailable: !snapshot,
+  });
+}

--- a/src/components/admin/AdminShell.tsx
+++ b/src/components/admin/AdminShell.tsx
@@ -8,7 +8,7 @@ import {
   LayoutDashboard, Inbox, KanbanSquare, Wallet,
   CalendarDays, Layers, Package, HelpCircle, Tag, MapPin,
   Mail, Settings, LogOut, Menu, Bell, AtSign, MessageSquare, StickyNote, UserPlus, Check,
-  Users, Timer, Plane, ListTodo, Trophy, Sparkles, Contact, Activity, Globe, Code2, Wand2, KeyRound, FileClock } from 'lucide-react';
+  Users, Timer, Plane, ListTodo, Trophy, Sparkles, Contact, Activity, Globe, Code2, Wand2, KeyRound, FileClock, Calculator } from 'lucide-react';
 import { COLORS } from './ui';
 
 async function doLogout() {
@@ -36,6 +36,7 @@ const NAV: NavGroup[] = [
       { href: '/admin/buchungen', label: 'Buchungen', icon: <Inbox className={ICON} /> },
       { href: '/admin/crm', label: 'CRM', icon: <KanbanSquare className={ICON} /> },
       { href: '/admin/kunden', label: 'Kunden', icon: <Contact className={ICON} /> },
+      { href: '/admin/kalkulation', label: 'Kalkulation', icon: <Calculator className={ICON} /> },
       { href: '/admin/incentive', label: 'Incentive Builder', icon: <Wand2 className={ICON} /> },
       { href: '/admin/finanzen', label: 'Finanzen', icon: <Wallet className={ICON} /> },
     ],

--- a/src/lib/calcModel.ts
+++ b/src/lib/calcModel.ts
@@ -1,0 +1,189 @@
+/**
+ * calcModel.ts — Reine Domänen-Logik der Angebotskalkulation (TASK-00115).
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Client- UND serverseitig nutzbar (keine DB-/Node-Abhängigkeiten):
+ * Kategorien, Positions-Typ, Summen-/Margen-Berechnung und der Vergleich
+ * Kurs-Snapshot vs. aktuelle Kurse (Basis für den FX-Alert).
+ */
+import { convertAmount, isCalcCurrency, type CalcCurrency, type RatesSnapshot } from './fxRates';
+
+/* ─── Kategorien ─────────────────────────────────────────────────────────── */
+
+export const CALC_CATEGORIES = [
+  { id: 'ticket', label: 'Ticket' },
+  { id: 'hotel', label: 'Unterkunft (Hotel)' },
+  { id: 'flug', label: 'Anreise (Flug)' },
+  { id: 'transfer', label: 'Transfer' },
+  { id: 'reisefuehrer', label: 'Reiseführer' },
+  { id: 'extras', label: 'Extras' },
+  { id: 'gifts', label: 'Gifts' },
+] as const;
+
+export type CalcCategoryId = (typeof CALC_CATEGORIES)[number]['id'];
+
+export function categoryLabel(id: string): string {
+  return CALC_CATEGORIES.find((c) => c.id === id)?.label || id;
+}
+
+/* ─── Positionen ─────────────────────────────────────────────────────────── */
+
+export interface CalcItem {
+  id: string;
+  category: string;
+  description: string;
+  currency: CalcCurrency;
+  /** EK je Einheit in `currency`. */
+  amount: number;
+  /** Menge (z. B. 4 Tickets à 500 USD), Default 1. */
+  qty: number;
+}
+
+export type MarginMode = 'percent' | 'fixed';
+
+/** EK einer Position (Menge × Einzel-EK) in ihrer Währung. */
+export function itemEk(item: Pick<CalcItem, 'amount' | 'qty'>): number {
+  const amount = Number(item.amount) || 0;
+  const qty = Number(item.qty) || 0;
+  return amount * qty;
+}
+
+/** Rohdaten (z. B. aus Request-Body) in saubere Positionen überführen. */
+export function sanitizeItems(raw: unknown, fallbackCurrency: CalcCurrency = 'CHF'): CalcItem[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter((it): it is Record<string, unknown> => !!it && typeof it === 'object')
+    .map((it) => ({
+      id: typeof it.id === 'string' && it.id ? it.id : crypto.randomUUID(),
+      category: typeof it.category === 'string' && it.category ? it.category : 'extras',
+      description: typeof it.description === 'string' ? it.description : '',
+      currency: isCalcCurrency(it.currency) ? it.currency : fallbackCurrency,
+      amount: Math.max(0, Number(it.amount) || 0),
+      qty: Math.max(0, Number(it.qty) || 0) || 1,
+    }));
+}
+
+/* ─── Summen & Marge ─────────────────────────────────────────────────────── */
+
+export interface CalcTotals {
+  /** EK gesamt in der Zielwährung. */
+  ekTarget: number;
+  /** Marge absolut in der Zielwährung. */
+  marginAmount: number;
+  /** Marge in % vom EK (bei Fixbetrag: effektiver Prozentsatz). */
+  marginPercent: number;
+  /** Verkaufspreis gesamt (EK + Marge) in der Zielwährung. */
+  vkTarget: number;
+  /** EK-Anteile je Eingabewährung (Summe in Währung + umgerechnet). */
+  byCurrency: Array<{ currency: CalcCurrency; sum: number; inTarget: number }>;
+}
+
+/** Summen + Marge auf Basis eines Kurs-Stands. Ohne Kurse → null (UI zeigt Hinweis). */
+export function computeTotals(
+  items: CalcItem[],
+  target: CalcCurrency,
+  rates: RatesSnapshot | null,
+  marginMode: MarginMode,
+  marginValue: number
+): CalcTotals | null {
+  if (!rates) return null;
+  const byCurrencyMap = new Map<CalcCurrency, number>();
+  let ekTarget = 0;
+  for (const item of items) {
+    const ek = itemEk(item);
+    if (ek <= 0) continue;
+    byCurrencyMap.set(item.currency, (byCurrencyMap.get(item.currency) || 0) + ek);
+    ekTarget += convertAmount(ek, item.currency, target, rates);
+  }
+  const value = Math.max(0, Number(marginValue) || 0);
+  const marginAmount = marginMode === 'fixed' ? value : (ekTarget * value) / 100;
+  const marginPercent = marginMode === 'percent' ? value : ekTarget > 0 ? (marginAmount / ekTarget) * 100 : 0;
+  return {
+    ekTarget,
+    marginAmount,
+    marginPercent,
+    vkTarget: ekTarget + marginAmount,
+    byCurrency: Array.from(byCurrencyMap.entries()).map(([currency, sum]) => ({
+      currency,
+      sum,
+      inTarget: convertAmount(sum, currency, target, rates),
+    })),
+  };
+}
+
+/* ─── FX-Vergleich (Snapshot vs. aktuell) ────────────────────────────────── */
+
+export interface FxComparison {
+  snapshotDate: string;
+  currentDate: string;
+  /** EK gesamt in Zielwährung zu Snapshot-Kursen. */
+  ekAtSnapshot: number;
+  /** EK gesamt in Zielwährung zu aktuellen Kursen. */
+  ekAtCurrent: number;
+  /** Differenz absolut (aktuell − Snapshot); > 0 = EK teurer geworden. */
+  diffAbs: number;
+  /** Differenz in %; > 0 = EK teurer (rot), < 0 = EK günstiger (grün). */
+  diffPct: number;
+  /** Kursveränderung je verwendeter Fremdwährung (ggü. Zielwährung). */
+  perCurrency: Array<{ currency: CalcCurrency; ratePct: number }>;
+}
+
+/**
+ * Vergleicht den EK der Kalkulation zu Snapshot- vs. aktuellen Kursen.
+ * null, wenn Kurse fehlen oder es (noch) keinen umrechenbaren EK gibt.
+ */
+export function compareEk(
+  items: CalcItem[],
+  target: CalcCurrency,
+  snapshot: RatesSnapshot | null,
+  current: RatesSnapshot | null
+): FxComparison | null {
+  if (!snapshot || !current) return null;
+  let ekAtSnapshot = 0;
+  let ekAtCurrent = 0;
+  const used = new Set<CalcCurrency>();
+  for (const item of items) {
+    const ek = itemEk(item);
+    if (ek <= 0) continue;
+    used.add(item.currency);
+    ekAtSnapshot += convertAmount(ek, item.currency, target, snapshot);
+    ekAtCurrent += convertAmount(ek, item.currency, target, current);
+  }
+  if (ekAtSnapshot <= 0) return null;
+  const diffAbs = ekAtCurrent - ekAtSnapshot;
+  const perCurrency: FxComparison['perCurrency'] = [];
+  for (const currency of used) {
+    if (currency === target) continue;
+    const crossSnap = convertAmount(1, currency, target, snapshot);
+    const crossCur = convertAmount(1, currency, target, current);
+    if (crossSnap > 0 && crossCur > 0) {
+      perCurrency.push({ currency, ratePct: ((crossCur - crossSnap) / crossSnap) * 100 });
+    }
+  }
+  return {
+    snapshotDate: snapshot.date,
+    currentDate: current.date,
+    ekAtSnapshot,
+    ekAtCurrent,
+    diffAbs,
+    diffPct: (diffAbs / ekAtSnapshot) * 100,
+    perCurrency,
+  };
+}
+
+/* ─── Formatierung ───────────────────────────────────────────────────────── */
+
+/** Geldbetrag formatiert (de-CH: 12'345.60). */
+export function fmtMoney(n: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat('de-CH', { style: 'currency', currency, minimumFractionDigits: 2 }).format(n || 0);
+  } catch {
+    return `${currency} ${(n || 0).toFixed(2)}`;
+  }
+}
+
+/** Prozentwert mit Vorzeichen, z. B. "+2,1 %" / "−1,4 %". */
+export function fmtPct(p: number, digits = 1): string {
+  const v = Number.isFinite(p) ? p : 0;
+  const s = v.toFixed(digits).replace('.', ',');
+  return `${v > 0 ? '+' : ''}${s} %`;
+}

--- a/src/lib/calculationStore.ts
+++ b/src/lib/calculationStore.ts
@@ -1,0 +1,225 @@
+/**
+ * calculationStore.ts — Angebotskalkulationen (TASK-00115).
+ * ─────────────────────────────────────────────────────────────────────────────
+ * EK-Kalkulation für Arrangements: Positionen je Kategorie mit EK in
+ * EUR/USD/CHF/GBP, Kurs-Snapshot zum Erstellzeitpunkt, Marge (Prozent oder
+ * Fixbetrag), optionale Zuordnung zu Kunde (CRM) und Anfrage (RQ-Nummer).
+ * Läuft über die Backend-Abstraktion `dbq` (SQLite ODER Postgres).
+ * Schema: database.initDatabase() (SQLite) bzw. dbq.applyPgSchemaEnhancements() (PG).
+ */
+import './database';
+import { dbGet, dbAll, dbRun } from './dbq';
+import { isCalcCurrency, type CalcCurrency, type RatesSnapshot } from './fxRates';
+import { sanitizeItems, type CalcItem, type MarginMode } from './calcModel';
+
+export type CalcStatus = 'entwurf' | 'aktiv' | 'archiviert';
+
+export interface OfferCalculation {
+  id: string;
+  calc_number: string;
+  created_at: string;
+  updated_at: string;
+  title: string;
+  customer_id: string | null;
+  booking_id: string | null;
+  target_currency: CalcCurrency;
+  margin_mode: MarginMode;
+  margin_value: number;
+  items: CalcItem[];
+  rates_snapshot: RatesSnapshot | null;
+  status: CalcStatus;
+  notes: string;
+  created_by: string;
+}
+
+/** Listen-/Detailzeile inkl. Kunde + Anfrage (JOIN). */
+export interface OfferCalculationRow extends OfferCalculation {
+  customer_name: string | null;
+  request_number: string | null;
+  package_title: string | null;
+}
+
+interface DbRow {
+  id: string;
+  calc_number: string | null;
+  created_at: string;
+  updated_at: string;
+  title: string;
+  customer_id: string | null;
+  booking_id: string | null;
+  target_currency: string;
+  margin_mode: string;
+  margin_value: number;
+  items: string;
+  rates_snapshot: string;
+  status: string;
+  notes: string;
+  created_by: string;
+  customer_name?: string | null;
+  request_number?: string | null;
+  package_title?: string | null;
+}
+
+function normStatus(s: unknown): CalcStatus {
+  return s === 'aktiv' || s === 'archiviert' ? s : 'entwurf';
+}
+
+function normMarginMode(m: unknown): MarginMode {
+  return m === 'fixed' ? 'fixed' : 'percent';
+}
+
+function normMarginValue(v: unknown): number {
+  const n = Number(v);
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return Math.min(n, 1_000_000);
+}
+
+function parseRow(r: DbRow): OfferCalculationRow {
+  let items: CalcItem[] = [];
+  try {
+    items = sanitizeItems(JSON.parse(r.items || '[]'));
+  } catch {
+    items = [];
+  }
+  let snapshot: RatesSnapshot | null = null;
+  try {
+    snapshot = r.rates_snapshot ? (JSON.parse(r.rates_snapshot) as RatesSnapshot) : null;
+    if (snapshot && (!snapshot.rates || typeof snapshot.rates !== 'object')) snapshot = null;
+  } catch {
+    snapshot = null;
+  }
+  return {
+    id: r.id,
+    calc_number: r.calc_number || '',
+    created_at: r.created_at,
+    updated_at: r.updated_at,
+    title: r.title || '',
+    customer_id: r.customer_id || null,
+    booking_id: r.booking_id || null,
+    target_currency: isCalcCurrency(r.target_currency) ? r.target_currency : 'CHF',
+    margin_mode: normMarginMode(r.margin_mode),
+    margin_value: normMarginValue(r.margin_value),
+    items,
+    rates_snapshot: snapshot,
+    status: normStatus(r.status),
+    notes: r.notes || '',
+    created_by: r.created_by || '',
+    customer_name: r.customer_name ?? null,
+    request_number: r.request_number ?? null,
+    package_title: r.package_title ?? null,
+  };
+}
+
+/** Nächste fortlaufende Kalkulationsnummer "KALK-1001" (atomar). */
+export async function nextCalcNumber(): Promise<string> {
+  const row = await dbGet<{ value: number }>(
+    `UPDATE counters SET value = value + 1 WHERE name = ? RETURNING value`,
+    ['calculation_number']
+  );
+  return `KALK-${row?.value ?? Date.now()}`;
+}
+
+const SELECT_SQL = `
+  SELECT oc.*, c.name AS customer_name, b.request_number AS request_number, b.package_title AS package_title
+  FROM offer_calculations oc
+  LEFT JOIN customers c ON c.id = oc.customer_id
+  LEFT JOIN booking_requests b ON b.id = oc.booking_id`;
+
+export async function listCalculations(): Promise<OfferCalculationRow[]> {
+  const rows = await dbAll<DbRow>(`${SELECT_SQL} ORDER BY oc.created_at DESC`);
+  return rows.map(parseRow);
+}
+
+export async function getCalculation(id: string): Promise<OfferCalculationRow | null> {
+  const row = await dbGet<DbRow>(`${SELECT_SQL} WHERE oc.id = ?`, [id]);
+  return row ? parseRow(row) : null;
+}
+
+export interface CalculationInput {
+  title?: unknown;
+  customer_id?: unknown;
+  booking_id?: unknown;
+  target_currency?: unknown;
+  margin_mode?: unknown;
+  margin_value?: unknown;
+  items?: unknown;
+  status?: unknown;
+  notes?: unknown;
+}
+
+function normTarget(c: unknown): CalcCurrency {
+  return isCalcCurrency(c) ? c : 'CHF';
+}
+
+function normIdRef(v: unknown): string | null {
+  const s = typeof v === 'string' ? v.trim() : '';
+  return s ? s : null;
+}
+
+export async function createCalculation(
+  input: CalculationInput,
+  snapshot: RatesSnapshot | null,
+  createdBy: string
+): Promise<OfferCalculationRow | null> {
+  const id = crypto.randomUUID();
+  const now = new Date().toISOString();
+  const target = normTarget(input.target_currency);
+  await dbRun(
+    `INSERT INTO offer_calculations (
+      id, calc_number, created_at, updated_at, title, customer_id, booking_id,
+      target_currency, margin_mode, margin_value, items, rates_snapshot, status, notes, created_by
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      id,
+      await nextCalcNumber(),
+      now,
+      now,
+      typeof input.title === 'string' ? input.title.trim() : '',
+      normIdRef(input.customer_id),
+      normIdRef(input.booking_id),
+      target,
+      normMarginMode(input.margin_mode),
+      normMarginValue(input.margin_value),
+      JSON.stringify(sanitizeItems(input.items, target)),
+      snapshot ? JSON.stringify(snapshot) : '',
+      normStatus(input.status),
+      typeof input.notes === 'string' ? input.notes : '',
+      createdBy || '',
+    ]
+  );
+  return getCalculation(id);
+}
+
+export type CalculationUpdate = CalculationInput & { rates_snapshot?: RatesSnapshot };
+
+export async function updateCalculation(id: string, updates: CalculationUpdate): Promise<OfferCalculationRow | null> {
+  const existing = await getCalculation(id);
+  if (!existing) return null;
+
+  const sets: string[] = [];
+  const vals: unknown[] = [];
+  const target = 'target_currency' in updates ? normTarget(updates.target_currency) : existing.target_currency;
+
+  if ('title' in updates) { sets.push('title = ?'); vals.push(typeof updates.title === 'string' ? updates.title.trim() : ''); }
+  if ('customer_id' in updates) { sets.push('customer_id = ?'); vals.push(normIdRef(updates.customer_id)); }
+  if ('booking_id' in updates) { sets.push('booking_id = ?'); vals.push(normIdRef(updates.booking_id)); }
+  if ('target_currency' in updates) { sets.push('target_currency = ?'); vals.push(target); }
+  if ('margin_mode' in updates) { sets.push('margin_mode = ?'); vals.push(normMarginMode(updates.margin_mode)); }
+  if ('margin_value' in updates) { sets.push('margin_value = ?'); vals.push(normMarginValue(updates.margin_value)); }
+  if ('items' in updates) { sets.push('items = ?'); vals.push(JSON.stringify(sanitizeItems(updates.items, target))); }
+  if ('status' in updates) { sets.push('status = ?'); vals.push(normStatus(updates.status)); }
+  if ('notes' in updates) { sets.push('notes = ?'); vals.push(typeof updates.notes === 'string' ? updates.notes : ''); }
+  if (updates.rates_snapshot) { sets.push('rates_snapshot = ?'); vals.push(JSON.stringify(updates.rates_snapshot)); }
+
+  if (sets.length) {
+    sets.push(`updated_at = ?`);
+    vals.push(new Date().toISOString());
+    await dbRun(`UPDATE offer_calculations SET ${sets.join(', ')} WHERE id = ?`, [...vals, id]);
+  }
+  return getCalculation(id);
+}
+
+export async function deleteCalculation(id: string): Promise<boolean> {
+  const { changes } = await dbRun(`DELETE FROM offer_calculations WHERE id = ?`, [id]);
+  return changes > 0;
+}

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -233,6 +233,28 @@ export function initDatabase() {
     CREATE INDEX IF NOT EXISTS idx_cdoc_customer ON customer_documents(customer_id);
     CREATE INDEX IF NOT EXISTS idx_cdoc_booking ON customer_documents(booking_id);
 
+    -- Angebotskalkulationen: EK je Position in EUR/USD/CHF/GBP, Kurs-Snapshot
+    -- zum Erstellzeitpunkt, Marge (percent|fixed). Positionen/Kurse als JSON-TEXT.
+    CREATE TABLE IF NOT EXISTS offer_calculations (
+      id TEXT PRIMARY KEY,
+      calc_number TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      title TEXT NOT NULL DEFAULT '',
+      customer_id TEXT,
+      booking_id TEXT,
+      target_currency TEXT NOT NULL DEFAULT 'CHF',
+      margin_mode TEXT NOT NULL DEFAULT 'percent',
+      margin_value REAL NOT NULL DEFAULT 0,
+      items TEXT NOT NULL DEFAULT '[]',
+      rates_snapshot TEXT NOT NULL DEFAULT '',
+      status TEXT NOT NULL DEFAULT 'entwurf',
+      notes TEXT NOT NULL DEFAULT '',
+      created_by TEXT NOT NULL DEFAULT ''
+    );
+    CREATE INDEX IF NOT EXISTS idx_offer_calcs_customer ON offer_calculations(customer_id);
+    CREATE INDEX IF NOT EXISTS idx_offer_calcs_booking ON offer_calculations(booking_id);
+
     -- Incentive Builder: gespeicherte KI-Reisepläne (brief/plan als JSON-TEXT).
     CREATE TABLE IF NOT EXISTS incentive_plans (
       id TEXT PRIMARY KEY,
@@ -549,6 +571,7 @@ export function initDatabase() {
 
   sqlite.prepare(`INSERT OR IGNORE INTO counters (name, value) VALUES ('request_number', 10000)`).run();
   sqlite.prepare(`INSERT OR IGNORE INTO counters (name, value) VALUES ('booking_number', 1000)`).run();
+  sqlite.prepare(`INSERT OR IGNORE INTO counters (name, value) VALUES ('calculation_number', 1000)`).run();
 }
 
 // Initialisierung nur zur Laufzeit (nicht während `next build`).

--- a/src/lib/dbq.ts
+++ b/src/lib/dbq.ts
@@ -340,6 +340,27 @@ export async function applyPgSchemaEnhancements(): Promise<void> {
         revoked integer NOT NULL DEFAULT 0
       )`);
       await pool.query(`CREATE INDEX IF NOT EXISTS idx_api_keys_hash ON api_keys(key_hash)`);
+      // Angebotskalkulationen (EK in Fremdwährungen, Kurs-Snapshot, Marge) — TASK-00115
+      await pool.query(`CREATE TABLE IF NOT EXISTS offer_calculations (
+        id text PRIMARY KEY,
+        calc_number text,
+        created_at text NOT NULL DEFAULT ${NOW_ISO_PG},
+        updated_at text NOT NULL DEFAULT ${NOW_ISO_PG},
+        title text NOT NULL DEFAULT '',
+        customer_id text,
+        booking_id text,
+        target_currency text NOT NULL DEFAULT 'CHF',
+        margin_mode text NOT NULL DEFAULT 'percent',
+        margin_value double precision NOT NULL DEFAULT 0,
+        items text NOT NULL DEFAULT '[]',
+        rates_snapshot text NOT NULL DEFAULT '',
+        status text NOT NULL DEFAULT 'entwurf',
+        notes text NOT NULL DEFAULT '',
+        created_by text NOT NULL DEFAULT ''
+      )`);
+      await pool.query(`CREATE INDEX IF NOT EXISTS idx_offer_calcs_customer ON offer_calculations(customer_id)`);
+      await pool.query(`CREATE INDEX IF NOT EXISTS idx_offer_calcs_booking ON offer_calculations(booking_id)`);
+      await pool.query(`INSERT INTO counters (name, value) SELECT 'calculation_number', 1000 WHERE NOT EXISTS (SELECT 1 FROM counters WHERE name = 'calculation_number')`);
       // Benachrichtigungs-Center (Glocke im Admin)
       await pool.query(`CREATE TABLE IF NOT EXISTS admin_notifications (
         id text PRIMARY KEY,

--- a/src/lib/fxRates.ts
+++ b/src/lib/fxRates.ts
@@ -1,0 +1,103 @@
+/**
+ * fxRates.ts — Wechselkurse für die Angebotskalkulation (TASK-00115).
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Holt aktuelle Referenzkurse (EZB via frankfurter.dev, Fallback open.er-api.com)
+ * und cached sie in-process (~30 min). Kurse sind EUR-basiert gespeichert
+ * (Einheiten je 1 EUR); Umrechnung beliebiger Paare über Kreuzkurs.
+ *
+ * Die reinen Rechen-Helfer (convertAmount) sind client-safe — der eigentliche
+ * Abruf (getCurrentRates) läuft nur serverseitig in API-Routen.
+ */
+
+export const CALC_CURRENCIES = ['EUR', 'USD', 'CHF', 'GBP'] as const;
+export type CalcCurrency = (typeof CALC_CURRENCIES)[number];
+
+export function isCalcCurrency(c: unknown): c is CalcCurrency {
+  return typeof c === 'string' && (CALC_CURRENCIES as readonly string[]).includes(c);
+}
+
+export interface RatesSnapshot {
+  base: 'EUR';
+  /** Kursdatum laut Quelle (EZB-Referenzkurs), z. B. "2026-07-28". */
+  date: string;
+  /** Zeitpunkt des Abrufs (ISO). */
+  fetched_at: string;
+  source: string;
+  /** Einheiten je 1 EUR (EUR: 1). */
+  rates: Record<CalcCurrency, number>;
+}
+
+/** Betrag von `from` nach `to` über den EUR-Kreuzkurs umrechnen. */
+export function convertAmount(amount: number, from: string, to: string, snapshot: RatesSnapshot): number {
+  if (from === to) return amount;
+  const rf = snapshot.rates[from as CalcCurrency];
+  const rt = snapshot.rates[to as CalcCurrency];
+  if (!rf || !rt || !Number.isFinite(amount)) return 0;
+  return (amount / rf) * rt;
+}
+
+// ───────────────────────── Abruf + Cache (nur Server) ─────────────────────────
+
+const TTL_MS = 30 * 60 * 1000;
+let cache: { at: number; snapshot: RatesSnapshot } | null = null;
+
+function buildSnapshot(date: string, source: string, r: Record<string, number>): RatesSnapshot {
+  return {
+    base: 'EUR',
+    date,
+    fetched_at: new Date().toISOString(),
+    source,
+    rates: { EUR: 1, USD: r.USD, CHF: r.CHF, GBP: r.GBP },
+  };
+}
+
+/** Primärquelle: EZB-Referenzkurse via frankfurter.dev (kein API-Key nötig). */
+async function fetchFrankfurter(): Promise<RatesSnapshot> {
+  const res = await fetch('https://api.frankfurter.dev/v1/latest?symbols=USD,CHF,GBP', {
+    signal: AbortSignal.timeout(8000),
+    cache: 'no-store',
+  });
+  if (!res.ok) throw new Error(`frankfurter HTTP ${res.status}`);
+  const json = (await res.json()) as { base?: string; date?: string; rates?: Record<string, number> };
+  const r = json.rates || {};
+  if (json.base !== 'EUR' || !r.USD || !r.CHF || !r.GBP) throw new Error('frankfurter: unerwartete Antwort');
+  return buildSnapshot(json.date || new Date().toISOString().slice(0, 10), 'EZB-Referenzkurse (frankfurter.dev)', r);
+}
+
+/** Fallback: open.er-api.com (täglich aktualisiert, kein Key). */
+async function fetchErApi(): Promise<RatesSnapshot> {
+  const res = await fetch('https://open.er-api.com/v6/latest/EUR', {
+    signal: AbortSignal.timeout(8000),
+    cache: 'no-store',
+  });
+  if (!res.ok) throw new Error(`er-api HTTP ${res.status}`);
+  const json = (await res.json()) as { result?: string; time_last_update_unix?: number; rates?: Record<string, number> };
+  const r = json.rates || {};
+  if (json.result !== 'success' || !r.USD || !r.CHF || !r.GBP) throw new Error('er-api: unerwartete Antwort');
+  const date = json.time_last_update_unix
+    ? new Date(json.time_last_update_unix * 1000).toISOString().slice(0, 10)
+    : new Date().toISOString().slice(0, 10);
+  return buildSnapshot(date, 'open.er-api.com', r);
+}
+
+/**
+ * Aktuelle Kurse (gecacht, ~30 min). Bei Abruf-Fehlern wird der letzte
+ * bekannte Stand geliefert; ganz ohne Daten → null (Aufrufer zeigen Hinweis).
+ */
+export async function getCurrentRates(force = false): Promise<RatesSnapshot | null> {
+  if (!force && cache && Date.now() - cache.at < TTL_MS) return cache.snapshot;
+  try {
+    const s = await fetchFrankfurter();
+    cache = { at: Date.now(), snapshot: s };
+    return s;
+  } catch (e1) {
+    try {
+      const s = await fetchErApi();
+      cache = { at: Date.now(), snapshot: s };
+      return s;
+    } catch (e2) {
+      console.warn('[fx] Kursabruf fehlgeschlagen:', (e1 as Error).message, '/', (e2 as Error).message);
+      return cache?.snapshot ?? null;
+    }
+  }
+}


### PR DESCRIPTION
- Neues Admin-Tool /admin/kalkulation: Positionen je Kategorie (Ticket, Hotel,
  Flug, Transfer, Reiseführer, Extras, Gifts), EK je Position in EUR/USD/CHF/GBP, Menge
- EZB-Kurse (frankfurter.dev, Fallback open.er-api.com) werden beim Anlegen als
  Snapshot festgeschrieben; Übersicht + Editor zeigen grün/rot-Alert mit %-Abweichung,
  wenn Kursbewegungen den EK verändern (Badge ab ±1 %), inkl. "Kurse neu festschreiben"
- Marge prozentual (Slider 0–200 %) oder Fixbetrag — der jeweils andere Wert wird mitberechnet
- Kundenansicht (Druck/PDF): nur Leistungen + Gesamtpreis in Zielwährung, ohne EK/Marge
- Zuordnung zu Kunde (CRM) und Anfrage (RQ); Schema SQLite + Postgres
  (offer_calculations, Counter calculation_number -> KALK-1001 ff.)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019oSJqEsFF6BXDUkeYJFhZf
