### PR TITLE
feat(admin): Mediathek - alle Server-Dateien mit oeffentlicher URL (TASK-00120)

### DIFF
--- a/src/app/admin/events/page.tsx
+++ b/src/app/admin/events/page.tsx
@@ -1103,21 +1103,47 @@ export default function AdminEventsPage() {
                         {form.auto_reply_pdfs.length > 0 ? (
                           <div className="mt-2 grid gap-2">
                             {form.auto_reply_pdfs.map((pdf, idx) => (
-                              <div key={`${pdf.file}-${idx}`} className="flex items-center justify-between gap-3 rounded-lg px-3 py-2 text-sm" style={{ background: '#f0fdf4', color: COLORS.navy }}>
-                                <span className="min-w-0 truncate">
-                                  📎 {pdf.name || pdf.file}
-                                  {formatFileSize(pdf.size) && (
-                                    <span className="ml-1.5 text-xs" style={{ color: COLORS.textMuted }}>· {formatFileSize(pdf.size)}</span>
-                                  )}
-                                </span>
-                                <button
-                                  type="button"
-                                  className="shrink-0 text-xs font-semibold underline"
-                                  style={{ color: COLORS.danger }}
-                                  onClick={() => setForm((prev) => ({ ...prev, auto_reply_pdfs: prev.auto_reply_pdfs.filter((_, i) => i !== idx) }))}
-                                >
-                                  Entfernen
-                                </button>
+                              <div key={`${pdf.file}-${idx}`} className="rounded-lg px-3 py-2 text-sm" style={{ background: '#f0fdf4', color: COLORS.navy }}>
+                                <div className="flex items-center justify-between gap-3">
+                                  <span className="min-w-0 truncate">
+                                    📎 {pdf.name || pdf.file}
+                                    {formatFileSize(pdf.size) && (
+                                      <span className="ml-1.5 text-xs" style={{ color: COLORS.textMuted }}>· {formatFileSize(pdf.size)}</span>
+                                    )}
+                                  </span>
+                                  <button
+                                    type="button"
+                                    className="shrink-0 text-xs font-semibold underline"
+                                    style={{ color: COLORS.danger }}
+                                    onClick={() => setForm((prev) => ({ ...prev, auto_reply_pdfs: prev.auto_reply_pdfs.filter((_, i) => i !== idx) }))}
+                                  >
+                                    Entfernen
+                                  </button>
+                                </div>
+                                {/* Öffentlicher Link zur Datei (TASK-00120) — z.B. um im Text auf das Angebot zu verlinken. */}
+                                <div className="mt-1 flex items-center gap-2 text-xs">
+                                  <Link2 className="h-3 w-3 shrink-0" style={{ color: COLORS.textMuted }} />
+                                  <a
+                                    href={`/dokumente/${encodeURIComponent(pdf.file)}`}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="min-w-0 truncate underline"
+                                    style={{ color: COLORS.info }}
+                                  >
+                                    /dokumente/{pdf.file}
+                                  </a>
+                                  <button
+                                    type="button"
+                                    className="shrink-0 font-semibold underline"
+                                    style={{ color: COLORS.textMuted }}
+                                    onClick={() => {
+                                      const url = `${window.location.origin}/dokumente/${encodeURIComponent(pdf.file)}`;
+                                      navigator.clipboard?.writeText(url).catch(() => window.prompt('URL kopieren:', url));
+                                    }}
+                                  >
+                                    URL kopieren
+                                  </button>
+                                </div>
                               </div>
                             ))}
                           </div>

--- a/src/app/admin/mediathek/page.tsx
+++ b/src/app/admin/mediathek/page.tsx
@@ -1,0 +1,346 @@
+'use client';
+
+/**
+ * /admin/mediathek — Mediathek: alle Dateien auf dem Webserver (TASK-00120)
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Zeigt sämtliche hochgeladenen Dateien aus allen Ablagen (Bilder, Anhänge der
+ * automatischen Antworten, Kundendokumente, Aufgaben- und Mail-Anhänge) mit
+ * Ablageort, Verwendung und – wo vorhanden – der öffentlichen URL zum Verlinken.
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Check, Copy, Download, ExternalLink, FileText, FolderOpen, Image as ImageIcon,
+  Link2, Paperclip, RefreshCw, Search, Trash2, Upload, Users,
+} from 'lucide-react';
+import AdminShell from '@/components/admin/AdminShell';
+import {
+  Badge, Button, Card, COLORS, EmptyState, PageHeader, SelectInput, Spinner, StatCard, TextInput,
+} from '@/components/admin/ui';
+
+type FileKind = 'bild' | 'anhang' | 'kundendokument' | 'aufgabe' | 'nachricht';
+
+interface InventoryUsage { label: string; href?: string }
+
+interface InventoryFile {
+  id: string;
+  kind: FileKind;
+  name: string;
+  fileName: string;
+  mime: string;
+  size: number;
+  updatedAt: string;
+  publicUrl: string | null;
+  href: string;
+  storage: string;
+  usedIn: InventoryUsage[];
+  missing?: boolean;
+  orphan?: boolean;
+}
+
+interface Inventory {
+  files: InventoryFile[];
+  counts: Record<FileKind, number>;
+  totalBytes: number;
+}
+
+const KIND_LABEL: Record<FileKind, string> = {
+  bild: 'Bilder',
+  anhang: 'Anhänge (Auto-Antwort)',
+  kundendokument: 'Kundendokumente',
+  aufgabe: 'Aufgaben-Anhänge',
+  nachricht: 'Mail-Anhänge',
+};
+
+const KIND_ICON: Record<FileKind, React.ReactNode> = {
+  bild: <ImageIcon className="h-4 w-4" />,
+  anhang: <Paperclip className="h-4 w-4" />,
+  kundendokument: <Users className="h-4 w-4" />,
+  aufgabe: <FileText className="h-4 w-4" />,
+  nachricht: <FileText className="h-4 w-4" />,
+};
+
+function formatBytes(bytes: number): string {
+  if (!bytes) return '—';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function formatDate(iso: string): string {
+  if (!iso) return '—';
+  const d = new Date(iso.includes('T') ? iso : iso.replace(' ', 'T') + 'Z');
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString('de-CH', { day: '2-digit', month: '2-digit', year: 'numeric' });
+}
+
+export default function MediathekPage() {
+  const [inventory, setInventory] = useState<Inventory | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [query, setQuery] = useState('');
+  const [kind, setKind] = useState<FileKind | 'alle'>('alle');
+  const [copied, setCopied] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [uploadMsg, setUploadMsg] = useState('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [origin, setOrigin] = useState('');
+
+  useEffect(() => { setOrigin(window.location.origin); }, []);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const res = await fetch('/api/admin/files').then((r) => r.json());
+      if (!res?.success) throw new Error(res?.error || 'Laden fehlgeschlagen.');
+      setInventory(res.data as Inventory);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const visible = useMemo(() => {
+    const files = inventory?.files || [];
+    const q = query.trim().toLowerCase();
+    return files.filter((f) => {
+      if (kind !== 'alle' && f.kind !== kind) return false;
+      if (!q) return true;
+      return (
+        f.name.toLowerCase().includes(q) ||
+        f.fileName.toLowerCase().includes(q) ||
+        f.storage.toLowerCase().includes(q) ||
+        f.usedIn.some((u) => u.label.toLowerCase().includes(q))
+      );
+    });
+  }, [inventory, query, kind]);
+
+  const copy = async (file: InventoryFile) => {
+    const url = file.publicUrl ? `${origin}${file.publicUrl}` : `${origin}${file.href}`;
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(file.id);
+      setTimeout(() => setCopied((c) => (c === file.id ? null : c)), 1800);
+    } catch {
+      window.prompt('URL kopieren:', url);
+    }
+  };
+
+  const upload = async (files: File[]) => {
+    if (files.length === 0) return;
+    setUploading(true);
+    setUploadMsg('');
+    try {
+      for (const file of files) {
+        const fd = new FormData();
+        fd.append('file', file);
+        const res = await fetch('/api/admin/files', { method: 'POST', body: fd }).then((r) => r.json());
+        if (!res?.success) throw new Error(res?.error || 'Upload fehlgeschlagen.');
+      }
+      setUploadMsg(`${files.length} Datei(en) hochgeladen.`);
+      await load();
+    } catch (e) {
+      setUploadMsg((e as Error).message);
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const remove = async (file: InventoryFile) => {
+    if (!window.confirm(`„${file.name}" endgültig vom Server löschen?`)) return;
+    try {
+      const res = await fetch(`/api/admin/files?file=${encodeURIComponent(file.fileName)}`, { method: 'DELETE' })
+        .then((r) => r.json());
+      if (!res?.success) throw new Error(res?.error || 'Löschen fehlgeschlagen.');
+      await load();
+    } catch (e) {
+      window.alert((e as Error).message);
+    }
+  };
+
+  const counts = inventory?.counts;
+
+  return (
+    <AdminShell title="Mediathek" wide>
+      <PageHeader
+        title="Mediathek"
+        description="Alle auf dem Webserver gespeicherten Dateien — mit Ablageort, Verwendung und öffentlicher URL zum Verlinken."
+        actions={
+          <>
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              className="hidden"
+              accept="application/pdf,.pdf,image/jpeg,.jpg,.jpeg,image/png,.png,image/webp,.webp"
+              onChange={(e) => {
+                const files = Array.from(e.target.files || []);
+                upload(files);
+                e.target.value = '';
+              }}
+            />
+            <Button variant="secondary" onClick={load} disabled={loading}>
+              <RefreshCw className="h-4 w-4" /> Aktualisieren
+            </Button>
+            <Button variant="accent" onClick={() => fileInputRef.current?.click()} disabled={uploading}>
+              {uploading ? <Spinner className="h-4 w-4" /> : <Upload className="h-4 w-4" />} Datei hochladen
+            </Button>
+          </>
+        }
+      />
+
+      {uploadMsg && (
+        <div className="mb-4 rounded-xl px-4 py-3 text-sm" style={{ background: '#f0fdf4', color: COLORS.navy }}>
+          {uploadMsg}
+        </div>
+      )}
+
+      {counts && (
+        <div className="mb-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <StatCard icon={<FolderOpen className="h-4 w-4" />} label="Dateien gesamt" value={inventory?.files.length ?? 0} sub={formatBytes(inventory?.totalBytes ?? 0)} />
+          <StatCard icon={<ImageIcon className="h-4 w-4" />} label="Bilder" value={counts.bild} sub="public/uploads/media" tone="info" />
+          <StatCard icon={<Paperclip className="h-4 w-4" />} label="Anhänge Auto-Antwort" value={counts.anhang} sub="data/uploads/auto-reply" tone="accent" />
+          <StatCard icon={<FileText className="h-4 w-4" />} label="Dateien in der Datenbank" value={counts.kundendokument + counts.aufgabe + counts.nachricht} sub="Kunden · Aufgaben · Mails" tone="navy" />
+        </div>
+      )}
+
+      <Card className="mb-4" padded>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <div className="relative flex-1">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2" style={{ color: '#9ca3af' }} />
+            <TextInput
+              className="pl-9"
+              placeholder="Dateiname, Event, Kunde …"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+            />
+          </div>
+          <div className="sm:w-72">
+            <SelectInput value={kind} onChange={(e) => setKind(e.target.value as FileKind | 'alle')}>
+              <option value="alle">Alle Ablagen</option>
+              {(Object.keys(KIND_LABEL) as FileKind[]).map((k) => (
+                <option key={k} value={k}>{KIND_LABEL[k]}{counts ? ` (${counts[k]})` : ''}</option>
+              ))}
+            </SelectInput>
+          </div>
+        </div>
+      </Card>
+
+      {error && (
+        <div className="mb-4 rounded-xl px-4 py-3 text-sm" style={{ background: '#fef2f2', color: COLORS.danger }}>{error}</div>
+      )}
+
+      {loading ? (
+        <div className="flex items-center gap-2 py-12" style={{ color: COLORS.textMuted }}>
+          <Spinner className="h-4 w-4" /> Dateien werden gelesen …
+        </div>
+      ) : visible.length === 0 ? (
+        <EmptyState
+          icon={<FolderOpen className="h-8 w-8" />}
+          title="Keine Dateien gefunden"
+          description="Passe die Suche an oder lade eine Datei hoch."
+        />
+      ) : (
+        <Card padded={false}>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr style={{ background: COLORS.surfaceMuted, color: COLORS.textMuted }}>
+                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider">Datei</th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider">Ablage</th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider">Verwendet in</th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider">Größe</th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider">Datum</th>
+                  <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wider">URL / Aktionen</th>
+                </tr>
+              </thead>
+              <tbody>
+                {visible.map((file) => (
+                  <tr key={file.id} className="border-t align-top" style={{ borderColor: COLORS.stroke }}>
+                    <td className="px-4 py-3">
+                      <div className="flex items-start gap-2">
+                        <span style={{ color: COLORS.textMuted }}>{KIND_ICON[file.kind]}</span>
+                        <div className="min-w-0">
+                          <div className="truncate font-semibold" style={{ color: COLORS.navy }}>{file.name}</div>
+                          <div className="truncate text-xs" style={{ color: COLORS.textMuted }}>{file.fileName}</div>
+                          {file.missing && <Badge tone="danger" className="mt-1">Datei fehlt auf dem Server</Badge>}
+                          {file.orphan && !file.missing && <Badge tone="warn" className="mt-1">nicht verwendet</Badge>}
+                        </div>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3">
+                      <div style={{ color: COLORS.navy }}>{KIND_LABEL[file.kind]}</div>
+                      <div className="text-xs" style={{ color: COLORS.textMuted }}>{file.storage}</div>
+                    </td>
+                    <td className="px-4 py-3">
+                      {file.usedIn.length === 0 ? (
+                        <span className="text-xs" style={{ color: COLORS.textMuted }}>—</span>
+                      ) : (
+                        <div className="grid gap-0.5">
+                          {file.usedIn.map((u, i) =>
+                            u.href ? (
+                              <a key={i} href={u.href} className="text-xs underline" style={{ color: COLORS.info }}>{u.label}</a>
+                            ) : (
+                              <span key={i} className="text-xs" style={{ color: COLORS.textMuted }}>{u.label}</span>
+                            )
+                          )}
+                        </div>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 whitespace-nowrap" style={{ color: COLORS.textMuted }}>{formatBytes(file.size)}</td>
+                    <td className="px-4 py-3 whitespace-nowrap" style={{ color: COLORS.textMuted }}>{formatDate(file.updatedAt)}</td>
+                    <td className="px-4 py-3">
+                      <div className="flex flex-col items-end gap-1.5">
+                        {file.publicUrl ? (
+                          <code className="max-w-[22rem] truncate rounded-lg px-2 py-1 text-xs" style={{ background: COLORS.surfaceMuted, color: COLORS.navy }}>
+                            {origin}{file.publicUrl}
+                          </code>
+                        ) : (
+                          <span className="text-xs" style={{ color: COLORS.textMuted }}>nur mit Login abrufbar</span>
+                        )}
+                        <div className="flex flex-wrap items-center justify-end gap-1.5">
+                          {!file.missing && (
+                            <>
+                              <Button size="sm" variant="secondary" onClick={() => copy(file)}>
+                                {copied === file.id ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+                                {copied === file.id ? 'Kopiert' : file.publicUrl ? 'URL kopieren' : 'Link kopieren'}
+                              </Button>
+                              <a href={file.href} target="_blank" rel="noreferrer">
+                                <Button size="sm" variant="ghost">
+                                  {file.publicUrl ? <ExternalLink className="h-3.5 w-3.5" /> : <Download className="h-3.5 w-3.5" />} Öffnen
+                                </Button>
+                              </a>
+                            </>
+                          )}
+                          {file.kind === 'anhang' && !file.missing && file.usedIn.length === 0 && (
+                            <Button size="sm" variant="danger" onClick={() => remove(file)}>
+                              <Trash2 className="h-3.5 w-3.5" /> Löschen
+                            </Button>
+                          )}
+                        </div>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+      )}
+
+      <div className="mt-6 flex items-start gap-2 rounded-xl px-4 py-3 text-xs" style={{ background: COLORS.surfaceMuted, color: COLORS.textMuted }}>
+        <Link2 className="mt-0.5 h-4 w-4 shrink-0" />
+        <div>
+          <strong style={{ color: COLORS.navy }}>Öffentliche Links:</strong> Bilder liegen unter <code>/uploads/media/…</code>,
+          Anhänge der automatischen Antworten sind über <code>/dokumente/&lt;dateiname&gt;</code> erreichbar — diese URL kann
+          direkt in Mails oder auf der Website verlinkt werden. Kundendokumente, Aufgaben- und Mail-Anhänge liegen in der
+          Datenbank und sind bewusst nur mit Admin-Login abrufbar.
+        </div>
+      </div>
+    </AdminShell>
+  );
+}

--- a/src/app/api/admin/files/route.ts
+++ b/src/app/api/admin/files/route.ts
@@ -1,0 +1,88 @@
+/**
+ * /api/admin/files — Mediathek (TASK-00120)
+ * ─────────────────────────────────────────────────────────────────────────────
+ * GET     Inventar aller auf dem Server gespeicherten Dateien (alle Ablagen).
+ * POST    Datei hochladen (multipart, Feld "file"):
+ *           Bilder  → public/uploads/media   (öffentliche URL /uploads/media/…)
+ *           PDF     → data/uploads/auto-reply (öffentliche URL /dokumente/…)
+ * DELETE  ?file=<name> löscht einen Auto-Antwort-Anhang — nur wenn er in
+ *         keinem Event mehr referenziert ist (Schutz vor kaputten Mailanhängen).
+ *
+ * Auth: greift die Middleware (alles unter /api/admin/* erfordert Session).
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+import { NextResponse } from 'next/server';
+import { deleteAutoReplyPdf, saveAutoReplyPdf, autoReplyPublicPath } from '@/lib/autoReplyStore';
+import { saveUploadedMedia } from '@/lib/mediaLibrary';
+import { listFileInventory } from '@/lib/fileInventory';
+
+const IMAGE_EXT = /\.(jpe?g|png|webp|gif|svg|avif)$/i;
+
+export async function GET() {
+  try {
+    const inventory = await listFileInventory();
+    return NextResponse.json({ success: true, data: inventory });
+  } catch (error) {
+    return NextResponse.json({ success: false, error: (error as Error).message }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const formData = await request.formData();
+    const file = formData.get('file');
+    if (!(file instanceof File)) {
+      return NextResponse.json({ success: false, error: 'Keine Datei erhalten.' }, { status: 400 });
+    }
+
+    // Bilder in die Bild-Mediathek (werden optimiert), alles andere als Dokument.
+    const target = (formData.get('target') as string | null) || (IMAGE_EXT.test(file.name) ? 'bild' : 'dokument');
+
+    if (target === 'bild') {
+      const item = await saveUploadedMedia(file);
+      return NextResponse.json({
+        success: true,
+        data: { kind: 'bild', name: item.name, url: item.url, size: item.size },
+      });
+    }
+
+    const meta = await saveAutoReplyPdf(file);
+    return NextResponse.json({
+      success: true,
+      data: { kind: 'anhang', name: meta.name, url: autoReplyPublicPath(meta.file), size: meta.size },
+    });
+  } catch (error) {
+    return NextResponse.json({ success: false, error: (error as Error).message }, { status: 400 });
+  }
+}
+
+export async function DELETE(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const fileName = searchParams.get('file') || '';
+    if (!fileName) {
+      return NextResponse.json({ success: false, error: 'Parameter "file" fehlt.' }, { status: 400 });
+    }
+
+    const inventory = await listFileInventory();
+    const entry = inventory.files.find((f) => f.kind === 'anhang' && f.fileName === fileName);
+
+    if (!entry) {
+      return NextResponse.json({ success: false, error: 'Datei nicht gefunden.' }, { status: 404 });
+    }
+    if (entry.usedIn.length > 0) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `Datei wird noch verwendet (${entry.usedIn.map((u) => u.label).join(', ')}). Erst im Event entfernen.`,
+        },
+        { status: 409 }
+      );
+    }
+
+    await deleteAutoReplyPdf(fileName);
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    return NextResponse.json({ success: false, error: (error as Error).message }, { status: 500 });
+  }
+}

--- a/src/app/dokumente/[file]/route.ts
+++ b/src/app/dokumente/[file]/route.ts
@@ -1,0 +1,43 @@
+/**
+ * GET /dokumente/<datei>  (TASK-00120)
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Liefert einen in der automatischen Antwort hinterlegten Anhang aus
+ * data/uploads/auto-reply aus — bewusst OHNE Login, damit auf ein Angebots-PDF
+ * direkt verlinkt werden kann (z.B. aus einer Mail oder von WordPress aus).
+ *
+ * Die Dateinamen sind nicht erratbar (Event-Slug + Zeitstempel), es werden
+ * ausschließlich Dateien aus diesem einen Verzeichnis ausgeliefert
+ * (Path-Traversal-Schutz in autoReplyStore.safeStoredName).
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+import { NextResponse } from 'next/server';
+import { readAutoReplyFile } from '@/lib/autoReplyStore';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ file: string }> }
+) {
+  const { file } = await params;
+  const requested = decodeURIComponent(file || '');
+
+  const found = await readAutoReplyFile(requested);
+  if (!found) {
+    return new NextResponse('Datei nicht gefunden', {
+      status: 404,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    });
+  }
+
+  const inline = /^(application\/pdf|image\/)/.test(found.mime);
+  return new NextResponse(new Uint8Array(found.buf), {
+    headers: {
+      'Content-Type': found.mime,
+      'Content-Length': String(found.buf.length),
+      'Content-Disposition': `${inline ? 'inline' : 'attachment'}; filename="${encodeURIComponent(requested)}"`,
+      'Cache-Control': 'public, max-age=3600',
+      'X-Content-Type-Options': 'nosniff',
+    },
+  });
+}

--- a/src/components/admin/AdminShell.tsx
+++ b/src/components/admin/AdminShell.tsx
@@ -8,7 +8,8 @@ import {
   LayoutDashboard, Inbox, KanbanSquare, Wallet,
   CalendarDays, Layers, Package, HelpCircle, Tag, MapPin,
   Mail, Settings, LogOut, Menu, Bell, AtSign, MessageSquare, StickyNote, UserPlus, Check,
-  Users, Timer, Plane, ListTodo, Trophy, Sparkles, Contact, Activity, Globe, Code2, Wand2, KeyRound, FileClock } from 'lucide-react';
+  Users, Timer, Plane, ListTodo, Trophy, Sparkles, Contact, Activity, Globe, Code2, Wand2, KeyRound, FileClock,
+  FolderOpen } from 'lucide-react';
 import { COLORS } from './ui';
 
 async function doLogout() {
@@ -49,6 +50,7 @@ const NAV: NavGroup[] = [
       { href: '/admin/faqs', label: 'FAQs', icon: <HelpCircle className={ICON} /> },
       { href: '/admin/categories', label: 'Kategorien SEO', icon: <Tag className={ICON} /> },
       { href: '/admin/shortcodes', label: 'WP-Shortcodes', icon: <Code2 className={ICON} /> },
+      { href: '/admin/mediathek', label: 'Mediathek', icon: <FolderOpen className={ICON} /> },
       { href: '/admin/pins', label: 'Lageplan-Icons', icon: <MapPin className={ICON} /> },
       { href: '/admin/tippspiel', label: 'WM-Tippspiel', icon: <Trophy className={ICON} /> },
     ],

--- a/src/lib/autoReplyStore.ts
+++ b/src/lib/autoReplyStore.ts
@@ -11,7 +11,7 @@
  * versendet — sie braucht keine öffentliche URL.
  * ─────────────────────────────────────────────────────────────────────────────
  */
-import { mkdir, writeFile, readFile, stat, unlink } from 'fs/promises';
+import { mkdir, writeFile, readFile, readdir, stat, unlink } from 'fs/promises';
 import path from 'path';
 
 const DATA_DIR = path.join(process.cwd(), 'data', 'uploads', 'auto-reply');
@@ -114,4 +114,59 @@ export async function deleteAutoReplyPdf(file: string): Promise<void> {
   const name = safeStoredName(file);
   if (!name) return;
   await unlink(path.join(DATA_DIR, name)).catch(() => {});
+}
+
+/* ─── Mediathek / öffentliche Links (TASK-00120) ──────────────────────────── */
+
+/**
+ * Öffentliche URL eines Anhangs. Die Route /dokumente/<datei> liefert die Datei
+ * aus data/uploads/auto-reply aus (siehe src/app/dokumente/[file]/route.ts) —
+ * damit lässt sich z.B. direkt auf ein Angebots-PDF verlinken.
+ */
+export function autoReplyPublicPath(file: string): string {
+  return `/dokumente/${encodeURIComponent(safeStoredName(file))}`;
+}
+
+export interface AutoReplyStoredFile {
+  /** Dateiname auf der Platte */
+  file: string;
+  size: number;
+  /** mtime als ISO-String */
+  updatedAt: string;
+  mime: string;
+}
+
+/** Alle physisch vorhandenen Auto-Antwort-Anhänge (neueste zuerst). */
+export async function listAutoReplyFiles(): Promise<AutoReplyStoredFile[]> {
+  await mkdir(DATA_DIR, { recursive: true });
+  const entries = await readdir(DATA_DIR, { withFileTypes: true }).catch(() => []);
+  const files = await Promise.all(
+    entries
+      .filter((e) => e.isFile() && !e.name.startsWith('.'))
+      .map(async (e) => {
+        const s = await stat(path.join(DATA_DIR, e.name)).catch(() => null);
+        if (!s) return null;
+        return {
+          file: e.name,
+          size: s.size,
+          updatedAt: s.mtime.toISOString(),
+          mime: autoReplyContentType(e.name),
+        } as AutoReplyStoredFile;
+      })
+  );
+  return files
+    .filter((f): f is AutoReplyStoredFile => Boolean(f))
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+}
+
+/** Liest einen Anhang als Buffer (für die öffentliche Auslieferung). null wenn nicht vorhanden. */
+export async function readAutoReplyFile(file: string): Promise<{ buf: Buffer; mime: string } | null> {
+  const name = safeStoredName(file);
+  if (!name) return null;
+  try {
+    const buf = await readFile(path.join(DATA_DIR, name));
+    return { buf, mime: autoReplyContentType(name) };
+  } catch {
+    return null;
+  }
 }

--- a/src/lib/fileInventory.ts
+++ b/src/lib/fileInventory.ts
@@ -1,0 +1,384 @@
+/**
+ * fileInventory.ts — Mediathek / Datei-Inventar (TASK-00120)
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Sammelt ALLE auf dem Webserver gespeicherten Dateien aus den vier
+ * unterschiedlichen Ablagen an einer Stelle, damit im Admin sichtbar ist,
+ * wo eine Datei liegt und unter welcher URL sie erreichbar ist:
+ *
+ *   1. bild            public/uploads/media + übrige Bilder unter public/   (öffentlich)
+ *   2. anhang          data/uploads/auto-reply  → öffentlich via /dokumente/<datei>
+ *   3. kundendokument  DB-Tabelle customer_documents          (nur mit Login)
+ *   4. aufgabe         DB-Tabelle task_attachments            (nur mit Login)
+ *   5. nachricht       DB-Tabelle booking_message_attachments (nur mit Login)
+ *
+ * „usedIn" zeigt, wo die Datei verwendet wird (Event, Kunde, Aufgabe …).
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+import {
+  autoReplyPublicPath,
+  listAutoReplyFiles,
+  autoReplyContentType,
+} from './autoReplyStore';
+import { listMediaLibrary } from './mediaLibrary';
+import { getEvents, getPackages, getSeries } from './contentStore';
+import { dbAll } from './dbq';
+
+export type FileKind = 'bild' | 'anhang' | 'kundendokument' | 'aufgabe' | 'nachricht';
+
+export const FILE_KIND_LABEL: Record<FileKind, string> = {
+  bild: 'Bilder',
+  anhang: 'Anhänge (Auto-Antwort)',
+  kundendokument: 'Kundendokumente',
+  aufgabe: 'Aufgaben-Anhänge',
+  nachricht: 'Mail-Anhänge (Buchungen)',
+};
+
+export interface InventoryUsage {
+  label: string;
+  href?: string;
+}
+
+export interface InventoryFile {
+  /** Eindeutige ID innerhalb des Inventars */
+  id: string;
+  kind: FileKind;
+  /** Anzeigename (Originalname, wenn bekannt) */
+  name: string;
+  /** Technischer Dateiname auf der Platte bzw. in der DB */
+  fileName: string;
+  mime: string;
+  size: number;
+  updatedAt: string;
+  /** Ohne Login erreichbare URL – null, wenn die Datei nur intern abrufbar ist */
+  publicUrl: string | null;
+  /** URL zum Öffnen/Download (mit Admin-Session) */
+  href: string;
+  /** Ablageort in Klartext */
+  storage: string;
+  /** Wo die Datei verwendet wird */
+  usedIn: InventoryUsage[];
+  /** Datei ist in einem Datensatz referenziert, liegt aber nicht (mehr) auf der Platte */
+  missing?: boolean;
+  /** Datei liegt auf der Platte, wird aber nirgends verwendet */
+  orphan?: boolean;
+}
+
+const IMAGE_MIME: Record<string, string> = {
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.webp': 'image/webp',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.avif': 'image/avif',
+};
+
+function extOf(name: string): string {
+  const i = name.lastIndexOf('.');
+  return i >= 0 ? name.slice(i).toLowerCase() : '';
+}
+
+function mimeForImage(name: string): string {
+  return IMAGE_MIME[extOf(name)] || 'application/octet-stream';
+}
+
+/* ─── 1. Bilder (public/) ─────────────────────────────────────────────────── */
+
+/** Index: Bild-URL → Verwendungsstellen in Events/Serien/Packages. */
+function buildImageUsageIndex(): Map<string, InventoryUsage[]> {
+  const index = new Map<string, InventoryUsage[]>();
+  const add = (url: string, usage: InventoryUsage) => {
+    if (!url || !url.startsWith('/')) return;
+    const list = index.get(url) || [];
+    if (!list.some((u) => u.label === usage.label)) list.push(usage);
+    index.set(url, list);
+  };
+
+  // Bild-URLs aus einem beliebigen Datensatz einsammeln (rekursiv über alle Strings).
+  const collect = (value: unknown, out: Set<string>) => {
+    if (typeof value === 'string') {
+      if (value.startsWith('/') && IMAGE_MIME[extOf(value)]) out.add(value);
+      return;
+    }
+    if (Array.isArray(value)) {
+      value.forEach((v) => collect(v, out));
+      return;
+    }
+    if (value && typeof value === 'object') {
+      Object.values(value as Record<string, unknown>).forEach((v) => collect(v, out));
+    }
+  };
+
+  try {
+    for (const event of getEvents()) {
+      const urls = new Set<string>();
+      collect(event, urls);
+      urls.forEach((u) => add(u, { label: `Event: ${event.title || event.name || event.slug}`, href: '/admin/events' }));
+    }
+  } catch { /* Content-Datei nicht lesbar – Index bleibt unvollständig */ }
+
+  try {
+    for (const series of getSeries()) {
+      const urls = new Set<string>();
+      collect(series, urls);
+      urls.forEach((u) => add(u, { label: `Serie: ${series.title || series.slug}`, href: '/admin/series' }));
+    }
+  } catch { /* ignore */ }
+
+  try {
+    for (const pkg of getPackages()) {
+      const urls = new Set<string>();
+      collect(pkg, urls);
+      urls.forEach((u) => add(u, { label: `Package: ${pkg.title || pkg.slug}`, href: '/admin/packages' }));
+    }
+  } catch { /* ignore */ }
+
+  return index;
+}
+
+async function collectImages(): Promise<InventoryFile[]> {
+  const usageIndex = buildImageUsageIndex();
+  const items = await listMediaLibrary();
+  return items.map((item) => {
+    const usedIn = usageIndex.get(item.url) || [];
+    return {
+      id: `bild:${item.relativePath}`,
+      kind: 'bild' as const,
+      name: item.name,
+      fileName: item.relativePath,
+      mime: mimeForImage(item.name),
+      size: item.size,
+      updatedAt: item.updatedAt,
+      publicUrl: item.url,
+      href: item.url,
+      storage: item.source === 'upload' ? 'public/uploads/media' : 'public/',
+      usedIn,
+      orphan: item.source === 'upload' && usedIn.length === 0,
+    };
+  });
+}
+
+/* ─── 2. Auto-Antwort-Anhänge (data/uploads/auto-reply) ───────────────────── */
+
+interface AutoReplyRef {
+  file: string;
+  name?: string | null;
+  usage: InventoryUsage;
+}
+
+/** Alle in Events referenzierten Auto-Antwort-Anhänge. */
+function autoReplyReferences(): AutoReplyRef[] {
+  const refs: AutoReplyRef[] = [];
+  let events: ReturnType<typeof getEvents> = [];
+  try {
+    events = getEvents();
+  } catch {
+    return refs;
+  }
+
+  for (const event of events) {
+    const usage: InventoryUsage = {
+      label: `Event: ${event.title || event.name || event.slug} → Automatische Antwort`,
+      href: '/admin/events',
+    };
+    const legacy = (event as { auto_reply_pdf?: string | null }).auto_reply_pdf;
+    const legacyName = (event as { auto_reply_pdf_name?: string | null }).auto_reply_pdf_name;
+    if (legacy) refs.push({ file: legacy, name: legacyName, usage });
+
+    const list = (event as { auto_reply_pdfs?: Array<{ file: string; name?: string | null }> | null }).auto_reply_pdfs;
+    if (Array.isArray(list)) {
+      for (const entry of list) {
+        if (entry?.file) refs.push({ file: entry.file, name: entry.name, usage });
+      }
+    }
+  }
+  return refs;
+}
+
+async function collectAutoReplyFiles(): Promise<InventoryFile[]> {
+  const [stored, refs] = [await listAutoReplyFiles(), autoReplyReferences()];
+  const byFile = new Map<string, AutoReplyRef[]>();
+  for (const ref of refs) {
+    const list = byFile.get(ref.file) || [];
+    list.push(ref);
+    byFile.set(ref.file, list);
+  }
+
+  const out: InventoryFile[] = stored.map((file) => {
+    const usedRefs = byFile.get(file.file) || [];
+    const usedIn: InventoryUsage[] = [];
+    for (const ref of usedRefs) {
+      if (!usedIn.some((u) => u.label === ref.usage.label)) usedIn.push(ref.usage);
+    }
+    return {
+      id: `anhang:${file.file}`,
+      kind: 'anhang' as const,
+      name: usedRefs[0]?.name || file.file,
+      fileName: file.file,
+      mime: file.mime,
+      size: file.size,
+      updatedAt: file.updatedAt,
+      publicUrl: autoReplyPublicPath(file.file),
+      href: autoReplyPublicPath(file.file),
+      storage: 'data/uploads/auto-reply',
+      usedIn,
+      orphan: usedIn.length === 0,
+    };
+  });
+
+  // In Events referenziert, aber nicht (mehr) auf der Platte
+  const storedNames = new Set(stored.map((f) => f.file));
+  for (const [file, list] of byFile) {
+    if (storedNames.has(file)) continue;
+    out.push({
+      id: `anhang:${file}`,
+      kind: 'anhang',
+      name: list[0]?.name || file,
+      fileName: file,
+      mime: autoReplyContentType(file),
+      size: 0,
+      updatedAt: '',
+      publicUrl: null,
+      href: autoReplyPublicPath(file),
+      storage: 'data/uploads/auto-reply (Datei fehlt)',
+      usedIn: list.map((r) => r.usage),
+      missing: true,
+    });
+  }
+
+  return out;
+}
+
+/* ─── 3.–5. Dateien in der Datenbank ──────────────────────────────────────── */
+
+interface DbFileRow {
+  id: string;
+  filename: string;
+  mime: string;
+  size: number;
+  created_at: string;
+  ref_id: string | null;
+  ref_label: string | null;
+  extra: string | null;
+}
+
+async function collectCustomerDocuments(): Promise<InventoryFile[]> {
+  const rows = await dbAll<DbFileRow>(
+    `SELECT d.id, d.filename, d.mime, d.size, d.created_at,
+            d.customer_id AS ref_id,
+            COALESCE(NULLIF(c.name, ''), NULLIF(c.company, ''), d.customer_id) AS ref_label,
+            d.title AS extra
+       FROM customer_documents d
+       LEFT JOIN customers c ON c.id = d.customer_id
+      ORDER BY d.created_at DESC`
+  ).catch(() => [] as DbFileRow[]);
+
+  return rows.map((r) => ({
+    id: `kundendokument:${r.id}`,
+    kind: 'kundendokument' as const,
+    name: r.extra || r.filename,
+    fileName: r.filename,
+    mime: r.mime || 'application/octet-stream',
+    size: Number(r.size) || 0,
+    updatedAt: r.created_at || '',
+    publicUrl: null,
+    href: `/api/admin/customers/${r.ref_id}/documents/${r.id}`,
+    storage: 'Datenbank: customer_documents',
+    usedIn: [{ label: `Kunde: ${r.ref_label || 'unbekannt'}`, href: r.ref_id ? `/admin/kunden/${r.ref_id}` : undefined }],
+  }));
+}
+
+async function collectTaskAttachments(): Promise<InventoryFile[]> {
+  const rows = await dbAll<DbFileRow>(
+    `SELECT a.id, a.filename, a.mime, a.size, a.created_at,
+            a.task_id AS ref_id,
+            t.title AS ref_label,
+            CAST(t.ticket_number AS TEXT) AS extra
+       FROM task_attachments a
+       LEFT JOIN staff_tasks t ON t.id = a.task_id
+      ORDER BY a.created_at DESC`
+  ).catch(() => [] as DbFileRow[]);
+
+  return rows.map((r) => {
+    const ticket = r.extra ? `TASK-${String(r.extra).padStart(5, '0')}` : null;
+    return {
+      id: `aufgabe:${r.id}`,
+      kind: 'aufgabe' as const,
+      name: r.filename,
+      fileName: r.filename,
+      mime: r.mime || 'application/octet-stream',
+      size: Number(r.size) || 0,
+      updatedAt: r.created_at || '',
+      publicUrl: null,
+      href: `/api/admin/tasks/${r.ref_id}/attachments?attId=${r.id}`,
+      storage: 'Datenbank: task_attachments',
+      usedIn: [
+        {
+          label: `Aufgabe: ${[ticket, r.ref_label].filter(Boolean).join(' · ') || 'unbekannt'}`,
+          href: '/admin/aufgaben',
+        },
+      ],
+    };
+  });
+}
+
+async function collectMessageAttachments(): Promise<InventoryFile[]> {
+  const rows = await dbAll<DbFileRow>(
+    `SELECT a.id, a.filename, a.mime, a.size, a.created_at,
+            m.booking_id AS ref_id,
+            COALESCE(NULLIF(b.booking_number, ''), NULLIF(b.request_number, ''), m.booking_id) AS ref_label,
+            m.subject AS extra
+       FROM booking_message_attachments a
+       LEFT JOIN booking_messages m ON m.id = a.message_id
+       LEFT JOIN booking_requests b ON b.id = m.booking_id
+      ORDER BY a.created_at DESC`
+  ).catch(() => [] as DbFileRow[]);
+
+  return rows.map((r) => ({
+    id: `nachricht:${r.id}`,
+    kind: 'nachricht' as const,
+    name: r.filename,
+    fileName: r.filename,
+    mime: r.mime || 'application/octet-stream',
+    size: Number(r.size) || 0,
+    updatedAt: r.created_at || '',
+    publicUrl: null,
+    href: `/api/admin/attachments/${r.id}`,
+    storage: 'Datenbank: booking_message_attachments',
+    usedIn: [
+      {
+        label: `Buchung: ${r.ref_label || 'unbekannt'}${r.extra ? ` · ${r.extra}` : ''}`,
+        href: r.ref_id ? `/admin/buchungen?id=${r.ref_id}` : undefined,
+      },
+    ],
+  }));
+}
+
+/* ─── Aggregation ─────────────────────────────────────────────────────────── */
+
+export interface FileInventory {
+  files: InventoryFile[];
+  counts: Record<FileKind, number>;
+  totalBytes: number;
+}
+
+export async function listFileInventory(): Promise<FileInventory> {
+  const groups = await Promise.all([
+    collectImages().catch(() => [] as InventoryFile[]),
+    collectAutoReplyFiles().catch(() => [] as InventoryFile[]),
+    collectCustomerDocuments(),
+    collectTaskAttachments(),
+    collectMessageAttachments(),
+  ]);
+
+  const files = groups.flat().sort((a, b) => (b.updatedAt || '').localeCompare(a.updatedAt || ''));
+
+  const counts = { bild: 0, anhang: 0, kundendokument: 0, aufgabe: 0, nachricht: 0 } as Record<FileKind, number>;
+  let totalBytes = 0;
+  for (const file of files) {
+    counts[file.kind] += 1;
+    totalBytes += file.size || 0;
+  }
+
+  return { files, counts, totalBytes };
+}


### PR DESCRIPTION
- Neue Admin-Seite /admin/mediathek listet saemtliche hochgeladenen Dateien aus
  allen Ablagen (Bilder public/uploads/media, Auto-Antwort-Anhaenge
  data/uploads/auto-reply, Kundendokumente, Aufgaben- und Mail-Anhaenge in der DB)
  mit Ablageort, Verwendung, Groesse, Datum und URL zum Kopieren.
- Neue oeffentliche Route /dokumente/<datei> liefert Auto-Antwort-Anhaenge aus,
  damit direkt auf ein Angebots-PDF verlinkt werden kann.
- Neue API /api/admin/files (GET Inventar, POST Upload, DELETE fuer unbenutzte
  Auto-Antwort-Anhaenge).
- Event-Editor zeigt zu jedem Auto-Antwort-Anhang den oeffentlichen Link inkl.
  URL kopieren.
- autoReplyStore: listAutoReplyFiles/readAutoReplyFile/autoReplyPublicPath.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
